### PR TITLE
Silent Installer Mode (headless --silent --store-id)

### DIFF
--- a/.claude/STATUS.md
+++ b/.claude/STATUS.md
@@ -9,9 +9,23 @@
 | **Branch** | `indypos-overhaul` |
 | **Sprint** | Sprint 7 |
 | **Phase** | ✅ **MERGED to `development` (2026-07-14 19:01, PR #50 "IndyPOS v4 Overhaul", merge commit).** Admin-provisioning (bootstrap password + server-enforced forced rotation) shipped as the final feature of the v4 overhaul. 18-task SDD plan, 3-perspective design review, whole-branch review, VM clean-install validated 18/18 + fonts + CWD fix + themed modal (Pond-approved). |
-| **Blocked?** | Not blocked — feature merged. **2026-07-17:** (1) distributable `IndyPOS-Setup.exe` rebuilt to embed the refined modal — `publish\IndyPOS-Setup.exe` 190.3 MB, v4.0.0.0, ProductVersion `4.0.0+b598cf3` (cosmetic-only, not VM-re-validated; prior build was 18/18). (2) **Tier-2 cleanup batch DONE** (commits `6246a01`,`d5990ac`,`836ddfb`): DRY password gens + 57-char comment, orphaned-`.tmp` cleanup, 5 test-rigor assertions. Bootstrapper 52p/8s, Application 243/243. `indypos-overhaul` branch kept. Remaining deferred-Minors (D3-m2/m3, C1-m1, D5-m1/m2, B5-m1, E1-m1) in `.superpowers/sdd/progress.md`. |
+| **Blocked?** | Not blocked. **2026-07-18: SILENT INSTALLER MODE COMPLETE + VM-VALIDATED** (see resume block below). Branch `indypos-overhaul` is **22 commits ahead of `origin/development`** (which already has #50 `9547e68`); local `development` is stale (176 behind origin). Awaiting Pond's merge/PR call. |
 
-## ⏯️ RESUME HERE (2026-07-14) — Admin-provisioning feature CODE COMPLETE + whole-branch reviewed; VM validation pending
+## ⏯️ RESUME HERE (2026-07-18) — Silent Installer Mode: FEATURE COMPLETE, VM-VALIDATED, ready to merge
+
+**Shipped this session (branch `indypos-overhaul`, silent-installer plan `02c0716`..`08a0f63`, 9-task SDD):**
+`IndyPOS-Setup.exe --silent --store-id <ID>` — headless install, no wizard. Reuses `InstallationOrchestrator` unchanged; authoritative ACL-locked log + `INDYPOS_MARKER` result lines; exit codes 0/1/2/3/4. VM harness now drives it (no vmconnect). Plan: `docs/superpowers/plans/2026-07-18-silent-installer-mode.md`. Spec: `docs/superpowers/specs/2026-07-18-silent-installer-mode-design.md`. Ledger: `.superpowers/sdd/progress.md`.
+
+- **New (`installer/IndyPOS.Bootstrapper/Silent/`):** `SilentArgs` (parser), `SilentOutcomeMapper` (outcome→exit/markers), `SecretScrubber`, `ConsoleAttach` (LibraryImport→needs `AllowUnsafeBlocks`), `SilentInstallLogger` (thread-safe IProgress sink), `Elevation`, `SilentInstaller` (driver). Extracted shared `Installers/AdminCredentialFile`. Additive `InstallationResult.ServiceStarted`/`HealthOk`. `Program.Main` → `int` + `--silent` branch.
+- **Critical fix (final whole-branch review caught it — lived in unchanged `DotNetInstaller.cs`):** headless path could hit `InstallManually`'s blocking `MessageBox` loop when .NET 10 absent + winget fails → hang. Fix: `InstallationConfig.Interactive` (silent=false) → `EnsureInstalledAsync` fails fast (exit 2) instead of the dialog. + restored harness outer watchdog (`InstallTimeoutMinutes` 30→50).
+
+**Verification:** build 0 err; `IndyPOS.Bootstrapper.Tests` **83 pass/8 skip/0 fail**. Every task per-task reviewed; **final whole-branch review PASSED (Ready to merge: YES)**. Installer rebuilt **190.3 MB (2026-07-18 07:15)**. **UNATTENDED VM clean-install PASSED** (9m27s, fully headless): markers `RESULT=success/ADMIN_SEEDED=true/CRED_FILE=…v4\Config\admin-credentials.txt/CRED_LOCKED=true/SERVICE_STARTED=true/HEALTH=ok`; verifier **18/18**. **Force-change modal confirmed live by Pond** ("it works"; cred file needs an *elevated* prompt to read — ACL working as intended). HEAD `08a0f63`.
+
+**NEXT (Pond's call — finishing-a-development-branch):** push `indypos-overhaul` (20 unpushed) + open PR vs `development` (recommended; #50 went via PR), OR merge locally. gh account = `purin-tavilsup` (owns this personal repo). Deferred minors (DEFER/WONTFIX triaged) in `.superpowers/sdd/progress.md` — none block merge.
+
+---
+
+## ⏯️ Earlier checkpoint (2026-07-14) — Admin-provisioning feature CODE COMPLETE + whole-branch reviewed; VM validation pending
 
 **What shipped this session (branch `indypos-overhaul`, commits `bc0b908`..`0db8ddd`, 24 commits incl. spec+plan+fixes):**
 Replaced the wizard-typed admin password with a **random single-use bootstrap** credential that is **server-side force-rotated on first login**. Executed the 18-task plan (`docs/superpowers/plans/2026-07-14-admin-provisioning-bootstrap.md`) via subagent-driven-development (fresh implementer + task reviewer per task; ledger at `.superpowers/sdd/progress.md`). Spec: `docs/superpowers/specs/2026-07-14-admin-provisioning-bootstrap-design.md`.

--- a/.claude/STATUS.md
+++ b/.claude/STATUS.md
@@ -8,8 +8,8 @@
 |-------|-------|
 | **Branch** | `indypos-overhaul` |
 | **Sprint** | Sprint 7 |
-| **Phase** | **Admin-provisioning (bootstrap + forced rotation) — CODE COMPLETE & REVIEWED (2026-07-14).** 18-task SDD plan executed via subagents; whole-branch review clean (must-fixes applied). Build 0 err, unit tests green. **PENDING: installer rebuild + VM clean-install validation matrix (needs Pond/vmconnect), then merge.** Prior: Installer Side-by-Side Stages 0–7 ✅. |
-| **Blocked?** | **VM VALIDATION PASSED (2026-07-14) — feature fully validated.** Verifier 18/18; admin-credentials.txt ACL-locked; initialAdmin removed + DPAPI secrets intact; force-change modal worked (DB: admin/Rungrat-001/must_change=f/logged-in); old bootstrap→401 (single-use). **Only remaining: mark PR #50 ready (`gh pr ready 50`) + merge to `development`** — Pond's call. |
+| **Phase** | ✅ **MERGED to `development` (2026-07-14 19:01, PR #50 "IndyPOS v4 Overhaul", merge commit).** Admin-provisioning (bootstrap password + server-enforced forced rotation) shipped as the final feature of the v4 overhaul. 18-task SDD plan, 3-perspective design review, whole-branch review, VM clean-install validated 18/18 + fonts + CWD fix + themed modal (Pond-approved). |
+| **Blocked?** | Not blocked — feature merged. **Optional follow-up:** rebuild distributable `IndyPOS-Setup.exe` to embed the refined modal (cosmetic gap vs the validated build; not merge-blocking). `indypos-overhaul` branch kept (not deleted). Deferred-Minors triage list in `.superpowers/sdd/progress.md`. |
 
 ## ⏯️ RESUME HERE (2026-07-14) — Admin-provisioning feature CODE COMPLETE + whole-branch reviewed; VM validation pending
 

--- a/.claude/STATUS.md
+++ b/.claude/STATUS.md
@@ -9,7 +9,7 @@
 | **Branch** | `indypos-overhaul` |
 | **Sprint** | Sprint 7 |
 | **Phase** | ✅ **MERGED to `development` (2026-07-14 19:01, PR #50 "IndyPOS v4 Overhaul", merge commit).** Admin-provisioning (bootstrap password + server-enforced forced rotation) shipped as the final feature of the v4 overhaul. 18-task SDD plan, 3-perspective design review, whole-branch review, VM clean-install validated 18/18 + fonts + CWD fix + themed modal (Pond-approved). |
-| **Blocked?** | Not blocked — feature merged. **Optional follow-up:** rebuild distributable `IndyPOS-Setup.exe` to embed the refined modal (cosmetic gap vs the validated build; not merge-blocking). `indypos-overhaul` branch kept (not deleted). Deferred-Minors triage list in `.superpowers/sdd/progress.md`. |
+| **Blocked?** | Not blocked — feature merged. **2026-07-17:** (1) distributable `IndyPOS-Setup.exe` rebuilt to embed the refined modal — `publish\IndyPOS-Setup.exe` 190.3 MB, v4.0.0.0, ProductVersion `4.0.0+b598cf3` (cosmetic-only, not VM-re-validated; prior build was 18/18). (2) **Tier-2 cleanup batch DONE** (commits `6246a01`,`d5990ac`,`836ddfb`): DRY password gens + 57-char comment, orphaned-`.tmp` cleanup, 5 test-rigor assertions. Bootstrapper 52p/8s, Application 243/243. `indypos-overhaul` branch kept. Remaining deferred-Minors (D3-m2/m3, C1-m1, D5-m1/m2, B5-m1, E1-m1) in `.superpowers/sdd/progress.md`. |
 
 ## ⏯️ RESUME HERE (2026-07-14) — Admin-provisioning feature CODE COMPLETE + whole-branch reviewed; VM validation pending
 

--- a/.claude/session-log.md
+++ b/.claude/session-log.md
@@ -4,6 +4,29 @@
 
 ---
 
+## 2026-07-14: Admin-provisioning feature built + v4 overhaul MERGED to `development` (PR #50) 🎉
+
+**Focus:** The last open branch item — the admin-provisioning model — taken from decision all the way to merged.
+
+**Design (brainstorming → spec → review):** Chose **random single-use bootstrap password + server-enforced forced rotation on first login**. (Pond first proposed a `greatSales@ddmmyy` template; walked through why a derived password is only safe as a *rotated single-use bootstrap*, then landed on random-shown-once + a `reset-admin` recovery path, and **server-side** enforcement.) Spec: `docs/superpowers/specs/2026-07-14-admin-provisioning-bootstrap-design.md`. A 3-perspective design review (Architect/Engineer/QA subagents) caught, pre-code: the cosmetic-only client gate, a latent `/auth/me` `sub`-claim bug, the re-install dead-credential case, and the EF-migration-on-populated-DB risk.
+
+**Execution (subagent-driven, 18 tasks):** Plan `docs/superpowers/plans/2026-07-14-admin-provisioning-bootstrap.md`, executed via `superpowers:subagent-driven-development` — fresh implementer + task reviewer per task, ledger at `.superpowers/sdd/progress.md`. StoreHub: `MustChangePassword` flag (+migration `defaultValue:false`) → `must_change` JWT claim → middleware 403s all routes except `/auth/change-password` → `POST /auth/change-password` (token identity, verify-then-atomic-set, fresh token) → `reset-admin` CLI. WinForms: deferred session + `FirstLoginCoordinator` + themed `ChangePasswordForm`. Installer: Store-ID-only wizard, random bootstrap, surgical `initialAdmin` removal (DPAPI secrets preserved), ACL-locked `admin-credentials.txt`. Whole-branch review (opus): "Ready with must-fixes" → 2 applied (ACL-lock summary file; change-password generic-catch crash-hardening).
+
+**VM validation (clean install):** verifier **18/18**; DB `admin/Rungrat-001/must_change`; **single-use proven** (old bootstrap→401 after rotation); appsettings `initialAdmin` gone + DPAPI secrets intact.
+
+**Three field-driven follow-ups this session:**
+1. **Themed modal** — the stock light-gray dialog clashed with the dark POS theme; restyled to match `MessageForm` (ModernTextBox/ModernButton, `#262626`/`#1E1E1E`, Gainsboro, teal/red accents), then refined (right-aligned button pair, inset fields + teal focus underline, spacing fix). Validated live via **WinForms DLL hot-swap** into the VM; Pond approved.
+2. **`reset-admin` CWD bug** — found during hot-swap: the exe loaded `appsettings.json` from the CWD, so the documented recovery command crashed ("ConnectionString is missing") from any dir but the install folder. Fix: `WebApplicationOptions.ContentRootPath = AppContext.BaseDirectory`. Proven in VM (`migrate` from `C:\` → exit 0).
+3. **FC Subject fonts** — the app references family `FC Subject [Non-commercial] Reg` by name in 304 places; fresh machines lacked it (fallback font). Added `FontInstaller` (Step 0, non-fatal): bundles Reg+Bold `.ttf` as embedded resources, installs to `Windows\Fonts` + HKLM + `WM_FONTCHANGE`. Confirmed installed + GDI-visible in VM. (Gotcha: font filenames have `[brackets]` → `-LiteralPath` needed in the build script.)
+
+**Merge:** `IndyPOS-Setup.exe` rebuilt 3× (theme+CWD, then fonts). PR #50 "IndyPOS v4 Overhaul" → out of draft → **merged to `development`** (merge commit, full history). `indypos-overhaul` branch kept.
+
+**Reusable techniques:** WinForms DLL hot-swap into Velopack `current\` over PSDirect for fast UI iteration (no reinstall); in-guest DPAPI conn-string decrypt + psql for DB checks; non-destructive `migrate`-from-arbitrary-CWD probe to validate content-root fixes without mutating admin state.
+
+**NEXT (all optional):** rebuild distributable installer to embed the refined modal (cosmetic gap vs validated build); Tier-2 code-cleanup minors (DRY password generators, orphaned-`.tmp` cleanup, a few test-rigor items — see `.superpowers/sdd/progress.md`); Tier-3 epics: **Epic I (Cloud Infra)**, **Epic M (multi-store-type M7–M13)**, silent installer mode. `gh` active account is now `purin-tavilsup` — `gh auth switch --user purin-mimica` for Mimica work.
+
+---
+
 ## 2026-06-24: Stage 7 closed — clean full install validated; Bug F + service-start timeout fixed ✅
 
 **Focus:** Validate the installer on a genuinely fresh VM install (not hot-swap), then fix what it surfaced.

--- a/docs/superpowers/plans/2026-07-18-silent-installer-mode.md
+++ b/docs/superpowers/plans/2026-07-18-silent-installer-mode.md
@@ -1,0 +1,1301 @@
+# Silent Installer Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a headless `IndyPOS-Setup.exe --silent --store-id <ID>` install path so the VM/CI clean-install cycle and field unattended installs run with no wizard.
+
+**Architecture:** A thin `SilentInstaller` driver reuses the existing headless `InstallationOrchestrator` unchanged. Pure units (arg parser, outcome→exit/marker mapper, secret scrubber) are TDD'd in isolation; the driver wires them plus a thread-safe stdout+ACL-locked-file logger and an overall watchdog timeout. Because the exe is `WinExe` (GUI subsystem), the durable log file is the authoritative result/marker channel and the caller captures the exit code via `Start-Process -Wait -PassThru`.
+
+**Tech Stack:** C# .NET 10 (`net10.0-windows`, WinForms host), xUnit + FluentAssertions, PowerShell (VM harness), Velopack/bootstrapper installer.
+
+**Spec:** `docs/superpowers/specs/2026-07-18-silent-installer-mode-design.md`
+
+## Global Constraints
+
+- Target framework: `net10.0-windows`; `Nullable` enable; `ImplicitUsings` enable (from the bootstrapper csproj — no per-file `using System;` needed for common namespaces).
+- Bootstrapper is `<OutputType>WinExe</OutputType>` with `requireAdministrator` manifest and `StartupObject=IndyPOS.Bootstrapper.Program`.
+- Test project `IndyPOS.Bootstrapper.Tests` has `InternalsVisibleTo` from the bootstrapper; use xUnit `[Fact]`/`[Theory]` + FluentAssertions `.Should()`. No `#region`, AAA with blank lines, test names `Method_Condition_ShouldExpectedBehavior`.
+- **No admin secret on the command line** — no `--app-password`; the bootstrap password stays installer-generated.
+- **The password is never emitted to stdout or the log** — only its file path (`CRED_FILE`).
+- Marker lines are prefixed `INDYPOS_MARKER ` and consumers read the **last** occurrence.
+- Exit codes: `0` success, `1` usage error, `2` install failed, `3` not elevated, `4` timeout.
+- New silent-path files live under `installer/IndyPOS.Bootstrapper/Silent/` (namespace `IndyPOS.Bootstrapper.Silent`); `AdminCredentialFile` lives in `Installers/` (namespace `IndyPOS.Bootstrapper.Installers`).
+- Commit after every task. `InstallationResult` stays a `class` (do not convert to a record).
+
+---
+
+## File Structure
+
+**New (silent path — `installer/IndyPOS.Bootstrapper/Silent/`):**
+- `SilentArgs.cs` — pure arg parser → `ParseResult`.
+- `SilentOutcomeMapper.cs` — pure `SilentOutcome` → `(exitCode, markers)`.
+- `SecretScrubber.cs` — pure connection-string redaction.
+- `ConsoleAttach.cs` — `AttachConsole` P/Invoke (best-effort).
+- `SilentInstallLogger.cs` — thread-safe `IProgress<InstallationProgress>` sink (stdout + file).
+- `Elevation.cs` — shared `IsElevated()` helper.
+- `SilentInstaller.cs` — headless driver (integration point).
+
+**New (`installer/IndyPOS.Bootstrapper/Installers/`):**
+- `AdminCredentialFile.cs` — shared ACL-locked cred-file writer (extracted from the wizard).
+
+**Modified:**
+- `installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs` — add `TryRestrictFilePermissions` returning success.
+- `installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs` — additive `InstallationResult.ServiceStarted` + `HealthOk`.
+- `installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs` — call `AdminCredentialFile.Write`; delete the private `WriteAdminSummaryFile`.
+- `installer/IndyPOS.Bootstrapper/Program.cs` — `Main` → `static int`; `--silent` branch.
+- `scripts/vm-testing/Reset-AndInstall.ps1` — silent invocation + gating rule (replaces the vmconnect handoff).
+- `scripts/vm-testing/VMTestConfig.psd1` — add `TestStoreId`.
+
+**Tests (`tests/IndyPOS.Bootstrapper.Tests/`):**
+- `Silent/SilentArgsTests.cs`, `Silent/SilentOutcomeMapperTests.cs`, `Silent/SecretScrubberTests.cs`, `Silent/SilentInstallLoggerTests.cs`, `Silent/SilentInstallerTests.cs`, `Installers/AdminCredentialFileTests.cs`.
+
+---
+
+### Task 1: `TryRestrictFilePermissions` + shared `AdminCredentialFile`
+
+**Files:**
+- Modify: `installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs:146-179`
+- Create: `installer/IndyPOS.Bootstrapper/Installers/AdminCredentialFile.cs`
+- Modify: `installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs:300,365-386`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Installers/AdminCredentialFileTests.cs`
+
+**Interfaces:**
+- Produces: `DatabaseSetup.TryRestrictFilePermissions(string filePath) : bool` (internal static); `AdminCredentialFile.Write(InstallationConfig config) : (string Path, bool Locked)`.
+
+- [ ] **Step 1: Write the failing test**
+
+`InstallationConfig.ConfigDirectory` is a computed property under `C:\ProgramData\IndyPOS\v4\Config`; the test writes there (the test process owns the file, so the ACL lock succeeds without elevation) and cleans up in `finally`.
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+using Xunit;
+
+namespace IndyPOS.Bootstrapper.Tests.Installers;
+
+public class AdminCredentialFileTests
+{
+    [Fact]
+    public void Write_WithSeededAdmin_ShouldWriteCredentialFileAndReturnPath()
+    {
+        var config = new InstallationConfig { StoreId = "STORE-1" };
+        var expectedPath = Path.Combine(config.ConfigDirectory, "admin-credentials.txt");
+
+        try
+        {
+            var (path, locked) = AdminCredentialFile.Write(config);
+
+            path.Should().Be(expectedPath);
+            File.Exists(path).Should().BeTrue();
+            var contents = File.ReadAllText(path);
+            contents.Should().Contain($"Username: {config.AdminUsername}");
+            contents.Should().Contain($"Password: {config.AdminPassword}");
+            locked.Should().BeTrue();
+        }
+        finally
+        {
+            if (File.Exists(expectedPath)) File.Delete(expectedPath);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~AdminCredentialFileTests"`
+Expected: FAIL — `AdminCredentialFile` does not exist (compile error).
+
+- [ ] **Step 3: Refactor `DatabaseSetup.RestrictFilePermissions` to expose success**
+
+In `installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs`, replace the whole `RestrictFilePermissions` method (lines 146-179) with:
+
+```csharp
+internal static void RestrictFilePermissions(string filePath) => TryRestrictFilePermissions(filePath);
+
+internal static bool TryRestrictFilePermissions(string filePath)
+{
+    try
+    {
+        var fileInfo = new FileInfo(filePath);
+        var security = fileInfo.GetAccessControl();
+
+        security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+
+        var rules = security.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+        foreach (System.Security.AccessControl.FileSystemAccessRule rule in rules)
+        {
+            security.RemoveAccessRule(rule);
+        }
+
+        security.AddAccessRule(new System.Security.AccessControl.FileSystemAccessRule(
+            new System.Security.Principal.SecurityIdentifier(
+                System.Security.Principal.WellKnownSidType.BuiltinAdministratorsSid, null),
+            System.Security.AccessControl.FileSystemRights.FullControl,
+            System.Security.AccessControl.AccessControlType.Allow));
+
+        security.AddAccessRule(new System.Security.AccessControl.FileSystemAccessRule(
+            new System.Security.Principal.SecurityIdentifier(
+                System.Security.Principal.WellKnownSidType.LocalSystemSid, null),
+            System.Security.AccessControl.FileSystemRights.FullControl,
+            System.Security.AccessControl.AccessControlType.Allow));
+
+        fileInfo.SetAccessControl(security);
+        return true;
+    }
+    catch
+    {
+        // Ignore permission errors - file is still created
+        return false;
+    }
+}
+```
+
+- [ ] **Step 4: Create `AdminCredentialFile`**
+
+Create `installer/IndyPOS.Bootstrapper/Installers/AdminCredentialFile.cs`:
+
+```csharp
+namespace IndyPOS.Bootstrapper.Installers;
+
+/// <summary>
+/// Writes the one-time admin bootstrap credential to an ACL-locked file.
+/// Shared by the wizard finish screen and the silent installer so both deliver
+/// the credential identically.
+/// </summary>
+public static class AdminCredentialFile
+{
+    /// <summary>
+    /// Writes admin-credentials.txt in the config dir and ACL-locks it to
+    /// Administrators + LocalSystem. Returns the path and whether the lock applied.
+    /// Never throws — a failed write returns Locked=false so callers can react.
+    /// </summary>
+    public static (string Path, bool Locked) Write(InstallationConfig config)
+    {
+        var path = Path.Combine(config.ConfigDirectory, "admin-credentials.txt");
+        var contents =
+            "IndyPOS initial admin sign-in\r\n" +
+            "================================\r\n" +
+            $"Username: {config.AdminUsername}\r\n" +
+            $"Password: {config.AdminPassword}\r\n\r\n" +
+            "This is a one-time password. You will be required to set a new one\r\n" +
+            "on first sign-in. Delete this file after you have signed in.\r\n";
+
+        try
+        {
+            Directory.CreateDirectory(config.ConfigDirectory);
+            File.WriteAllText(path, contents);
+        }
+        catch
+        {
+            return (path, false);
+        }
+
+        return (path, DatabaseSetup.TryRestrictFilePermissions(path));
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~AdminCredentialFileTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Point the wizard at the shared writer**
+
+In `installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs`:
+- Replace the call at line 300 `WriteAdminSummaryFile(_config);` with `AdminCredentialFile.Write(_config);`
+- Delete the entire private method `WriteAdminSummaryFile` (lines 365-386).
+
+- [ ] **Step 7: Build to verify the wizard still compiles**
+
+Run: `dotnet build installer/IndyPOS.Bootstrapper/IndyPOS.Bootstrapper.csproj -c Release`
+Expected: `Build succeeded. 0 Error(s)`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs installer/IndyPOS.Bootstrapper/Installers/AdminCredentialFile.cs installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs tests/IndyPOS.Bootstrapper.Tests/Installers/AdminCredentialFileTests.cs
+git commit -m "refactor(installer): extract shared ACL-locked admin credential writer"
+```
+
+---
+
+### Task 2: `SecretScrubber`
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Silent/SecretScrubber.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Silent/SecretScrubberTests.cs`
+
+**Interfaces:**
+- Produces: `SecretScrubber.Scrub(string? text) : string`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Silent;
+using Xunit;
+
+namespace IndyPOS.Bootstrapper.Tests.Silent;
+
+public class SecretScrubberTests
+{
+    [Theory]
+    [InlineData("Host=127.0.0.1;Password=SuperSecret;Db=x")]
+    [InlineData("Host=127.0.0.1;Pwd=SuperSecret")]
+    public void Scrub_WithPasswordAssignment_ShouldRedactValue(string input)
+    {
+        var result = SecretScrubber.Scrub(input);
+
+        result.Should().NotContain("SuperSecret");
+        result.Should().Contain("***REDACTED***");
+    }
+
+    [Fact]
+    public void Scrub_WithPlainText_ShouldReturnUnchanged()
+    {
+        SecretScrubber.Scrub("provisioning failed (exit 1)").Should().Be("provisioning failed (exit 1)");
+    }
+
+    [Fact]
+    public void Scrub_WithNull_ShouldReturnEmpty()
+    {
+        SecretScrubber.Scrub(null).Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~SecretScrubberTests"`
+Expected: FAIL — `SecretScrubber` does not exist.
+
+- [ ] **Step 3: Implement `SecretScrubber`**
+
+Create `installer/IndyPOS.Bootstrapper/Silent/SecretScrubber.cs`:
+
+```csharp
+using System.Text.RegularExpressions;
+
+namespace IndyPOS.Bootstrapper.Silent;
+
+/// <summary>
+/// Best-effort redaction of connection-string-shaped secrets from text before it
+/// is persisted to the install log or echoed to stdout on a failure path.
+/// </summary>
+public static partial class SecretScrubber
+{
+    // Password=... or Pwd=... up to the next ';' or end of string (case-insensitive).
+    [GeneratedRegex(@"(?i)\b(password|pwd)\s*=\s*[^;]*")]
+    private static partial Regex PasswordAssignment();
+
+    public static string Scrub(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+        return PasswordAssignment().Replace(text, "$1=***REDACTED***");
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~SecretScrubberTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Silent/SecretScrubber.cs tests/IndyPOS.Bootstrapper.Tests/Silent/SecretScrubberTests.cs
+git commit -m "feat(installer): add SecretScrubber for install-log failure output"
+```
+
+---
+
+### Task 3: `SilentArgs` parser
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `record SilentInstallOptions(string StoreId, int TimeoutMinutes)`
+  - `enum ParseStatus { Silent, NotSilent, UsageError }`
+  - `record ParseResult(ParseStatus Status, SilentInstallOptions? Options, string? ErrorMessage)` with factories `Silent(options)`, `NotSilent()`, `Usage(message)`
+  - `SilentArgs.Parse(string[] args) : ParseResult`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Silent;
+using Xunit;
+
+namespace IndyPOS.Bootstrapper.Tests.Silent;
+
+public class SilentArgsTests
+{
+    [Theory]
+    [InlineData(new[] { "--silent", "--store-id", "ABC" })]
+    [InlineData(new[] { "--silent", "--store-id=ABC" })]
+    [InlineData(new[] { "--SILENT", "--Store-Id", "ABC" })]
+    public void Parse_WithSilentAndStoreId_ShouldReturnSilentWithStoreId(string[] args)
+    {
+        var result = SilentArgs.Parse(args);
+
+        result.Status.Should().Be(ParseStatus.Silent);
+        result.Options!.StoreId.Should().Be("ABC");
+        result.Options.TimeoutMinutes.Should().Be(45);
+    }
+
+    [Fact]
+    public void Parse_WithStoreIdValue_ShouldPreserveCaseAndTrim()
+    {
+        var result = SilentArgs.Parse(new[] { "--silent", "--store-id", "  Rungrat-001  " });
+
+        result.Options!.StoreId.Should().Be("Rungrat-001");
+    }
+
+    [Fact]
+    public void Parse_WithTimeoutOverride_ShouldUseIt()
+    {
+        var result = SilentArgs.Parse(new[] { "--silent", "--store-id", "A", "--timeout-minutes", "10" });
+
+        result.Options!.TimeoutMinutes.Should().Be(10);
+    }
+
+    [Theory]
+    [InlineData(new[] { "--silent" })]
+    [InlineData(new[] { "--silent", "--store-id" })]
+    [InlineData(new[] { "--silent", "--store-id", " " })]
+    [InlineData(new[] { "--silent", "--store-id", "A", "--timeout-minutes", "0" })]
+    [InlineData(new[] { "--silent", "--store-id", "A", "--timeout-minutes", "notanumber" })]
+    [InlineData(new[] { "--silent", "--store-id", "A", "--bogus" })]
+    public void Parse_WithBadSilentArgs_ShouldReturnUsageError(string[] args)
+    {
+        SilentArgs.Parse(args).Status.Should().Be(ParseStatus.UsageError);
+    }
+
+    [Theory]
+    [InlineData(new string[0])]
+    [InlineData(new[] { "--store-id", "ABC" })]
+    public void Parse_WithoutSilent_ShouldReturnNotSilent(string[] args)
+    {
+        SilentArgs.Parse(args).Status.Should().Be(ParseStatus.NotSilent);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~SilentArgsTests"`
+Expected: FAIL — `SilentArgs` does not exist.
+
+- [ ] **Step 3: Implement `SilentArgs`**
+
+Create `installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs`:
+
+```csharp
+namespace IndyPOS.Bootstrapper.Silent;
+
+public sealed record SilentInstallOptions(string StoreId, int TimeoutMinutes);
+
+public enum ParseStatus { Silent, NotSilent, UsageError }
+
+public sealed record ParseResult(ParseStatus Status, SilentInstallOptions? Options, string? ErrorMessage)
+{
+    public static ParseResult Silent(SilentInstallOptions options) => new(ParseStatus.Silent, options, null);
+    public static ParseResult NotSilent() => new(ParseStatus.NotSilent, null, null);
+    public static ParseResult Usage(string message) => new(ParseStatus.UsageError, null, message);
+}
+
+/// <summary>
+/// Pure parser for the silent-install command line. No I/O — fully unit-testable.
+/// Flag NAMES are case-insensitive; the --store-id VALUE is preserved verbatim
+/// (only trimmed).
+/// </summary>
+public static class SilentArgs
+{
+    private const int DefaultTimeoutMinutes = 45;
+
+    public static ParseResult Parse(string[] args)
+    {
+        var isSilent = args.Any(a => NameOf(a).Equals("--silent", StringComparison.OrdinalIgnoreCase));
+        if (!isSilent) return ParseResult.NotSilent();
+
+        string? storeId = null;
+        var timeoutMinutes = DefaultTimeoutMinutes;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var name = NameOf(args[i]);
+            var inlineValue = InlineValueOf(args[i]);
+
+            switch (name.ToLowerInvariant())
+            {
+                case "--silent":
+                    break;
+
+                case "--store-id":
+                    if (!TryReadValue(args, ref i, inlineValue, out storeId))
+                        return ParseResult.Usage("--store-id requires a value.");
+                    break;
+
+                case "--timeout-minutes":
+                    if (!TryReadValue(args, ref i, inlineValue, out var raw)
+                        || !int.TryParse(raw, out timeoutMinutes)
+                        || timeoutMinutes <= 0)
+                        return ParseResult.Usage("--timeout-minutes requires a positive integer.");
+                    break;
+
+                default:
+                    return ParseResult.Usage($"Unknown argument: {args[i]}");
+            }
+        }
+
+        storeId = storeId?.Trim();
+        if (string.IsNullOrWhiteSpace(storeId))
+            return ParseResult.Usage("--silent requires --store-id <ID>.");
+
+        return ParseResult.Silent(new SilentInstallOptions(storeId, timeoutMinutes));
+    }
+
+    private static string NameOf(string arg)
+    {
+        var eq = arg.IndexOf('=');
+        return eq >= 0 ? arg[..eq] : arg;
+    }
+
+    private static string? InlineValueOf(string arg)
+    {
+        var eq = arg.IndexOf('=');
+        return eq >= 0 ? arg[(eq + 1)..] : null;
+    }
+
+    // Reads the value for a flag: the inline "=value" if present, else the next
+    // token (which must exist and not itself be a flag). Advances i past a
+    // consumed next token so it is not re-parsed as unknown.
+    private static bool TryReadValue(string[] args, ref int i, string? inlineValue, out string? value)
+    {
+        if (inlineValue is not null)
+        {
+            value = inlineValue;
+            return true;
+        }
+
+        if (i + 1 < args.Length && !args[i + 1].StartsWith("--"))
+        {
+            value = args[++i];
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~SilentArgsTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs
+git commit -m "feat(installer): add silent-install argument parser"
+```
+
+---
+
+### Task 4: `SilentOutcomeMapper`
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `abstract record SilentOutcome` with `InstallSucceeded(bool AdminSeeded, string? CredFile, bool CredLocked, bool ServiceStarted, bool HealthOk)`, `InstallFailed(string Message)`, `InstallTimedOut`, `UsageErrorOutcome(string Message)`, `NotElevatedOutcome`
+  - `SilentOutcomeMapper.Map(SilentOutcome outcome) : (int ExitCode, IReadOnlyList<string> Markers)`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Silent;
+using Xunit;
+
+namespace IndyPOS.Bootstrapper.Tests.Silent;
+
+public class SilentOutcomeMapperTests
+{
+    [Fact]
+    public void Map_WithSeededLockedSuccess_ShouldReturnZeroAndAllMarkers()
+    {
+        var outcome = new InstallSucceeded(AdminSeeded: true, CredFile: @"C:\x\admin-credentials.txt",
+            CredLocked: true, ServiceStarted: true, HealthOk: true);
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(0);
+        markers.Should().Contain("INDYPOS_MARKER RESULT=success");
+        markers.Should().Contain("INDYPOS_MARKER ADMIN_SEEDED=true");
+        markers.Should().Contain(@"INDYPOS_MARKER CRED_FILE=C:\x\admin-credentials.txt");
+        markers.Should().Contain("INDYPOS_MARKER CRED_LOCKED=true");
+        markers.Should().Contain("INDYPOS_MARKER SERVICE_STARTED=true");
+        markers.Should().Contain("INDYPOS_MARKER HEALTH=ok");
+    }
+
+    [Fact]
+    public void Map_WithUnlockedCredFile_ShouldStayZeroButFlagUnlocked()
+    {
+        var outcome = new InstallSucceeded(true, @"C:\x\admin-credentials.txt", CredLocked: false, true, true);
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(0);
+        markers.Should().Contain("INDYPOS_MARKER CRED_LOCKED=false");
+    }
+
+    [Fact]
+    public void Map_WithAdminAlreadyExisting_ShouldOmitCredFileAndEmitResetHint()
+    {
+        var outcome = new InstallSucceeded(AdminSeeded: false, CredFile: null, CredLocked: false,
+            ServiceStarted: true, HealthOk: false);
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(0);
+        markers.Should().Contain("INDYPOS_MARKER ADMIN_SEEDED=false");
+        markers.Should().NotContain(m => m.StartsWith("INDYPOS_MARKER CRED_FILE="));
+        markers.Should().Contain(m => m.StartsWith("INDYPOS_MARKER RESET_HINT="));
+        markers.Should().Contain("INDYPOS_MARKER HEALTH=failed");
+    }
+
+    [Fact]
+    public void Map_WithInstallFailed_ShouldReturnTwoAndOnlyResultMarker()
+    {
+        var (exit, markers) = SilentOutcomeMapper.Map(new InstallFailed("boom"));
+
+        exit.Should().Be(2);
+        markers.Should().ContainSingle().Which.Should().Be("INDYPOS_MARKER RESULT=failed");
+    }
+
+    [Fact]
+    public void Map_WithTimeout_ShouldReturnFour()
+    {
+        var (exit, markers) = SilentOutcomeMapper.Map(new InstallTimedOut());
+
+        exit.Should().Be(4);
+        markers.Should().ContainSingle().Which.Should().Be("INDYPOS_MARKER RESULT=timeout");
+    }
+
+    [Fact]
+    public void Map_WithUsageError_ShouldReturnOne()
+    {
+        SilentOutcomeMapper.Map(new UsageErrorOutcome("bad")).ExitCode.Should().Be(1);
+    }
+
+    [Fact]
+    public void Map_WithNotElevated_ShouldReturnThree()
+    {
+        SilentOutcomeMapper.Map(new NotElevatedOutcome()).ExitCode.Should().Be(3);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~SilentOutcomeMapperTests"`
+Expected: FAIL — types do not exist.
+
+- [ ] **Step 3: Implement the outcome model + mapper**
+
+Create `installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs`:
+
+```csharp
+namespace IndyPOS.Bootstrapper.Silent;
+
+public abstract record SilentOutcome;
+
+public sealed record InstallSucceeded(
+    bool AdminSeeded, string? CredFile, bool CredLocked, bool ServiceStarted, bool HealthOk) : SilentOutcome;
+
+public sealed record InstallFailed(string Message) : SilentOutcome;
+
+public sealed record InstallTimedOut : SilentOutcome;
+
+public sealed record UsageErrorOutcome(string Message) : SilentOutcome;
+
+public sealed record NotElevatedOutcome : SilentOutcome;
+
+/// <summary>
+/// Pure mapping from a run's outcome to an exit code + the non-secret marker
+/// lines. No I/O — every permutation is unit-testable without running an install.
+/// </summary>
+public static class SilentOutcomeMapper
+{
+    private const string Prefix = "INDYPOS_MARKER ";
+    private const string ResetHint =
+        "run \"IndyPOS.StoreHub.exe reset-admin\" from the StoreHub install dir to reissue a bootstrap password";
+
+    public static (int ExitCode, IReadOnlyList<string> Markers) Map(SilentOutcome outcome) => outcome switch
+    {
+        InstallSucceeded s => (0, SuccessMarkers(s)),
+        InstallFailed => (2, [Prefix + "RESULT=failed"]),
+        InstallTimedOut => (4, [Prefix + "RESULT=timeout"]),
+        UsageErrorOutcome => (1, [Prefix + "RESULT=failed"]),
+        NotElevatedOutcome => (3, [Prefix + "RESULT=failed"]),
+        _ => throw new ArgumentOutOfRangeException(nameof(outcome))
+    };
+
+    private static IReadOnlyList<string> SuccessMarkers(InstallSucceeded s)
+    {
+        var markers = new List<string>
+        {
+            Prefix + "RESULT=success",
+            Prefix + $"ADMIN_SEEDED={Lower(s.AdminSeeded)}"
+        };
+
+        if (s.AdminSeeded)
+        {
+            markers.Add(Prefix + $"CRED_FILE={s.CredFile}");
+            markers.Add(Prefix + $"CRED_LOCKED={Lower(s.CredLocked)}");
+        }
+        else
+        {
+            markers.Add(Prefix + $"RESET_HINT={ResetHint}");
+        }
+
+        markers.Add(Prefix + $"SERVICE_STARTED={Lower(s.ServiceStarted)}");
+        markers.Add(Prefix + $"HEALTH={(s.HealthOk ? "ok" : "failed")}");
+        return markers;
+    }
+
+    private static string Lower(bool value) => value ? "true" : "false";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~SilentOutcomeMapperTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs
+git commit -m "feat(installer): add silent outcome->exit/marker mapper"
+```
+
+---
+
+### Task 5: `ConsoleAttach` + `SilentInstallLogger`
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Silent/ConsoleAttach.cs`
+- Create: `installer/IndyPOS.Bootstrapper/Silent/SilentInstallLogger.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Silent/SilentInstallLoggerTests.cs`
+
+**Interfaces:**
+- Consumes: `IProgress<InstallationProgress>`, `InstallationProgress` (from `IndyPOS.Bootstrapper.Installers`).
+- Produces:
+  - `ConsoleAttach.TryAttach() : bool` (internal static)
+  - `SilentInstallLogger(TextWriter file) : IProgress<InstallationProgress>, IDisposable` with `WriteLine(string)` (timestamped) and `WriteMarker(string)` (raw).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+using IndyPOS.Bootstrapper.Silent;
+using Xunit;
+
+namespace IndyPOS.Bootstrapper.Tests.Silent;
+
+public class SilentInstallLoggerTests
+{
+    [Fact]
+    public void Report_WithLogMessage_ShouldWriteTimestampedLineToFile()
+    {
+        var sink = new StringWriter();
+        using var logger = new SilentInstallLogger(sink);
+
+        logger.Report(InstallationProgress.Log("Installing PostgreSQL"));
+
+        sink.ToString().Should().Contain("Installing PostgreSQL");
+    }
+
+    [Fact]
+    public void Report_WithErrorProgress_ShouldPrefixWarning()
+    {
+        var sink = new StringWriter();
+        using var logger = new SilentInstallLogger(sink);
+
+        logger.Report(InstallationProgress.Error("service failed"));
+
+        sink.ToString().Should().Contain("WARNING: service failed");
+    }
+
+    [Fact]
+    public void WriteMarker_ShouldWriteRawLineWithoutTimestamp()
+    {
+        var sink = new StringWriter();
+        using var logger = new SilentInstallLogger(sink);
+
+        logger.WriteMarker("INDYPOS_MARKER RESULT=success");
+
+        var lines = sink.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        lines.Should().Contain("INDYPOS_MARKER RESULT=success");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~SilentInstallLoggerTests"`
+Expected: FAIL — types do not exist.
+
+- [ ] **Step 3: Implement `ConsoleAttach`**
+
+Create `installer/IndyPOS.Bootstrapper/Silent/ConsoleAttach.cs`:
+
+```csharp
+using System.Runtime.InteropServices;
+
+namespace IndyPOS.Bootstrapper.Silent;
+
+/// <summary>
+/// Best-effort attach to the launching console so Console output reaches the
+/// caller. A no-op (returns false) when there is no parent console — e.g. a
+/// PowerShell Direct host — in which case the durable log file is the record.
+/// </summary>
+internal static partial class ConsoleAttach
+{
+    private const int ATTACH_PARENT_PROCESS = -1;
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool AttachConsole(int dwProcessId);
+
+    public static bool TryAttach()
+    {
+        try { return AttachConsole(ATTACH_PARENT_PROCESS); }
+        catch { return false; }
+    }
+}
+```
+
+- [ ] **Step 4: Implement `SilentInstallLogger`**
+
+Create `installer/IndyPOS.Bootstrapper/Silent/SilentInstallLogger.cs`:
+
+```csharp
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Silent;
+
+/// <summary>
+/// Thread-safe progress sink for the silent installer. Each line goes to the
+/// durable log file (authoritative) and, best-effort, stdout. Report runs inline
+/// on threadpool continuation threads, so all writes are serialized under a lock
+/// and flushed per line — an early crash still leaves a diagnosable log.
+/// </summary>
+public sealed class SilentInstallLogger(TextWriter file) : IProgress<InstallationProgress>, IDisposable
+{
+    private readonly object _gate = new();
+
+    public void Report(InstallationProgress value)
+    {
+        if (!string.IsNullOrEmpty(value.LogMessage))
+        {
+            WriteLine((value.IsError ? "WARNING: " : string.Empty) + value.LogMessage);
+        }
+        else if (!string.IsNullOrEmpty(value.StepName))
+        {
+            WriteLine($"[{value.StepName}] {value.StatusMessage}");
+        }
+    }
+
+    public void WriteLine(string line) => Emit($"[{DateTime.Now:HH:mm:ss}] {line}");
+
+    public void WriteMarker(string marker) => Emit(marker);
+
+    private void Emit(string text)
+    {
+        lock (_gate)
+        {
+            file.WriteLine(text);
+            file.Flush();
+            try { Console.Out.WriteLine(text); } catch { /* no console attached */ }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate) { file.Dispose(); }
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~SilentInstallLoggerTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Silent/ConsoleAttach.cs installer/IndyPOS.Bootstrapper/Silent/SilentInstallLogger.cs tests/IndyPOS.Bootstrapper.Tests/Silent/SilentInstallLoggerTests.cs
+git commit -m "feat(installer): add console-attach + thread-safe silent install logger"
+```
+
+---
+
+### Task 6: `InstallationResult` additive fields
+
+**Files:**
+- Modify: `installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs:290-296,336-340`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Installers/InstallationResultTests.cs` (new)
+
+**Interfaces:**
+- Produces: `InstallationResult.ServiceStarted : bool` and `InstallationResult.HealthOk : bool` (init-only).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/IndyPOS.Bootstrapper.Tests/Installers/InstallationResultTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+using Xunit;
+
+namespace IndyPOS.Bootstrapper.Tests.Installers;
+
+public class InstallationResultTests
+{
+    [Fact]
+    public void InstallationResult_ShouldCarryServiceAndHealthFlags()
+    {
+        var result = new InstallationResult { AdminSeeded = true, ServiceStarted = true, HealthOk = false };
+
+        result.AdminSeeded.Should().BeTrue();
+        result.ServiceStarted.Should().BeTrue();
+        result.HealthOk.Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~InstallationResultTests"`
+Expected: FAIL — `ServiceStarted`/`HealthOk` do not exist.
+
+- [ ] **Step 3: Add the fields and populate them**
+
+In `installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs`, replace the `InstallationResult` class (lines 336-340) with:
+
+```csharp
+/// <summary>Outcome of a successful installation, surfaced to the wizard's finish screen.</summary>
+public class InstallationResult
+{
+    public bool AdminSeeded { get; init; }
+    public bool ServiceStarted { get; init; }
+    public bool HealthOk { get; init; }
+}
+```
+
+Then update the single `return` at line 295 to populate them:
+
+```csharp
+        return new InstallationResult
+        {
+            AdminSeeded = provisionResult.AdminSeeded,
+            ServiceStarted = startResult.Success,
+            HealthOk = healthOk
+        };
+```
+
+(`startResult.Success` and `healthOk` are already in scope at this point — assigned at lines 249 and 263.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~InstallationResultTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs tests/IndyPOS.Bootstrapper.Tests/Installers/InstallationResultTests.cs
+git commit -m "feat(installer): surface ServiceStarted/HealthOk on InstallationResult"
+```
+
+---
+
+### Task 7: `Elevation`, `SilentInstaller`, and the `Program` entry branch
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Silent/Elevation.cs`
+- Create: `installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs`
+- Modify: `installer/IndyPOS.Bootstrapper/Program.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Silent/SilentInstallerTests.cs`
+
+**Interfaces:**
+- Consumes: `SilentArgs`, `ParseResult`, `ParseStatus`, `SilentInstallOptions`, `SilentOutcomeMapper`, all `SilentOutcome` records, `SilentInstallLogger`, `ConsoleAttach`, `SecretScrubber`, `AdminCredentialFile`, `InstallationOrchestrator`, `InstallationConfig`, `DatabaseSetup.TryRestrictFilePermissions`.
+- Produces: `Elevation.IsElevated() : bool`; `SilentInstaller.Run(ParseResult parse) : int`.
+
+- [ ] **Step 1: Write the failing test**
+
+The install path is VM-validated (Task 9); the deterministic unit seam is the pre-install branch — a usage error returns exit 1 without touching the orchestrator or filesystem.
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Silent;
+using Xunit;
+
+namespace IndyPOS.Bootstrapper.Tests.Silent;
+
+public class SilentInstallerTests
+{
+    [Fact]
+    public void Run_WithUsageErrorParseResult_ShouldReturnExitOne()
+    {
+        var parse = ParseResult.Usage("--silent requires --store-id <ID>.");
+
+        var exit = SilentInstaller.Run(parse);
+
+        exit.Should().Be(1);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~SilentInstallerTests"`
+Expected: FAIL — `SilentInstaller` does not exist.
+
+- [ ] **Step 3: Implement `Elevation`**
+
+Create `installer/IndyPOS.Bootstrapper/Silent/Elevation.cs`:
+
+```csharp
+using System.Security.Principal;
+
+namespace IndyPOS.Bootstrapper.Silent;
+
+/// <summary>Shared elevation check for the interactive and silent entry paths.</summary>
+public static class Elevation
+{
+    public static bool IsElevated()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+        return new WindowsPrincipal(identity).IsInRole(WindowsBuiltInRole.Administrator);
+    }
+}
+```
+
+- [ ] **Step 4: Implement `SilentInstaller`**
+
+Create `installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs`:
+
+```csharp
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Silent;
+
+/// <summary>
+/// Headless entry point for `--silent --store-id <ID>`. Reuses
+/// InstallationOrchestrator unchanged; the durable log file is the authoritative
+/// result/marker channel and the exit code is the automation contract.
+/// </summary>
+public static class SilentInstaller
+{
+    public static int Run(ParseResult parse)
+    {
+        ConsoleAttach.TryAttach();
+
+        if (parse.Status == ParseStatus.UsageError)
+            return Emit(new UsageErrorOutcome(parse.ErrorMessage ?? "Invalid arguments."), logger: null);
+
+        if (!Elevation.IsElevated())
+            return Emit(new NotElevatedOutcome(), logger: null);
+
+        var options = parse.Options!;
+        var config = new InstallationConfig { StoreId = options.StoreId };
+
+        var (logPath, writer) = OpenLog(config);
+        var logger = new SilentInstallLogger(writer);
+
+        var outcome = RunInstall(config, options, logger);
+        var exit = Emit(outcome, logger);
+
+        // Dispose (flush + close the file) BEFORE copying to install-latest.log.
+        logger.Dispose();
+        CopyLatest(config, logPath);
+        return exit;
+    }
+
+    private static SilentOutcome RunInstall(
+        InstallationConfig config, SilentInstallOptions options, SilentInstallLogger logger)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(options.TimeoutMinutes));
+
+        InstallationResult result;
+        try
+        {
+            result = new InstallationOrchestrator()
+                .InstallAsync(config, logger, cts.Token)
+                .GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            logger.WriteLine("ERROR: installation timed out.");
+            return new InstallTimedOut();
+        }
+        catch (Exception ex)
+        {
+            var message = SecretScrubber.Scrub(ex.Message);
+            logger.WriteLine("ERROR: " + message);
+            return new InstallFailed(message);
+        }
+
+        if (!result.AdminSeeded)
+            return new InstallSucceeded(false, null, false, result.ServiceStarted, result.HealthOk);
+
+        var (path, locked) = AdminCredentialFile.Write(config);
+        return new InstallSucceeded(true, path, locked, result.ServiceStarted, result.HealthOk);
+    }
+
+    private static int Emit(SilentOutcome outcome, SilentInstallLogger? logger)
+    {
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+        foreach (var marker in markers)
+        {
+            if (logger is not null) logger.WriteMarker(marker);
+            else TryConsole(marker);
+        }
+        return exit;
+    }
+
+    private static (string LogPath, TextWriter Writer) OpenLog(InstallationConfig config)
+    {
+        Directory.CreateDirectory(config.LogsDirectory);
+        var logPath = Path.Combine(
+            config.LogsDirectory, $"install-{DateTime.Now:yyyyMMdd-HHmmss}-{Environment.ProcessId}.log");
+        File.WriteAllText(logPath, string.Empty);
+        DatabaseSetup.TryRestrictFilePermissions(logPath);
+
+        var stream = new FileStream(logPath, FileMode.Append, FileAccess.Write, FileShare.Read);
+        return (logPath, new StreamWriter(stream) { AutoFlush = true });
+    }
+
+    private static void CopyLatest(InstallationConfig config, string logPath)
+    {
+        try
+        {
+            var latest = Path.Combine(config.LogsDirectory, "install-latest.log");
+            File.Copy(logPath, latest, overwrite: true);
+            DatabaseSetup.TryRestrictFilePermissions(latest);
+        }
+        catch { /* best-effort convenience copy */ }
+    }
+
+    private static void TryConsole(string text)
+    {
+        try { Console.Out.WriteLine(text); } catch { /* no console attached */ }
+    }
+}
+```
+
+- [ ] **Step 5: Wire the `Program` entry branch**
+
+Replace the entire contents of `installer/IndyPOS.Bootstrapper/Program.cs` with:
+
+```csharp
+using IndyPOS.Bootstrapper.Silent;
+using IndyPOS.Bootstrapper.UI;
+
+namespace IndyPOS.Bootstrapper;
+
+internal static class Program
+{
+    [STAThread]
+    static int Main(string[] args)
+    {
+        var parse = SilentArgs.Parse(args);
+        if (parse.Status != ParseStatus.NotSilent)
+        {
+            // Headless path: no message loop, no ApplicationConfiguration.Initialize.
+            return SilentInstaller.Run(parse);
+        }
+
+        ApplicationConfiguration.Initialize();
+
+        if (!Elevation.IsElevated())
+        {
+            MessageBox.Show(
+                "IndyPOS Setup requires administrator privileges.\n\n" +
+                "Please right-click and select 'Run as administrator'.",
+                "Administrator Required",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning);
+            return 0;
+        }
+
+        Application.Run(new InstallationWizard());
+        return 0;
+    }
+}
+```
+
+- [ ] **Step 6: Run test + build to verify**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj --filter "FullyQualifiedName~SilentInstallerTests"`
+Expected: PASS.
+
+Run: `dotnet build installer/IndyPOS.Bootstrapper/IndyPOS.Bootstrapper.csproj -c Release`
+Expected: `Build succeeded. 0 Error(s)`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Silent/Elevation.cs installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs installer/IndyPOS.Bootstrapper/Program.cs tests/IndyPOS.Bootstrapper.Tests/Silent/SilentInstallerTests.cs
+git commit -m "feat(installer): headless silent installer entry path"
+```
+
+---
+
+### Task 8: Wire silent mode into the VM harness
+
+**Files:**
+- Modify: `scripts/vm-testing/VMTestConfig.psd1`
+- Modify: `scripts/vm-testing/Reset-AndInstall.ps1:230-268,326`
+
+**Interfaces:**
+- Consumes: `SilentInstaller` via `IndyPOS-Setup.exe --silent --store-id <TestStoreId>`; markers from `install-latest.log`.
+
+- [ ] **Step 1: Add the test store id to the harness config**
+
+In `scripts/vm-testing/VMTestConfig.psd1`, add a `TestStoreId` entry (match the value used in the manual runs):
+
+```powershell
+    TestStoreId = 'Rungrat-001'
+```
+
+- [ ] **Step 2: Replace the wizard handoff with a silent invocation**
+
+In `scripts/vm-testing/Reset-AndInstall.ps1`, replace the entire `Invoke-WizardHandoff` function (lines 230-268) with:
+
+```powershell
+function Invoke-SilentInstall {
+    param($Credential)
+
+    Write-Section '5. Run installer (silent)'
+
+    $guestInstaller = Join-Path $Config.GuestStagingDir $Config.GuestInstallerName
+    $storeId        = $Config.TestStoreId
+    $logDir         = "C:\ProgramData\IndyPOS\v4\logs"
+    $latestLog      = Join-Path $logDir 'install-latest.log'
+
+    Write-Info "Running (in guest): $guestInstaller --silent --store-id $storeId"
+
+    $run = Invoke-Command -VMName $Config.VMName -Credential $Credential -ScriptBlock {
+        param($exe, $id)
+        $p = Start-Process -FilePath $exe -ArgumentList '--silent', '--store-id', $id -Wait -PassThru
+        [pscustomobject]@{ ExitCode = $p.ExitCode }
+    } -ArgumentList $guestInstaller, $storeId
+
+    Write-Info "Installer exit code: $($run.ExitCode)"
+
+    $markers = Invoke-Command -VMName $Config.VMName -Credential $Credential -ScriptBlock {
+        param($p)
+        if (Test-Path $p) { Get-Content $p | Where-Object { $_ -like 'INDYPOS_MARKER *' } } else { @() }
+    } -ArgumentList $latestLog
+
+    # Parse the LAST occurrence of each marker key (D9).
+    $marker = @{}
+    foreach ($line in $markers) {
+        if ($line -match '^INDYPOS_MARKER\s+([A-Z_]+)=(.*)$') { $marker[$Matches[1]] = $Matches[2] }
+    }
+    foreach ($k in $marker.Keys) { Write-Info "marker $k=$($marker[$k])" }
+
+    # Authoritative gating rule: exit code + RESULT + service.
+    $failed = ($run.ExitCode -ne 0) -or ($marker['RESULT'] -ne 'success') -or ($marker['SERVICE_STARTED'] -eq 'false')
+    if ($failed) {
+        throw "Silent install failed (exit=$($run.ExitCode), RESULT=$($marker['RESULT']), SERVICE_STARTED=$($marker['SERVICE_STARTED'])). See $latestLog in the guest."
+    }
+    if ($marker['CRED_LOCKED'] -eq 'false') {
+        Write-Warn2 "Credential file could not be ACL-locked (CRED_LOCKED=false)."
+    }
+    Write-OK "Silent install completed (RESULT=success)."
+}
+```
+
+- [ ] **Step 3: Call the new function from Main**
+
+In `scripts/vm-testing/Reset-AndInstall.ps1`, replace line 326 `Invoke-WizardHandoff -Credential $cred` with:
+
+```powershell
+    Invoke-SilentInstall -Credential $cred
+```
+
+- [ ] **Step 4: Parse-check the script**
+
+Run: `pwsh -NoProfile -Command "$null = [System.Management.Automation.Language.Parser]::ParseFile('scripts/vm-testing/Reset-AndInstall.ps1', [ref]$null, [ref]$null); 'parse-ok'"`
+Expected: prints `parse-ok` (no parse errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/vm-testing/VMTestConfig.psd1 scripts/vm-testing/Reset-AndInstall.ps1
+git commit -m "test(installer): drive VM harness via silent install (no vmconnect handoff)"
+```
+
+---
+
+### Task 9: Full build, installer rebuild, and VM validation
+
+**Files:**
+- No source changes — verification only.
+
+- [ ] **Step 1: Run the full bootstrapper test suite**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests/IndyPOS.Bootstrapper.Tests.csproj`
+Expected: all pass (prior baseline 52 pass / 8 skip, plus the new silent-path tests; 0 failures).
+
+- [ ] **Step 2: Build the whole solution**
+
+Run: `dotnet build -c Release`
+Expected: `Build succeeded. 0 Error(s)`.
+
+- [ ] **Step 3: Rebuild the distributable installer**
+
+Run: `pwsh -File scripts/publish.ps1` then `pwsh -File installer/build-installer.ps1`
+Expected: `publish\IndyPOS-Setup.exe` produced (~190 MB), v4.0.0.0.
+
+- [ ] **Step 4: Run the unattended VM clean-install cycle**
+
+Run: `pwsh -File scripts/vm-testing/Reset-AndInstall.ps1 -KeepRunning`
+Expected: no vmconnect handoff; `RESULT: PASS` from the verifier; installer exit 0; markers show `RESULT=success`, `ADMIN_SEEDED=true`, `SERVICE_STARTED=true`, `CRED_LOCKED=true`.
+
+- [ ] **Step 5: Confirm the credential + force-change flow (manual, in-guest)**
+
+Read the cred file path from the `CRED_FILE` marker, read the file (as admin in-guest), and confirm login → forced password change works via the WinForms app (as in the prior manual VM validation). Confirm a re-run of the silent installer over the same install emits `ADMIN_SEEDED=false` + a `RESET_HINT` marker and writes no new cred file.
+
+- [ ] **Step 6: Commit any doc/status updates**
+
+```bash
+git add .claude/STATUS.md
+git commit -m "docs(indypos): silent installer mode validated in VM"
+```
+
+---
+
+## Notes for the implementer
+
+- **Do not** modify `InstallationOrchestrator`'s install steps — only the additive result fields in Task 6.
+- The `--silent` path must never call `Application.Run` or show a `MessageBox` — an unattended run would hang.
+- Markers on the failure/timeout paths are intentionally minimal (`RESULT=failed|timeout` only); the harness parser tolerates missing markers.
+- `DateTime.Now` is fine in this application code (the workflow-script restriction does not apply here).

--- a/docs/superpowers/specs/2026-07-18-silent-installer-mode-design.md
+++ b/docs/superpowers/specs/2026-07-18-silent-installer-mode-design.md
@@ -1,0 +1,354 @@
+# Design: Silent Installer Mode — Unattended Headless Install
+
+**Date:** 2026-07-18
+**Status:** Draft (revised after 3-perspective sub-agent review — security / architecture / QA)
+**Author:** Pond + Claude (pair)
+**Reviewed by:** Security / Architecture / QA sub-agents (2026-07-18)
+
+## Problem
+
+`IndyPOS-Setup.exe` only runs interactively: `Program.Main` checks for admin
+rights, then `Application.Run(new InstallationWizard())`. The operator types a
+Store ID and clicks through the wizard; every install therefore needs a human at
+the keyboard.
+
+This blocks two things:
+
+1. **VM/CI validation.** Every real production bug in this project's history was
+   caught by the Hyper-V clean-install cycle — and every one of those runs needs
+   a person to drive the wizard via `vmconnect.exe` (~15 min + manual clicks
+   each). `Reset-AndInstall.ps1` already automates snapshot restore → copy
+   installer → poll manifest → verify, but it stalls in the middle waiting for a
+   human to complete the wizard. There is no way to run the full cycle unattended
+   or in CI.
+2. **Field/customer unattended installs.** A support engineer provisioning a
+   store PC cannot script the install; they must remote in and click.
+
+The install *engine* is already headless: `InstallationOrchestrator.InstallAsync`
+runs all seven steps with no UI dependency and returns an `InstallationResult`.
+Only the *entry path* and the wizard's *output surfaces* (on-screen credential
+reveal, on-screen progress log) assume a human is watching.
+
+## Goals
+
+- `IndyPOS-Setup.exe --silent --store-id <ID>` performs a complete install with
+  no window and no prompts.
+- **No weakening** of the admin-provisioning security model
+  (`2026-07-14-admin-provisioning-bootstrap-design.md`): the bootstrap password
+  stays installer-generated, single-use, force-rotated, and delivered only via
+  the ACL-locked `admin-credentials.txt`.
+- A **reliable** machine-readable success/failure contract that survives a
+  GUI-subsystem process launched over PSDirect (see Decision D8) so
+  `Reset-AndInstall.ps1` and CI can branch on the result.
+- Durable, ACL-locked install log on disk so a failed unattended field install
+  can be diagnosed after the fact (there was no screen to have watched) without
+  exposing secrets on a shared store PC.
+- A watchdog so a hung step (e.g. a stalled Postgres download) cannot hang CI
+  forever.
+- Zero behavioural changes to `InstallationOrchestrator`'s install steps — the
+  silent path reuses it; the only change is additive result fields.
+
+## Non-Goals
+
+- **Caller-supplied admin password** (`--app-password`). Rejected: it would put a
+  secret on the command line (process listing, PowerShell history, CI logs) and
+  reintroduce the human-chosen-password weakness the bootstrap redesign removed.
+- **`--credentials-out <path>`** convenience copy. YAGNI for now — the CI harness
+  runs as admin/SYSTEM in-guest and can read the canonical ACL-locked file
+  directly. Revisit only if a consumer genuinely can't reach the config dir.
+- Silent **uninstall** or **upgrade-specific** flags (separate future work).
+- Auto-launching the POS app after a silent install (no user to hand off to).
+- Removing the pre-existing machine-secret exposure on child-process command
+  lines (psql `PASSWORD '…'`, EDB `--superpassword`). This is identical in
+  attended mode, out of scope here, and noted as known residual under Security.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Design for **both** field + CI, holding the stricter **field-grade** security bar | One code path, safe everywhere; CI is just the field path run in a throwaway VM. |
+| D2 | Credential surface = **ACL-locked `admin-credentials.txt`** (source of truth) + non-secret markers | The file is identical to the attended path; markers give automation a signal without leaking the password. |
+| D3 | **No caller-supplied password**; installer generates as today | Keeps the single-use / force-rotate property; no admin secret on the command line. |
+| D4 | Progress → durable log file (authoritative) **and** stdout (best-effort live view) | Live view for an elevated prompt / captured console; durable file for field post-mortem and — per D8 — the reliable channel. |
+| D5 | Soft failures (service didn't start, health check failed) **stay non-fatal** (exit 0) but surface as markers; the **verifier**, not the orchestrator's marker, is the CI health authority | Parity with the wizard's "install completed with a warning"; avoids the 10s-marker-vs-30s-verifier race producing contradictory CI results. The harness gating rule (below) is what actually fails a broken install. |
+| D6 | Silent mode does **not** auto-launch the POS app | Unattended — nothing to hand off to. |
+| D7 | Silent mode never shows a modal; preconditions fail via **exit code**, not MessageBox | A popup would hang an unattended run forever. |
+| D8 | **The durable log file is the authoritative result + marker channel.** stdout is best-effort only. Exit code is captured by the caller via `Start-Process -Wait -PassThru`. | The bootstrapper is `WinExe` (GUI subsystem). `AttachConsole(ATTACH_PARENT_PROCESS)` does not reach a PSDirect host (`wsmprovhost` has no console), and a GUI exe launched via `&`/`Invoke-Command` returns immediately without a reliable `$LASTEXITCODE`. Relying on stdout/`$LASTEXITCODE` would silently break the CI payoff. |
+| D9 | Markers are emitted with a unique line prefix `INDYPOS_MARKER ` and parsers take the **last** occurrence | The bare `ADMIN_SEEDED=` token already exists as a child-process protocol (`StoreHub.exe migrate`, `StoreHubInstaller` greps it); a prefix + last-wins removes any collision with relayed/echoed progress lines. |
+| D10 | `SilentInstaller` owns an overall **watchdog timeout** (default 45 min, `--timeout-minutes` override) | Attended mode has a Cancel button; silent has none, and dropping the vmconnect/manifest-poll handoff removes the old 30-min outer bound. 45 min clears the internal 25-min Postgres timeout with margin. |
+| D11 | ACL-lock the durable log (Administrators + SYSTEM) and **scrub persisted failure output** | The log by design captures step output and, on failure, child-process stderr (which can contain a connection string). ProgramData is `Users`-readable by default; without this the log is a plaintext leak on a shared POS terminal. |
+| D12 | Verify the cred-file ACL was actually applied; if not, emit **`CRED_LOCKED=false`** (exit stays 0) | `RestrictFilePermissions` swallows all failures. In silent mode the file is the *only* carrier of the password, so a silently-unlocked file must be signalled explicitly rather than masked; the harness decides whether to treat it as fatal. |
+
+## CLI contract
+
+```
+IndyPOS-Setup.exe --silent --store-id <ID> [--timeout-minutes <N>]
+```
+
+- `--silent` absent → today's `InstallationWizard`, entirely unchanged.
+- `--silent` present, `--store-id` present and non-blank → headless install.
+- `--silent` present, `--store-id` missing/blank/whitespace → usage error (exit 1).
+- `--timeout-minutes <N>` optional, default 45; must be a positive integer.
+- Flag **names** are case-insensitive (`--SILENT`, `--Store-Id`); the store-id
+  **value** is preserved verbatim (only trimmed), never lower-cased.
+- Both `--store-id <value>` and `--store-id=<value>` forms accepted.
+- Unknown flags alongside `--silent` → usage error (fail fast, don't guess).
+
+### Precondition: caller must already be elevated
+
+`app.manifest` is `requireAdministrator`, so Windows will not start the process
+non-elevated without a UAC consent prompt — which would hang an unattended run.
+**The silent caller must already hold an elevated token** (PSDirect in-guest runs
+as admin/SYSTEM, so CI is fine). The internal `IsRunningAsAdmin()` check remains
+as defense-in-depth and maps to exit 3, but the real contract is "invoke from an
+elevated session."
+
+### Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Install completed — admin seeded **or** already existed; all steps ran |
+| `1` | Usage error — `--store-id` missing/blank, unknown flag, bad `--timeout-minutes` |
+| `2` | Install failed — `InstallationOrchestrator` threw |
+| `3` | Not elevated (defense-in-depth; normally unreachable behind the UAC manifest) |
+| `4` | Timed out — watchdog fired before the install completed |
+
+Exit code (captured via `Start-Process -Wait -PassThru`) is the primary
+automation contract. Soft warnings never change it (see the harness rule below).
+
+### Markers (non-secret, prefixed, written to log + stdout)
+
+Emitted on their own lines, prefixed, after the streamed progress:
+
+```
+INDYPOS_MARKER RESULT=success            # or: failed | timeout
+INDYPOS_MARKER ADMIN_SEEDED=true         # or: false (admin already existed → no cred file)
+INDYPOS_MARKER CRED_FILE=C:\ProgramData\IndyPOS\v4\Config\admin-credentials.txt
+INDYPOS_MARKER CRED_LOCKED=true          # or: false → cred file could NOT be ACL-locked (D12)
+INDYPOS_MARKER SERVICE_STARTED=true      # or: false
+INDYPOS_MARKER HEALTH=ok                 # or: failed (advisory — verifier is the gate, D5)
+INDYPOS_MARKER RESET_HINT=<msg>          # only when ADMIN_SEEDED=false: how to recover via reset-admin
+```
+
+- The password itself is **never** emitted; `CRED_FILE` points at the ACL-locked
+  file. `CRED_FILE` / `CRED_LOCKED` are present only when `ADMIN_SEEDED=true`.
+- On a hard failure (exit 2) or timeout (exit 4), the orchestrator never returns
+  an `InstallationResult`, so only `RESULT=failed|timeout` is guaranteed — the
+  other markers are **absent**. Parsers must tolerate missing markers.
+
+## Architecture
+
+### Entry path (`Program.cs`)
+
+`Main` becomes `static int` and parses `args` before anything else:
+
+```
+int Main(args):
+    if args has "--silent":
+        return SilentInstaller.Run(args)     // no ApplicationConfiguration.Initialize, no Application.Run
+    // interactive path, unchanged:
+    if not elevated: MessageBox + return 0
+    ApplicationConfiguration.Initialize()
+    Application.Run(new InstallationWizard())
+    return 0
+```
+
+Keep `Main` thin — parsing lives in `SilentArgs`, the run in `SilentInstaller`.
+The silent branch installs no `WindowsFormsSynchronizationContext`, so blocking
+on the orchestrator via `.GetAwaiter().GetResult()` is safe (no message-loop
+deadlock). Do not add a sync context to this path.
+
+### New units
+
+| Unit | Responsibility | Depends on |
+|------|----------------|------------|
+| `SilentInstallOptions` (record) + `SilentArgs.Parse(args)` → `ParseOutcome` | Pure args → options / usage-error. No I/O. | — |
+| `SilentInstaller` | Headless driver: elevation check → build config → create+lock log → run orchestrator under a watchdog CTS → write+verify cred file → map outcome to exit code + markers. | `InstallationOrchestrator`, `AdminCredentialFile`, `SilentInstallLogger`, `SilentOutcomeMapper` |
+| `SilentOutcomeMapper.Map(outcome)` → `(int exitCode, IReadOnlyList<string> markers)` | **Pure** mapping over an outcome union (below). No I/O — fully unit-testable. | — |
+| `SilentInstallLogger` (`IProgress<InstallationProgress>`) | Thread-safe fan-out sink: each progress line → stdout (best-effort) + the on-disk log, under a lock, flushed per line. Scrubs/bounds failure text before persisting. | `SecretScrubber` |
+| `AdminCredentialFile.Write(config)` → `string path` | Shared helper extracted from the wizard's `WriteAdminSummaryFile`: writes `admin-credentials.txt`, `RestrictFilePermissions`, **verifies the ACL**, returns the path + a locked flag. | `DatabaseSetup.RestrictFilePermissions` |
+| `ConsoleAttach.TryAttach()` | `AttachConsole(ATTACH_PARENT_PROCESS)` P/Invoke; best-effort no-op when no parent console. | kernel32 |
+| `SecretScrubber.Scrub(text)` | Best-effort redaction of connection-string-shaped substrings before persisting failure output. | — |
+
+### Outcome model (for a pure, testable mapper)
+
+The driver reduces a run to one of:
+
+```
+SilentOutcome =
+  | Success(InstallationResult result, bool credLocked)
+  | InstallFailed(string message)        // orchestrator threw
+  | TimedOut
+  | UsageError(string message)
+  | NotElevated
+```
+
+`SilentOutcomeMapper.Map` turns any of these into `(exitCode, markers[])` with no
+I/O, so all permutations — including hard-fail and timeout — are unit-tested
+without running an install.
+
+### Refactor: shared credential-file writer
+
+`WriteAdminSummaryFile` currently lives as a `private static` in
+`InstallationWizard`. Extract it to `AdminCredentialFile.Write(config)` (returns
+the written path + whether the ACL verified), so the wizard and `SilentInstaller`
+share one implementation (DRY — second consumer). The wizard calls the extracted
+method; on-screen behaviour is unchanged.
+
+### Additive orchestrator change (wizard-safe)
+
+`InstallAsync` already computes `startResult.Success` and `healthOk` at its single
+`return` (`InstallationOrchestrator.cs:249,263,295`). Extend `InstallationResult`
+(kept a `class` with `init` setters — do **not** modernize to a record) with
+`ServiceStarted` and `HealthOk` bools populated there. The wizard ignores them;
+the silent path uses them for `SERVICE_STARTED` / `HEALTH` markers instead of
+re-parsing log strings. No step logic changes.
+
+## Data / control flow (silent run)
+
+```
+1. ConsoleAttach.TryAttach()                     # best-effort; stdout is convenience only
+2. outcome = SilentArgs.Parse(args)
+     usage error?  -> stderr message; print RESULT=failed marker to stdout; return 1
+3. elevation check
+     not admin?    -> stderr message; return 3        # no file/log side effects yet
+4. config = new InstallationConfig { StoreId = options.StoreId.Trim() }
+5. create + ACL-lock <SystemRoot>\logs\ ; open install-<ts>-<pid>.log (+ install-latest.log)
+6. logger = new SilentInstallLogger(logFile)
+7. cts = new CTS(timeout)                          # watchdog (D10)
+   try:
+       result = await orchestrator.InstallAsync(config, logger, cts.Token)
+   catch OperationCanceledException when cts timed out:
+       outcome = TimedOut                          # RESULT=timeout; return 4
+   catch Exception ex:
+       outcome = InstallFailed(Scrub(ex.Message))  # RESULT=failed;  return 2
+8. if result.AdminSeeded:
+       (path, locked) = AdminCredentialFile.Write(config)
+       markers += CRED_FILE=path, CRED_LOCKED=locked   # CRED_LOCKED=false is the warning signal; exit stays 0
+   else:
+       markers += RESET_HINT=<run "IndyPOS.StoreHub.exe reset-admin" to reissue a bootstrap password>
+9. emit markers (RESULT/ADMIN_SEEDED/SERVICE_STARTED/HEALTH/…) to log + stdout
+10. return 0
+```
+
+Ordering note: the logs directory is created **only after** the elevation check
+passes (step 5), so a usage/not-elevated exit leaves no side effects.
+
+## Error handling
+
+- **Usage / not-elevated:** message to stderr, exit 1 / 3, no file or log side
+  effects.
+- **Watchdog timeout:** cancel the orchestrator, `RESULT=timeout`, exit 4. The
+  harness also keeps its own outer `Invoke-Command` timeout as belt-and-braces.
+- **Orchestrator throws:** logger persists a **scrubbed, bounded** message (raw
+  child-process stderr is *not* written verbatim to the durable log — write a
+  generic "step X failed (exit N); see StoreHub logs at <path>" line and scrub
+  connection-string-shaped text), `RESULT=failed`, exit 2. Partial-install
+  cleanup is out of scope (matches the wizard).
+- **Cred-file write / ACL failure:** non-fatal to the install (matches wizard),
+  but reported: `CRED_LOCKED=false` and a warning in the log. The bootstrap
+  password is recoverable via `reset-admin`, so a lost/unlocked file is not a
+  lockout. (Caveat: `reset-admin` prints the new password to stdout — its output
+  is sensitive and must not be captured into durable/CI logs.)
+- **Console attach fails** (detached / PSDirect host): proceed silently; the
+  ACL-locked log file is the authoritative record (D8).
+
+## Logging
+
+- Log file: `<SystemRoot>\logs\install-YYYYMMDD-HHMMSS-<pid>.log`
+  (`C:\ProgramData\IndyPOS\v4\logs\…`), plus a stable `install-latest.log`
+  (copy/rewrite) so a consumer can read a deterministic path without globbing.
+  The `<pid>` suffix avoids same-second collisions on CI retry loops.
+- The logs directory and both files are ACL-locked (Administrators + SYSTEM) via
+  `RestrictFilePermissions` (D11).
+- Every `InstallationProgress` line is timestamped and written to stdout + file
+  under a lock, flushed per line (so an early hard crash still leaves a
+  diagnosable log). Error-flagged lines get a `WARNING:`/`ERROR:` prefix.
+- Markers are written last, to both surfaces, with the `INDYPOS_MARKER ` prefix.
+
+## Security
+
+- **Happy-path progress carries no secret** — verified across all seven steps:
+  `InstallationOrchestrator` and the installers log labels ("Creating database
+  user 'indypos_app'…"), never the values; `StoreHub.exe migrate` emits only
+  `ADMIN_SEEDED=`.
+- **Failure output is scrubbed + bounded** before it reaches the durable log or
+  stdout (D11) — closes the one plausible leak (child-process stderr containing a
+  connection string).
+- **Durable log is ACL-locked** (D11) — no plaintext step output readable by a
+  cashier on a shared terminal.
+- **Cred-file ACL is verified** (D12) — a silently-unlocked password file is
+  reported (`CRED_LOCKED=false`), never masked as success.
+- **No admin secret on the command line** — `--silent --store-id <ID>` contains
+  no secret; PowerShell history stays clean.
+- **Known residual (pre-existing, not worsened):** the DB app-user password
+  (psql `PASSWORD '…'`, `DatabaseSetup.cs:201,275`) and the Postgres superuser
+  password (EDB `--superpassword`, `PostgresInstaller.cs:198`) are visible to
+  `Win32_Process` during the install window. Identical in attended mode; tracked
+  separately, out of scope here.
+
+## Testing
+
+### Unit (no Docker / no VM)
+
+- `SilentArgs.Parse`:
+  - `--silent --store-id ABC` and `--store-id=ABC` → `StoreId=ABC`.
+  - `--silent` with no / blank / whitespace store id → usage error.
+  - `--store-id` appearing last with no following value → usage error.
+  - unknown flag alongside `--silent` → usage error (must **not** fire on the
+    store-id's value token).
+  - `--timeout-minutes` absent → default; non-integer / ≤0 → usage error.
+  - flag-name case-insensitivity; store-id value preserved verbatim + trimmed.
+  - no `--silent` → "interactive" outcome.
+- `SilentOutcomeMapper.Map` over the outcome union: Success(seeded, locked),
+  Success(seeded, **unlocked** → CRED_LOCKED=false, still exit 0),
+  Success(already-existed → no CRED_FILE, RESET_HINT present), InstallFailed
+  (exit 2, only RESULT=failed), TimedOut (exit 4), UsageError (exit 1),
+  NotElevated (exit 3) → each asserts the exact exit code + marker set.
+- `SecretScrubber.Scrub`: connection-string-shaped input is redacted; ordinary
+  text passes through.
+- `AdminCredentialFile.Write` round-trip in a temp dir: file contents include
+  username + password + one-time notice; returns the written path.
+
+### Integration (VM — the payoff)
+
+Extend `Reset-AndInstall.ps1` to run silent install in-guest and gate on a
+**concrete, explicit rule**:
+
+- Launch: `Start-Process -Wait -PassThru IndyPOS-Setup.exe --silent --store-id
+  <VMTestConfig store id>` (in-guest, over PSDirect) → capture `.ExitCode`.
+- Read markers from the **durable log** (`install-latest.log`), not stdout (D8).
+- **Pass/fail rule (authoritative):** FAIL if
+  `ExitCode ≠ 0 OR RESULT≠success OR SERVICE_STARTED=false`. Treat `HEALTH` as
+  advisory; the existing `Test-IndyPOSInstallation.ps1` verifier (30s health
+  window, flips `OverallPass` on failure) is the health authority and runs as the
+  second gate.
+- Then read the cred file (path from the `CRED_FILE` marker — never a hardcoded
+  `v4`) and exercise the login / force-change flow, as the manual VM run does.
+- Keep an outer `Invoke-Command` timeout as belt-and-braces to D10.
+
+This turns the whole clean-install cycle into one unattended command.
+
+## Impact / files
+
+| File | Change |
+|------|--------|
+| `installer/IndyPOS.Bootstrapper/Program.cs` | `Main` → `static int`; parse args; branch to `SilentInstaller` on `--silent`. |
+| `installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs` (new) | `SilentInstallOptions` record + `Parse`. |
+| `installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs` (new) | Headless driver + watchdog. |
+| `installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs` (new) | Pure outcome → exit-code + markers. |
+| `installer/IndyPOS.Bootstrapper/Silent/SilentInstallLogger.cs` (new) | Thread-safe stdout + ACL-locked-file `IProgress` sink. |
+| `installer/IndyPOS.Bootstrapper/Silent/ConsoleAttach.cs` (new) | `AttachConsole` P/Invoke. |
+| `installer/IndyPOS.Bootstrapper/Silent/SecretScrubber.cs` (new) | Redact connection-string-shaped failure text. |
+| `installer/IndyPOS.Bootstrapper/Installers/AdminCredentialFile.cs` (new) | Extracted shared cred-file writer (+ ACL verify, returns path). |
+| `installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs` | Call `AdminCredentialFile.Write` instead of the private method. |
+| `installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs` | Additive: `InstallationResult.ServiceStarted` + `HealthOk`. |
+| `scripts/vm-testing/Reset-AndInstall.ps1` | Drive silent install (`Start-Process -Wait -PassThru`); parse markers from log; apply the gating rule; drop the vmconnect handoff. |
+| `scripts/vm-testing/VMTestConfig.psd1` | Read cred/manifest paths from markers, not a hardcoded `v4` (guard the major-version bump). |
+| `tests/IndyPOS.Bootstrapper.Tests/…` | Arg-parse, outcome-mapper, scrubber, cred-file unit tests. |
+
+## Open questions
+
+None outstanding — CLI shape, credential surface, log surface, the
+GUI-subsystem/PSDirect channel, exit-code semantics, watchdog, and the harness
+gating rule are all settled (brainstorming + sub-agent review).

--- a/installer/IndyPOS.Bootstrapper/IndyPOS.Bootstrapper.csproj
+++ b/installer/IndyPOS.Bootstrapper/IndyPOS.Bootstrapper.csproj
@@ -6,6 +6,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- <ApplicationIcon>indypos-installer.ico</ApplicationIcon> -->
     <StartupObject>IndyPOS.Bootstrapper.Program</StartupObject>
 

--- a/installer/IndyPOS.Bootstrapper/Installers/AdminCredentialFile.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/AdminCredentialFile.cs
@@ -1,0 +1,38 @@
+namespace IndyPOS.Bootstrapper.Installers;
+
+/// <summary>
+/// Writes the one-time admin bootstrap credential to an ACL-locked file.
+/// Shared by the wizard finish screen and the silent installer so both deliver
+/// the credential identically.
+/// </summary>
+public static class AdminCredentialFile
+{
+    /// <summary>
+    /// Writes admin-credentials.txt in the config dir and ACL-locks it to
+    /// Administrators + LocalSystem. Returns the path and whether the lock applied.
+    /// Never throws — a failed write returns Locked=false so callers can react.
+    /// </summary>
+    public static (string Path, bool Locked) Write(InstallationConfig config)
+    {
+        var path = Path.Combine(config.ConfigDirectory, "admin-credentials.txt");
+        var contents =
+            "IndyPOS initial admin sign-in\r\n" +
+            "================================\r\n" +
+            $"Username: {config.AdminUsername}\r\n" +
+            $"Password: {config.AdminPassword}\r\n\r\n" +
+            "This is a one-time password. You will be required to set a new one\r\n" +
+            "on first sign-in. Delete this file after you have signed in.\r\n";
+
+        try
+        {
+            Directory.CreateDirectory(config.ConfigDirectory);
+            File.WriteAllText(path, contents);
+        }
+        catch
+        {
+            return (path, false);
+        }
+
+        return (path, DatabaseSetup.TryRestrictFilePermissions(path));
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs
@@ -333,8 +333,20 @@ public class DatabaseSetup
             var stripped = RemoveInitialAdminNode(original);
 
             var tempPath = configPath + ".tmp";
-            await File.WriteAllTextAsync(tempPath, stripped, cancellationToken);
-            File.Move(tempPath, configPath, overwrite: true);
+            try
+            {
+                await File.WriteAllTextAsync(tempPath, stripped, cancellationToken);
+                File.Move(tempPath, configPath, overwrite: true);
+            }
+            finally
+            {
+                // A successful Move consumes the temp file; this only runs on a
+                // mid-write/move failure, where we must not leave a stray .tmp behind.
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+            }
 
             RestrictFilePermissions(configPath);
             return true;

--- a/installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs
@@ -143,7 +143,9 @@ public class DatabaseSetup
         return Convert.ToBase64String(bytes);
     }
 
-    internal static void RestrictFilePermissions(string filePath)
+    internal static void RestrictFilePermissions(string filePath) => TryRestrictFilePermissions(filePath);
+
+    internal static bool TryRestrictFilePermissions(string filePath)
     {
         try
         {
@@ -171,10 +173,12 @@ public class DatabaseSetup
                 System.Security.AccessControl.AccessControlType.Allow));
 
             fileInfo.SetAccessControl(security);
+            return true;
         }
         catch
         {
             // Ignore permission errors - file is still created
+            return false;
         }
     }
 

--- a/installer/IndyPOS.Bootstrapper/Installers/DotNetInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/DotNetInstaller.cs
@@ -26,7 +26,8 @@ public class DotNetInstaller
     /// </summary>
     public async Task<DotNetInstallerResult> EnsureInstalledAsync(
         IProgress<string>? log = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        bool interactive = true)
     {
         log?.Report("Checking installed .NET runtimes...");
 
@@ -43,6 +44,17 @@ public class DotNetInstaller
         {
             log?.Report(".NET 10 Desktop Runtime installed via winget");
             return new DotNetInstallerResult { Success = true, WasInstalled = true };
+        }
+
+        if (!interactive)
+        {
+            log?.Report(".NET 10 Desktop Runtime missing and could not be installed automatically (winget unavailable).");
+            return new DotNetInstallerResult
+            {
+                Success = false,
+                WasInstalled = false,
+                ErrorMessage = ".NET 10 Desktop Runtime is required but is missing and winget could not install it automatically."
+            };
         }
 
         log?.Report("Silent install unavailable; switching to manual install");

--- a/installer/IndyPOS.Bootstrapper/Installers/InstallationConfig.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/InstallationConfig.cs
@@ -17,6 +17,13 @@ public class InstallationConfig
     public required string StoreId { get; init; }
 
     /// <summary>
+    /// True for the interactive wizard; false for the headless --silent path.
+    /// When false, prerequisite installers must never block on UI (e.g. the
+    /// .NET manual-install dialog) — they fail fast so the run can't hang.
+    /// </summary>
+    public bool Interactive { get; init; } = true;
+
+    /// <summary>
     /// Username for the initial SystemAdmin login (chosen in the wizard).
     /// </summary>
     public string AdminUsername { get; init; } = "admin";

--- a/installer/IndyPOS.Bootstrapper/Installers/InstallationConfig.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/InstallationConfig.cs
@@ -102,23 +102,19 @@ public class InstallationConfig
 
     // 32 alphanumeric chars (~190 bits). Alphanumeric avoids any quoting/escaping
     // hazard in the Npgsql connection string and the CREATE/ALTER ROLE SQL.
-    private static string GenerateSecret()
-    {
-        const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-        var chars = new char[32];
-        for (var i = 0; i < chars.Length; i++)
-        {
-            chars[i] = alphabet[RandomNumberGenerator.GetInt32(alphabet.Length)];
-        }
-        return new string(chars);
-    }
+    private static string GenerateSecret() =>
+        GenerateRandomString("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", 32);
 
-    // 14 chars from a 56-char alphabet with ambiguous glyphs (0/O/1/l/I) removed
+    // 14 chars from a 57-char alphabet with ambiguous glyphs (0/O/1/l/I) removed
     // so it is easy to read off the finish screen and type once. Single-use.
-    private static string GenerateAdminPassword()
+    private static string GenerateAdminPassword() =>
+        GenerateRandomString("ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789", 14);
+
+    // Cryptographically-random string drawn uniformly from the given alphabet.
+    // RandomNumberGenerator.GetInt32 is unbiased, so no modulo skew.
+    private static string GenerateRandomString(string alphabet, int length)
     {
-        const string alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789";
-        var chars = new char[14];
+        var chars = new char[length];
         for (var i = 0; i < chars.Length; i++)
         {
             chars[i] = alphabet[RandomNumberGenerator.GetInt32(alphabet.Length)];

--- a/installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs
@@ -292,7 +292,12 @@ public class InstallationOrchestrator
             "IndyPOS has been installed successfully!",
             100));
 
-        return new InstallationResult { AdminSeeded = provisionResult.AdminSeeded };
+        return new InstallationResult
+        {
+            AdminSeeded = provisionResult.AdminSeeded,
+            ServiceStarted = startResult.Success,
+            HealthOk = healthOk
+        };
     }
 
     private static async Task<bool> VerifyStoreHubHealthAsync(int port, CancellationToken cancellationToken)
@@ -337,4 +342,6 @@ public class InstallationException : Exception
 public class InstallationResult
 {
     public bool AdminSeeded { get; init; }
+    public bool ServiceStarted { get; init; }
+    public bool HealthOk { get; init; }
 }

--- a/installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs
@@ -47,7 +47,8 @@ public class InstallationOrchestrator
 
         var dotNetResult = await _dotNetInstaller.EnsureInstalledAsync(
             new Progress<string>(msg => progress.Report(InstallationProgress.Log(msg))),
-            cancellationToken);
+            cancellationToken,
+            config.Interactive);
 
         if (!dotNetResult.Success)
         {

--- a/installer/IndyPOS.Bootstrapper/Program.cs
+++ b/installer/IndyPOS.Bootstrapper/Program.cs
@@ -1,3 +1,4 @@
+using IndyPOS.Bootstrapper.Silent;
 using IndyPOS.Bootstrapper.UI;
 
 namespace IndyPOS.Bootstrapper;
@@ -5,12 +6,18 @@ namespace IndyPOS.Bootstrapper;
 internal static class Program
 {
     [STAThread]
-    static void Main(string[] args)
+    static int Main(string[] args)
     {
+        var parse = SilentArgs.Parse(args);
+        if (parse.Status != ParseStatus.NotSilent)
+        {
+            // Headless path: no message loop, no ApplicationConfiguration.Initialize.
+            return SilentInstaller.Run(parse);
+        }
+
         ApplicationConfiguration.Initialize();
 
-        // Check if running as admin
-        if (!IsRunningAsAdmin())
+        if (!Elevation.IsElevated())
         {
             MessageBox.Show(
                 "IndyPOS Setup requires administrator privileges.\n\n" +
@@ -18,16 +25,10 @@ internal static class Program
                 "Administrator Required",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Warning);
-            return;
+            return 0;
         }
 
         Application.Run(new InstallationWizard());
-    }
-
-    private static bool IsRunningAsAdmin()
-    {
-        using var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
-        var principal = new System.Security.Principal.WindowsPrincipal(identity);
-        return principal.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
+        return 0;
     }
 }

--- a/installer/IndyPOS.Bootstrapper/Silent/ConsoleAttach.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/ConsoleAttach.cs
@@ -1,0 +1,23 @@
+using System.Runtime.InteropServices;
+
+namespace IndyPOS.Bootstrapper.Silent;
+
+/// <summary>
+/// Best-effort attach to the launching console so Console output reaches the
+/// caller. A no-op (returns false) when there is no parent console — e.g. a
+/// PowerShell Direct host — in which case the durable log file is the record.
+/// </summary>
+internal static partial class ConsoleAttach
+{
+    private const int ATTACH_PARENT_PROCESS = -1;
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool AttachConsole(int dwProcessId);
+
+    public static bool TryAttach()
+    {
+        try { return AttachConsole(ATTACH_PARENT_PROCESS); }
+        catch { return false; }
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Silent/Elevation.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/Elevation.cs
@@ -1,0 +1,13 @@
+using System.Security.Principal;
+
+namespace IndyPOS.Bootstrapper.Silent;
+
+/// <summary>Shared elevation check for the interactive and silent entry paths.</summary>
+public static class Elevation
+{
+    public static bool IsElevated()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+        return new WindowsPrincipal(identity).IsInRole(WindowsBuiltInRole.Administrator);
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Silent/SecretScrubber.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SecretScrubber.cs
@@ -1,0 +1,20 @@
+using System.Text.RegularExpressions;
+
+namespace IndyPOS.Bootstrapper.Silent;
+
+/// <summary>
+/// Best-effort redaction of connection-string-shaped secrets from text before it
+/// is persisted to the install log or echoed to stdout on a failure path.
+/// </summary>
+public static partial class SecretScrubber
+{
+    // Password=... or Pwd=... up to the next ';' or end of string (case-insensitive).
+    [GeneratedRegex(@"(?i)\b(password|pwd)\s*=\s*[^;]*")]
+    private static partial Regex PasswordAssignment();
+
+    public static string Scrub(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+        return PasswordAssignment().Replace(text, "$1=***REDACTED***");
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs
@@ -1,0 +1,97 @@
+namespace IndyPOS.Bootstrapper.Silent;
+
+public sealed record SilentInstallOptions(string StoreId, int TimeoutMinutes);
+
+public enum ParseStatus { Silent, NotSilent, UsageError }
+
+public sealed record ParseResult(ParseStatus Status, SilentInstallOptions? Options, string? ErrorMessage)
+{
+    public static ParseResult Silent(SilentInstallOptions options) => new(ParseStatus.Silent, options, null);
+    public static ParseResult NotSilent() => new(ParseStatus.NotSilent, null, null);
+    public static ParseResult Usage(string message) => new(ParseStatus.UsageError, null, message);
+}
+
+/// <summary>
+/// Pure parser for the silent-install command line. No I/O — fully unit-testable.
+/// Flag NAMES are case-insensitive; the --store-id VALUE is preserved verbatim
+/// (only trimmed).
+/// </summary>
+public static class SilentArgs
+{
+    private const int DefaultTimeoutMinutes = 45;
+
+    public static ParseResult Parse(string[] args)
+    {
+        var isSilent = args.Any(a => NameOf(a).Equals("--silent", StringComparison.OrdinalIgnoreCase));
+        if (!isSilent) return ParseResult.NotSilent();
+
+        string? storeId = null;
+        var timeoutMinutes = DefaultTimeoutMinutes;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var name = NameOf(args[i]);
+            var inlineValue = InlineValueOf(args[i]);
+
+            switch (name.ToLowerInvariant())
+            {
+                case "--silent":
+                    break;
+
+                case "--store-id":
+                    if (!TryReadValue(args, ref i, inlineValue, out storeId))
+                        return ParseResult.Usage("--store-id requires a value.");
+                    break;
+
+                case "--timeout-minutes":
+                    if (!TryReadValue(args, ref i, inlineValue, out var raw)
+                        || !int.TryParse(raw, out timeoutMinutes)
+                        || timeoutMinutes <= 0)
+                        return ParseResult.Usage("--timeout-minutes requires a positive integer.");
+                    break;
+
+                default:
+                    return ParseResult.Usage($"Unknown argument: {args[i]}");
+            }
+        }
+
+        storeId = storeId?.Trim();
+        if (string.IsNullOrWhiteSpace(storeId))
+            return ParseResult.Usage("--silent requires --store-id <ID>.");
+
+        return ParseResult.Silent(new SilentInstallOptions(storeId, timeoutMinutes));
+    }
+
+    private static string NameOf(string arg)
+    {
+        var eq = arg.IndexOf('=');
+        return eq >= 0 ? arg[..eq] : arg;
+    }
+
+    private static string? InlineValueOf(string arg)
+    {
+        var eq = arg.IndexOf('=');
+        return eq >= 0 ? arg[(eq + 1)..] : null;
+    }
+
+    // Reads the value for a flag: the inline "=value" if present, else the next
+    // token (which must exist and not itself be a flag). Advances i past a
+    // consumed next token so it is not re-parsed as unknown.
+    private static bool TryReadValue(string[] args, ref int i, string? inlineValue, out string? value)
+    {
+        if (inlineValue is not null)
+        {
+            value = inlineValue;
+            return true;
+        }
+
+        if (i + 1 < args.Length && !args[i + 1].StartsWith("--"))
+        {
+            value = args[++i];
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentInstallLogger.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentInstallLogger.cs
@@ -1,0 +1,45 @@
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Silent;
+
+/// <summary>
+/// Thread-safe progress sink for the silent installer. Each line goes to the
+/// durable log file (authoritative) and, best-effort, stdout. Report runs inline
+/// on threadpool continuation threads, so all writes are serialized under a lock
+/// and flushed per line — an early crash still leaves a diagnosable log.
+/// </summary>
+public sealed class SilentInstallLogger(TextWriter file) : IProgress<InstallationProgress>, IDisposable
+{
+    private readonly object _gate = new();
+
+    public void Report(InstallationProgress value)
+    {
+        if (!string.IsNullOrEmpty(value.LogMessage))
+        {
+            WriteLine((value.IsError ? "WARNING: " : string.Empty) + value.LogMessage);
+        }
+        else if (!string.IsNullOrEmpty(value.StepName))
+        {
+            WriteLine($"[{value.StepName}] {value.StatusMessage}");
+        }
+    }
+
+    public void WriteLine(string line) => Emit($"[{DateTime.Now:HH:mm:ss}] {line}");
+
+    public void WriteMarker(string marker) => Emit(marker);
+
+    private void Emit(string text)
+    {
+        lock (_gate)
+        {
+            file.WriteLine(text);
+            file.Flush();
+            try { Console.Out.WriteLine(text); } catch { /* no console attached */ }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate) { file.Dispose(); }
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs
@@ -1,0 +1,106 @@
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Silent;
+
+/// <summary>
+/// Headless entry point for `--silent --store-id <ID>`. Reuses
+/// InstallationOrchestrator unchanged; the durable log file is the authoritative
+/// result/marker channel and the exit code is the automation contract.
+/// </summary>
+public static class SilentInstaller
+{
+    public static int Run(ParseResult parse)
+    {
+        ConsoleAttach.TryAttach();
+
+        if (parse.Status == ParseStatus.UsageError)
+            return Emit(new UsageErrorOutcome(parse.ErrorMessage ?? "Invalid arguments."), logger: null);
+
+        if (!Elevation.IsElevated())
+            return Emit(new NotElevatedOutcome(), logger: null);
+
+        var options = parse.Options!;
+        var config = new InstallationConfig { StoreId = options.StoreId };
+
+        var (logPath, writer) = OpenLog(config);
+        var logger = new SilentInstallLogger(writer);
+
+        var outcome = RunInstall(config, options, logger);
+        var exit = Emit(outcome, logger);
+
+        // Dispose (flush + close the file) BEFORE copying to install-latest.log.
+        logger.Dispose();
+        CopyLatest(config, logPath);
+        return exit;
+    }
+
+    private static SilentOutcome RunInstall(
+        InstallationConfig config, SilentInstallOptions options, SilentInstallLogger logger)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(options.TimeoutMinutes));
+
+        InstallationResult result;
+        try
+        {
+            result = new InstallationOrchestrator()
+                .InstallAsync(config, logger, cts.Token)
+                .GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            logger.WriteLine("ERROR: installation timed out.");
+            return new InstallTimedOut();
+        }
+        catch (Exception ex)
+        {
+            var message = SecretScrubber.Scrub(ex.Message);
+            logger.WriteLine("ERROR: " + message);
+            return new InstallFailed(message);
+        }
+
+        if (!result.AdminSeeded)
+            return new InstallSucceeded(false, null, false, result.ServiceStarted, result.HealthOk);
+
+        var (path, locked) = AdminCredentialFile.Write(config);
+        return new InstallSucceeded(true, path, locked, result.ServiceStarted, result.HealthOk);
+    }
+
+    private static int Emit(SilentOutcome outcome, SilentInstallLogger? logger)
+    {
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+        foreach (var marker in markers)
+        {
+            if (logger is not null) logger.WriteMarker(marker);
+            else TryConsole(marker);
+        }
+        return exit;
+    }
+
+    private static (string LogPath, TextWriter Writer) OpenLog(InstallationConfig config)
+    {
+        Directory.CreateDirectory(config.LogsDirectory);
+        var logPath = Path.Combine(
+            config.LogsDirectory, $"install-{DateTime.Now:yyyyMMdd-HHmmss}-{Environment.ProcessId}.log");
+        File.WriteAllText(logPath, string.Empty);
+        DatabaseSetup.TryRestrictFilePermissions(logPath);
+
+        var stream = new FileStream(logPath, FileMode.Append, FileAccess.Write, FileShare.Read);
+        return (logPath, new StreamWriter(stream) { AutoFlush = true });
+    }
+
+    private static void CopyLatest(InstallationConfig config, string logPath)
+    {
+        try
+        {
+            var latest = Path.Combine(config.LogsDirectory, "install-latest.log");
+            File.Copy(logPath, latest, overwrite: true);
+            DatabaseSetup.TryRestrictFilePermissions(latest);
+        }
+        catch { /* best-effort convenience copy */ }
+    }
+
+    private static void TryConsole(string text)
+    {
+        try { Console.Out.WriteLine(text); } catch { /* no console attached */ }
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs
@@ -22,7 +22,18 @@ public static class SilentInstaller
         var options = parse.Options!;
         var config = new InstallationConfig { StoreId = options.StoreId };
 
-        var (logPath, writer) = OpenLog(config);
+        string logPath;
+        TextWriter writer;
+        try
+        {
+            (logPath, writer) = OpenLog(config);
+        }
+        catch (Exception ex)
+        {
+            var message = SecretScrubber.Scrub(ex.Message);
+            return Emit(new InstallFailed(message), logger: null);
+        }
+
         var logger = new SilentInstallLogger(writer);
 
         var outcome = RunInstall(config, options, logger);

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs
@@ -20,7 +20,7 @@ public static class SilentInstaller
             return Emit(new NotElevatedOutcome(), logger: null);
 
         var options = parse.Options!;
-        var config = new InstallationConfig { StoreId = options.StoreId };
+        var config = new InstallationConfig { StoreId = options.StoreId, Interactive = false };
 
         string logPath;
         TextWriter writer;

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs
@@ -1,0 +1,60 @@
+namespace IndyPOS.Bootstrapper.Silent;
+
+public abstract record SilentOutcome;
+
+public sealed record InstallSucceeded(
+    bool AdminSeeded, string? CredFile, bool CredLocked, bool ServiceStarted, bool HealthOk) : SilentOutcome;
+
+public sealed record InstallFailed(string Message) : SilentOutcome;
+
+public sealed record InstallTimedOut : SilentOutcome;
+
+public sealed record UsageErrorOutcome(string Message) : SilentOutcome;
+
+public sealed record NotElevatedOutcome : SilentOutcome;
+
+/// <summary>
+/// Pure mapping from a run's outcome to an exit code + the non-secret marker
+/// lines. No I/O — every permutation is unit-testable without running an install.
+/// </summary>
+public static class SilentOutcomeMapper
+{
+    private const string Prefix = "INDYPOS_MARKER ";
+    private const string ResetHint =
+        "run \"IndyPOS.StoreHub.exe reset-admin\" from the StoreHub install dir to reissue a bootstrap password";
+
+    public static (int ExitCode, IReadOnlyList<string> Markers) Map(SilentOutcome outcome) => outcome switch
+    {
+        InstallSucceeded s => (0, SuccessMarkers(s)),
+        InstallFailed => (2, [Prefix + "RESULT=failed"]),
+        InstallTimedOut => (4, [Prefix + "RESULT=timeout"]),
+        UsageErrorOutcome => (1, [Prefix + "RESULT=failed"]),
+        NotElevatedOutcome => (3, [Prefix + "RESULT=failed"]),
+        _ => throw new ArgumentOutOfRangeException(nameof(outcome))
+    };
+
+    private static IReadOnlyList<string> SuccessMarkers(InstallSucceeded s)
+    {
+        var markers = new List<string>
+        {
+            Prefix + "RESULT=success",
+            Prefix + $"ADMIN_SEEDED={Lower(s.AdminSeeded)}"
+        };
+
+        if (s.AdminSeeded)
+        {
+            markers.Add(Prefix + $"CRED_FILE={s.CredFile}");
+            markers.Add(Prefix + $"CRED_LOCKED={Lower(s.CredLocked)}");
+        }
+        else
+        {
+            markers.Add(Prefix + $"RESET_HINT={ResetHint}");
+        }
+
+        markers.Add(Prefix + $"SERVICE_STARTED={Lower(s.ServiceStarted)}");
+        markers.Add(Prefix + $"HEALTH={(s.HealthOk ? "ok" : "failed")}");
+        return markers;
+    }
+
+    private static string Lower(bool value) => value ? "true" : "false";
+}

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs
@@ -28,7 +28,7 @@ public static class SilentOutcomeMapper
         InstallSucceeded s => (0, SuccessMarkers(s)),
         InstallFailed => (2, [Prefix + "RESULT=failed"]),
         InstallTimedOut => (4, [Prefix + "RESULT=timeout"]),
-        UsageErrorOutcome => (1, [Prefix + "RESULT=failed"]),
+        UsageErrorOutcome u => (1, [Prefix + "RESULT=failed", Prefix + $"REASON={u.Message}"]),
         NotElevatedOutcome => (3, [Prefix + "RESULT=failed"]),
         _ => throw new ArgumentOutOfRangeException(nameof(outcome))
     };

--- a/installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs
+++ b/installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs
@@ -297,7 +297,7 @@ public partial class InstallationWizard : Form
                 Log($"  Password: {_config.AdminPassword}", Color.White);
                 Log("You will be asked to set a new password on first sign-in.", Color.White);
 
-                WriteAdminSummaryFile(_config);
+                AdminCredentialFile.Write(_config);
             }
             else
             {
@@ -360,29 +360,6 @@ public partial class InstallationWizard : Form
         _logTextBox.SelectionColor = color;
         _logTextBox.AppendText($"[{DateTime.Now:HH:mm:ss}] {message}\n");
         _logTextBox.ScrollToCaret();
-    }
-
-    private static void WriteAdminSummaryFile(InstallationConfig config)
-    {
-        try
-        {
-            var path = Path.Combine(config.ConfigDirectory, "admin-credentials.txt");
-            var contents =
-                "IndyPOS initial admin sign-in\r\n" +
-                "================================\r\n" +
-                $"Username: {config.AdminUsername}\r\n" +
-                $"Password: {config.AdminPassword}\r\n\r\n" +
-                "This is a one-time password. You will be required to set a new one\r\n" +
-                "on first sign-in. Delete this file after you have signed in.\r\n";
-
-            Directory.CreateDirectory(config.ConfigDirectory);
-            File.WriteAllText(path, contents);
-            DatabaseSetup.RestrictFilePermissions(path);
-        }
-        catch
-        {
-            // Non-fatal — the password is also shown on screen.
-        }
     }
 
     private void CancelButton_Click(object? sender, EventArgs e)

--- a/scripts/vm-testing/README.md
+++ b/scripts/vm-testing/README.md
@@ -1,11 +1,14 @@
 # VM Smoke-Test (Stage 4)
 
-Semi-automated installer smoke-test on a Hyper-V VM. One command from a
-clean Windows snapshot to a verified IndyPOS v4 install + report.
+Fully automated installer smoke-test on a Hyper-V VM. One command from a
+clean Windows snapshot to a verified IndyPOS v4 install + report — no manual
+wizard step.
 
-> Why "semi"? The bootstrapper is a WinForms wizard with no silent mode (yet).
-> These scripts handle every step *around* the wizard; you click through the
-> wizard once per cycle inside the VM.
+> The bootstrapper runs headlessly via
+> `IndyPOS-Setup.exe --silent --store-id <TestStoreId>`. The harness reads the
+> outcome from `INDYPOS_MARKER` lines in the guest's
+> `C:\ProgramData\IndyPOS\v4\logs\install-latest.log` (exit code + `RESULT` +
+> `SERVICE_STARTED` gate the run).
 
 ## Files
 
@@ -134,25 +137,25 @@ What you'll see:
 [ OK ] Installer staged in guest.
 
 ========================================
- 5. Run wizard (manual)
+ 5. Run installer (silent)
 ========================================
-[INFO] Opening vmconnect.exe — click through the wizard inside the VM.
-[INFO] Inside the VM, run as admin:  C:\Test\IndyPOS-Setup.exe
+[INFO] Running (in guest): C:\Test\IndyPOS-Setup.exe --silent --store-id Rungrat-001
+[INFO] Installer exit code: 0
+[INFO] marker RESULT=success
+[INFO] marker ADMIN_SEEDED=true
+[INFO] marker CRED_FILE=C:\ProgramData\IndyPOS\v4\Config\admin-credentials.txt
+[INFO] marker CRED_LOCKED=true
+[INFO] marker SERVICE_STARTED=true
+[INFO] marker HEALTH=ok
+[ OK ] Silent install completed (RESULT=success).
 
 ========================================
- 6. Wait for install-manifest.json (timeout 30 min)
-========================================
-[INFO] Polling guest for C:\ProgramData\IndyPOS\v4.0.0\install-manifest.json every 15s...
-............................
-[ OK ] install-manifest.json detected — wizard finished.
-
-========================================
- 7. In-VM verification
+ 6. In-VM verification
 ========================================
 [INFO] Running Test-IndyPOSInstallation.ps1 inside guest...
 
 ========================================
- 8. Results
+ 7. Results
 ========================================
 
 [Manifest]
@@ -187,10 +190,11 @@ What you'll see:
 ========================================
 ```
 
-Inside the VM during step 5: open File Explorer → `C:\Test\` → right-click
-`IndyPOS-Setup.exe` → Run as administrator → click through the wizard
-(Store ID, App Password ×2, Start). The host script picks up automatically
-when the bootstrapper writes the manifest.
+Step 5 runs unattended: the host launches `IndyPOS-Setup.exe --silent
+--store-id <TestStoreId>` in the guest via PowerShell Direct, waits for it to
+exit (bounded by the outer `InstallTimeoutMinutes` watchdog), then reads the
+`INDYPOS_MARKER` result lines from the guest's `install-latest.log`. No manual
+interaction inside the VM.
 
 ## Common switches
 

--- a/scripts/vm-testing/README.md
+++ b/scripts/vm-testing/README.md
@@ -224,9 +224,13 @@ when the bootstrapper writes the manifest.
 - **Snapshot drift** — If you patched Windows / changed config inside the
   Clean-Windows snapshot, delete the old checkpoint and re-`Checkpoint-VM`
   after another clean boot.
-- **Postgres install timeout** — Bump `InstallTimeoutMinutes` in
-  `VMTestConfig.psd1`. Defender RT scan is the usual culprit; step 3's
-  `Set-MpPreference -DisableRealtimeMonitoring $true` is recommended.
+- **Install taking longer than expected** — `InstallTimeoutMinutes` in
+  `VMTestConfig.psd1` (default 50) is the *outer* harness watchdog, set above
+  the installer's own 45-min in-process watchdog so the in-guest install
+  fails first with proper markers/exit codes and this one only catches a true
+  hang. Bump it if you also raise the in-process watchdog. Defender RT scan is
+  the usual culprit; step 3's `Set-MpPreference -DisableRealtimeMonitoring
+  $true` is recommended.
 - **"Multiple manifests found"** — Verifier saw both `v4.0.0\` and another
   `v*\` install. Clean the VM and re-snapshot, or pass `-ManifestPath`.
 

--- a/scripts/vm-testing/README.md
+++ b/scripts/vm-testing/README.md
@@ -204,9 +204,6 @@ when the bootstrapper writes the manifest.
 # Refresh stored creds
 .\Reset-AndInstall.ps1 -RecreateCredential
 
-# Already have vmconnect open from a previous run
-.\Reset-AndInstall.ps1 -Headless
-
 # Test a non-default installer build
 .\Reset-AndInstall.ps1 -InstallerPath 'C:\some\other\IndyPOS-Setup.exe'
 ```

--- a/scripts/vm-testing/Reset-AndInstall.ps1
+++ b/scripts/vm-testing/Reset-AndInstall.ps1
@@ -4,14 +4,15 @@
     "verified IndyPOS install".
 
 .DESCRIPTION
-    Semi-automated: the IndyPOS bootstrapper is a WinForms wizard with no
-    silent mode (yet), so this script handles everything around the wizard:
+    Fully automated VM smoke-test orchestrator. Takes a clean VM from snapshot
+    to verified IndyPOS install via headless silent installer:
 
         1. Restore VM to Clean-Windows snapshot
         2. Start VM, wait for PowerShell Direct readiness
         3. Copy the installer into the guest (C:\Test\IndyPOS-Setup.exe)
-        4. Open vmconnect.exe so you can click through the wizard
-        5. Poll inside the VM for install-manifest.json (up to 30 min)
+        4. Run installer in guest: IndyPOS-Setup.exe --silent --store-id <TestStoreId>
+        5. Poll for success markers in C:\ProgramData\IndyPOS\v4\logs\install-latest.log
+           (RESULT=success and SERVICE_STARTED != false gate the flow)
         6. Run Test-IndyPOSInstallation.ps1 in the guest
         7. Pretty-print the report; exit non-zero if any check failed
 

--- a/scripts/vm-testing/Reset-AndInstall.ps1
+++ b/scripts/vm-testing/Reset-AndInstall.ps1
@@ -281,7 +281,7 @@ function Invoke-SilentInstall {
 function Invoke-Verifier {
     param($Credential)
 
-    Write-Section '7. In-VM verification'
+    Write-Section '6. In-VM verification'
 
     Write-Info 'Running Test-IndyPOSInstallation.ps1 inside guest...'
     $result = Invoke-Command -VMName $Config.VMName -Credential $Credential `
@@ -292,7 +292,7 @@ function Invoke-Verifier {
 function Format-Report {
     param($Result)
 
-    Write-Section '8. Results'
+    Write-Section '7. Results'
 
     $byCategory = $Result.Checks | Group-Object Category
     foreach ($g in $byCategory) {

--- a/scripts/vm-testing/Reset-AndInstall.ps1
+++ b/scripts/vm-testing/Reset-AndInstall.ps1
@@ -227,44 +227,47 @@ function Copy-Installer {
     Write-OK 'Installer staged in guest.'
 }
 
-function Invoke-WizardHandoff {
+function Invoke-SilentInstall {
     param($Credential)
 
-    Write-Section '5. Run wizard (manual)'
+    Write-Section '5. Run installer (silent)'
 
     $guestInstaller = Join-Path $Config.GuestStagingDir $Config.GuestInstallerName
+    $storeId        = $Config.TestStoreId
+    $logDir         = "C:\ProgramData\IndyPOS\v4\logs"
+    $latestLog      = Join-Path $logDir 'install-latest.log'
 
-    if ($Headless) {
-        Write-Info '-Headless set; not launching vmconnect. Drive the wizard yourself.'
-    } else {
-        Write-Info 'Opening vmconnect.exe — click through the wizard inside the VM.'
-        Write-Info "Inside the VM, run as admin:  $guestInstaller"
-        Start-Process 'vmconnect.exe' -ArgumentList 'localhost', $Config.VMName | Out-Null
+    Write-Info "Running (in guest): $guestInstaller --silent --store-id $storeId"
+
+    $run = Invoke-Command -VMName $Config.VMName -Credential $Credential -ScriptBlock {
+        param($exe, $id)
+        $p = Start-Process -FilePath $exe -ArgumentList '--silent', '--store-id', $id -Wait -PassThru
+        [pscustomobject]@{ ExitCode = $p.ExitCode }
+    } -ArgumentList $guestInstaller, $storeId
+
+    Write-Info "Installer exit code: $($run.ExitCode)"
+
+    $markers = Invoke-Command -VMName $Config.VMName -Credential $Credential -ScriptBlock {
+        param($p)
+        if (Test-Path $p) { Get-Content $p | Where-Object { $_ -like 'INDYPOS_MARKER *' } } else { @() }
+    } -ArgumentList $latestLog
+
+    # Parse the LAST occurrence of each marker key (D9).
+    $marker = @{}
+    foreach ($line in $markers) {
+        if ($line -match '^INDYPOS_MARKER\s+([A-Z_]+)=(.*)$') { $marker[$Matches[1]] = $Matches[2] }
     }
+    foreach ($k in $marker.Keys) { Write-Info "marker $k=$($marker[$k])" }
 
-    Write-Section "6. Wait for install-manifest.json (timeout $($Config.InstallTimeoutMinutes) min)"
-    Write-Info "Polling guest for $($Config.GuestManifestPath) every $($Config.InstallPollIntervalSec)s..."
-
-    $deadline = (Get-Date).AddMinutes($Config.InstallTimeoutMinutes)
-    $lastDots = 0
-    while ((Get-Date) -lt $deadline) {
-        $exists = Invoke-Command -VMName $Config.VMName -Credential $Credential -ScriptBlock {
-            param($p)
-            Test-Path $p
-        } -ArgumentList $Config.GuestManifestPath -ErrorAction SilentlyContinue
-
-        if ($exists) {
-            Write-Host ''
-            Write-OK 'install-manifest.json detected — wizard finished.'
-            return
-        }
-
-        Write-Host '.' -NoNewline -ForegroundColor DarkGray
-        $lastDots++
-        if ($lastDots % 60 -eq 0) { Write-Host '' }
-        Start-Sleep -Seconds $Config.InstallPollIntervalSec
+    # Authoritative gating rule: exit code + RESULT + service.
+    $failed = ($run.ExitCode -ne 0) -or ($marker['RESULT'] -ne 'success') -or ($marker['SERVICE_STARTED'] -eq 'false')
+    if ($failed) {
+        throw "Silent install failed (exit=$($run.ExitCode), RESULT=$($marker['RESULT']), SERVICE_STARTED=$($marker['SERVICE_STARTED'])). See $latestLog in the guest."
     }
-    throw "Timed out after $($Config.InstallTimeoutMinutes) min. Check the wizard window for errors."
+    if ($marker['CRED_LOCKED'] -eq 'false') {
+        Write-Warn2 "Credential file could not be ACL-locked (CRED_LOCKED=false)."
+    }
+    Write-OK "Silent install completed (RESULT=success)."
 }
 
 # --- Verification + report --------------------------------------------------
@@ -323,7 +326,7 @@ try {
     Restore-CleanVM
     Wait-PowerShellDirect -Credential $cred
     Copy-Installer -Credential $cred
-    Invoke-WizardHandoff -Credential $cred
+    Invoke-SilentInstall -Credential $cred
     $result = Invoke-Verifier -Credential $cred
     Format-Report -Result $result
 

--- a/scripts/vm-testing/Reset-AndInstall.ps1
+++ b/scripts/vm-testing/Reset-AndInstall.ps1
@@ -35,10 +35,6 @@
 .PARAMETER RecreateCredential
     Forget the cached SecureString and re-prompt for the VM admin password.
 
-.PARAMETER Headless
-    Don't launch vmconnect.exe. Use when you already have the console open
-    or are running the wizard via another remote channel.
-
 .EXAMPLE
     .\Reset-AndInstall.ps1
 
@@ -55,8 +51,7 @@ param(
     [string]$InstallerPath,
     [switch]$SkipRestore,
     [switch]$KeepRunning,
-    [switch]$RecreateCredential,
-    [switch]$Headless
+    [switch]$RecreateCredential
 )
 
 $ErrorActionPreference = 'Stop'

--- a/scripts/vm-testing/Reset-AndInstall.ps1
+++ b/scripts/vm-testing/Reset-AndInstall.ps1
@@ -235,11 +235,21 @@ function Invoke-SilentInstall {
 
     Write-Info "Running (in guest): $guestInstaller --silent --store-id $storeId"
 
-    $run = Invoke-Command -VMName $Config.VMName -Credential $Credential -ScriptBlock {
+    $timeoutSec = $Config.InstallTimeoutMinutes * 60
+    $job = Invoke-Command -VMName $Config.VMName -Credential $Credential -AsJob -ScriptBlock {
         param($exe, $id)
         $p = Start-Process -FilePath $exe -ArgumentList '--silent', '--store-id', $id -Wait -PassThru
         [pscustomobject]@{ ExitCode = $p.ExitCode }
     } -ArgumentList $guestInstaller, $storeId
+
+    if (-not (Wait-Job -Job $job -Timeout $timeoutSec)) {
+        Stop-Job -Job $job
+        Remove-Job -Job $job -Force
+        throw "Silent install exceeded the $($Config.InstallTimeoutMinutes)-min harness watchdog (in-guest install hung). See $latestLog in the guest."
+    }
+
+    $run = Receive-Job -Job $job
+    Remove-Job -Job $job
 
     Write-Info "Installer exit code: $($run.ExitCode)"
 

--- a/scripts/vm-testing/VMTestConfig.psd1
+++ b/scripts/vm-testing/VMTestConfig.psd1
@@ -17,6 +17,7 @@
     # Host -> guest staging path. Bootstrapper writes manifest, scripts poll it.
     GuestStagingDir     = 'C:\Test'
     GuestInstallerName  = 'IndyPOS-Setup.exe'
+    TestStoreId         = 'Rungrat-001'
     GuestManifestPath   = 'C:\ProgramData\IndyPOS\v4\install-manifest.json'
 
     # Credential storage. SecureString XML, DPAPI-encrypted per Windows user.

--- a/scripts/vm-testing/VMTestConfig.psd1
+++ b/scripts/vm-testing/VMTestConfig.psd1
@@ -18,7 +18,6 @@
     GuestStagingDir     = 'C:\Test'
     GuestInstallerName  = 'IndyPOS-Setup.exe'
     TestStoreId         = 'Rungrat-001'
-    GuestManifestPath   = 'C:\ProgramData\IndyPOS\v4\install-manifest.json'
 
     # Credential storage. SecureString XML, DPAPI-encrypted per Windows user.
     # First run prompts for VM admin password and caches here. Path is relative
@@ -28,8 +27,7 @@
     # Timeouts (seconds unless suffixed)
     VMStartTimeoutSec       = 180
     PSDirectReadyTimeoutSec = 300
-    InstallPollIntervalSec  = 15
-    InstallTimeoutMinutes   = 30   # Postgres extraction alone is ~9m on host
+    InstallTimeoutMinutes   = 50   # Outer harness watchdog; must exceed the installer's 45-min in-process watchdog
     HealthProbeTimeoutSec   = 60
     HealthCheckPort         = 5000
 }

--- a/tests/IndyPOS.Application.Tests/StoreHub/Auth/ChangePasswordCommandHandlerTests.cs
+++ b/tests/IndyPOS.Application.Tests/StoreHub/Auth/ChangePasswordCommandHandlerTests.cs
@@ -74,6 +74,7 @@ public class ChangePasswordCommandHandlerTests
         var result = await _sut.HandleAsync(new ChangePasswordCommand(user.Id, "oldPass123", "short7!"));
 
         Assert.False(result.Success);
+        _repo.Verify(r => r.SetPasswordAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -83,6 +84,7 @@ public class ChangePasswordCommandHandlerTests
         var result = await _sut.HandleAsync(new ChangePasswordCommand(user.Id, "samePass123", "samePass123"));
 
         Assert.False(result.Success);
+        _repo.Verify(r => r.SetPasswordAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -92,5 +94,6 @@ public class ChangePasswordCommandHandlerTests
         var result = await _sut.HandleAsync(new ChangePasswordCommand(Guid.NewGuid(), "x", "brandNew123"));
 
         Assert.False(result.Success);
+        _repo.Verify(r => r.SetPasswordAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/tests/IndyPOS.Application.Tests/StoreHub/Auth/InitialAdminSeederTests.cs
+++ b/tests/IndyPOS.Application.Tests/StoreHub/Auth/InitialAdminSeederTests.cs
@@ -73,4 +73,16 @@ public class InitialAdminSeederTests
 
         _repo.Verify(r => r.SetPasswordAsync(existing.Id, It.IsAny<string>(), true, It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task ResetAsync_WhenAdminAbsent_CreatesAdminWithMustChange()
+    {
+        _repo.Setup(r => r.GetByUsernameAsync("admin", It.IsAny<CancellationToken>())).ReturnsAsync((StoreUser?)null);
+        var sut = Build("admin", "ignored");
+
+        await sut.ResetAsync("newBootstrap123");
+
+        _repo.Verify(r => r.AddAsync(It.Is<StoreUser>(u => u.Username == "admin" && u.MustChangePassword), It.IsAny<CancellationToken>()), Times.Once);
+        _repo.Verify(r => r.SetPasswordAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }

--- a/tests/IndyPOS.Application.Tests/StoreHub/Auth/StoreAuthServiceTests.cs
+++ b/tests/IndyPOS.Application.Tests/StoreHub/Auth/StoreAuthServiceTests.cs
@@ -214,6 +214,23 @@ public class StoreAuthServiceTests
         Assert.True(result.MustChangePassword);
     }
 
+    [Fact]
+    public async Task AuthenticateAsync_WhenUserNeedNotChangePassword_ReturnsFlagFalse()
+    {
+        var password = "SecurePassword123!";
+        var user = CreateTestUser(_passwordHasher.Hash(password), passwordVersion: 2);
+        user.MustChangePassword = false;
+
+        _userRepositoryMock
+            .Setup(x => x.GetByUsernameAsync("testuser", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        var result = await _sut.AuthenticateAsync("testuser", password);
+
+        Assert.True(result.Success);
+        Assert.False(result.MustChangePassword);
+    }
+
     private static StoreUser CreateTestUser(string passwordHash, int passwordVersion) => new()
     {
         Id = Guid.NewGuid(),

--- a/tests/IndyPOS.Bootstrapper.Tests/Installers/AdminCredentialFileTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Installers/AdminCredentialFileTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+using Xunit;
+
+namespace IndyPOS.Bootstrapper.Tests.Installers;
+
+public class AdminCredentialFileTests
+{
+    [Fact]
+    public void Write_WithSeededAdmin_ShouldWriteCredentialFileAndReturnPath()
+    {
+        var config = new InstallationConfig { StoreId = "STORE-1" };
+        var expectedPath = Path.Combine(config.ConfigDirectory, "admin-credentials.txt");
+
+        try
+        {
+            var (path, locked) = AdminCredentialFile.Write(config);
+
+            path.Should().Be(expectedPath);
+            File.Exists(path).Should().BeTrue();
+            var contents = File.ReadAllText(path);
+            contents.Should().Contain($"Username: {config.AdminUsername}");
+            contents.Should().Contain($"Password: {config.AdminPassword}");
+            locked.Should().BeTrue();
+        }
+        finally
+        {
+            if (File.Exists(expectedPath)) File.Delete(expectedPath);
+        }
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Installers/InstallationResultTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Installers/InstallationResultTests.cs
@@ -1,0 +1,17 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Tests.Installers;
+
+public class InstallationResultTests
+{
+    [Fact]
+    public void InstallationResult_ShouldCarryServiceAndHealthFlags()
+    {
+        var result = new InstallationResult { AdminSeeded = true, ServiceStarted = true, HealthOk = false };
+
+        result.AdminSeeded.Should().BeTrue();
+        result.ServiceStarted.Should().BeTrue();
+        result.HealthOk.Should().BeFalse();
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Silent/SecretScrubberTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Silent/SecretScrubberTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Silent;
+using Xunit;
+
+namespace IndyPOS.Bootstrapper.Tests.Silent;
+
+public class SecretScrubberTests
+{
+    [Theory]
+    [InlineData("Host=127.0.0.1;Password=SuperSecret;Db=x")]
+    [InlineData("Host=127.0.0.1;Pwd=SuperSecret")]
+    public void Scrub_WithPasswordAssignment_ShouldRedactValue(string input)
+    {
+        var result = SecretScrubber.Scrub(input);
+
+        result.Should().NotContain("SuperSecret");
+        result.Should().Contain("***REDACTED***");
+    }
+
+    [Fact]
+    public void Scrub_WithPlainText_ShouldReturnUnchanged()
+    {
+        SecretScrubber.Scrub("provisioning failed (exit 1)").Should().Be("provisioning failed (exit 1)");
+    }
+
+    [Fact]
+    public void Scrub_WithNull_ShouldReturnEmpty()
+    {
+        SecretScrubber.Scrub(null).Should().BeEmpty();
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Silent;
+using Xunit;
+
+namespace IndyPOS.Bootstrapper.Tests.Silent;
+
+public class SilentArgsTests
+{
+    public static TheoryData<string[]> ValidSilentArgs => new()
+    {
+        new[] { "--silent", "--store-id", "ABC" },
+        new[] { "--silent", "--store-id=ABC" },
+        new[] { "--SILENT", "--Store-Id", "ABC" },
+    };
+
+    [Theory]
+    [MemberData(nameof(ValidSilentArgs))]
+    public void Parse_WithSilentAndStoreId_ShouldReturnSilentWithStoreId(string[] args)
+    {
+        var result = SilentArgs.Parse(args);
+
+        result.Status.Should().Be(ParseStatus.Silent);
+        result.Options!.StoreId.Should().Be("ABC");
+        result.Options.TimeoutMinutes.Should().Be(45);
+    }
+
+    [Fact]
+    public void Parse_WithStoreIdValue_ShouldPreserveCaseAndTrim()
+    {
+        var result = SilentArgs.Parse(new[] { "--silent", "--store-id", "  Rungrat-001  " });
+
+        result.Options!.StoreId.Should().Be("Rungrat-001");
+    }
+
+    [Fact]
+    public void Parse_WithTimeoutOverride_ShouldUseIt()
+    {
+        var result = SilentArgs.Parse(new[] { "--silent", "--store-id", "A", "--timeout-minutes", "10" });
+
+        result.Options!.TimeoutMinutes.Should().Be(10);
+    }
+
+    public static TheoryData<string[]> BadSilentArgs => new()
+    {
+        new[] { "--silent" },
+        new[] { "--silent", "--store-id" },
+        new[] { "--silent", "--store-id", " " },
+        new[] { "--silent", "--store-id", "A", "--timeout-minutes", "0" },
+        new[] { "--silent", "--store-id", "A", "--timeout-minutes", "notanumber" },
+        new[] { "--silent", "--store-id", "A", "--bogus" },
+    };
+
+    [Theory]
+    [MemberData(nameof(BadSilentArgs))]
+    public void Parse_WithBadSilentArgs_ShouldReturnUsageError(string[] args)
+    {
+        SilentArgs.Parse(args).Status.Should().Be(ParseStatus.UsageError);
+    }
+
+    public static TheoryData<string[]> NoSilentArgs => new()
+    {
+        Array.Empty<string>(),
+        new[] { "--store-id", "ABC" },
+    };
+
+    [Theory]
+    [MemberData(nameof(NoSilentArgs))]
+    public void Parse_WithoutSilent_ShouldReturnNotSilent(string[] args)
+    {
+        SilentArgs.Parse(args).Status.Should().Be(ParseStatus.NotSilent);
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentInstallLoggerTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentInstallLoggerTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+using IndyPOS.Bootstrapper.Silent;
+
+namespace IndyPOS.Bootstrapper.Tests.Silent;
+
+public class SilentInstallLoggerTests
+{
+    [Fact]
+    public void Report_WithLogMessage_ShouldWriteTimestampedLineToFile()
+    {
+        var sink = new StringWriter();
+        using var logger = new SilentInstallLogger(sink);
+
+        logger.Report(InstallationProgress.Log("Installing PostgreSQL"));
+
+        sink.ToString().Should().Contain("Installing PostgreSQL");
+    }
+
+    [Fact]
+    public void Report_WithErrorProgress_ShouldPrefixWarning()
+    {
+        var sink = new StringWriter();
+        using var logger = new SilentInstallLogger(sink);
+
+        logger.Report(InstallationProgress.Error("service failed"));
+
+        sink.ToString().Should().Contain("WARNING: service failed");
+    }
+
+    [Fact]
+    public void WriteMarker_ShouldWriteRawLineWithoutTimestamp()
+    {
+        var sink = new StringWriter();
+        using var logger = new SilentInstallLogger(sink);
+
+        logger.WriteMarker("INDYPOS_MARKER RESULT=success");
+
+        var lines = sink.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        lines.Should().Contain("INDYPOS_MARKER RESULT=success");
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentInstallLoggerTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentInstallLoggerTests.cs
@@ -39,4 +39,15 @@ public class SilentInstallLoggerTests
         var lines = sink.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
         lines.Should().Contain("INDYPOS_MARKER RESULT=success");
     }
+
+    [Fact]
+    public void Report_WithStepProgress_ShouldWriteBracketedStepLine()
+    {
+        var sink = new StringWriter();
+        using var logger = new SilentInstallLogger(sink);
+
+        logger.Report(InstallationProgress.Step("PostgreSQL", "Installing PostgreSQL 18", 10));
+
+        sink.ToString().Should().Contain("[PostgreSQL] Installing PostgreSQL 18");
+    }
 }

--- a/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentInstallerTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentInstallerTests.cs
@@ -1,0 +1,17 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Silent;
+
+namespace IndyPOS.Bootstrapper.Tests.Silent;
+
+public class SilentInstallerTests
+{
+    [Fact]
+    public void Run_WithUsageErrorParseResult_ShouldReturnExitOne()
+    {
+        var parse = ParseResult.Usage("--silent requires --store-id <ID>.");
+
+        var exit = SilentInstaller.Run(parse);
+
+        exit.Should().Be(1);
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs
@@ -67,9 +67,13 @@ public class SilentOutcomeMapperTests
     }
 
     [Fact]
-    public void Map_WithUsageError_ShouldReturnOne()
+    public void Map_WithUsageError_ShouldReturnOneAndReasonMarker()
     {
-        SilentOutcomeMapper.Map(new UsageErrorOutcome("bad")).ExitCode.Should().Be(1);
+        var (exit, markers) = SilentOutcomeMapper.Map(new UsageErrorOutcome("bad"));
+
+        exit.Should().Be(1);
+        markers.Should().Contain("INDYPOS_MARKER RESULT=failed");
+        markers.Should().Contain("INDYPOS_MARKER REASON=bad");
     }
 
     [Fact]

--- a/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Silent;
+
+namespace IndyPOS.Bootstrapper.Tests.Silent;
+
+public class SilentOutcomeMapperTests
+{
+    [Fact]
+    public void Map_WithSeededLockedSuccess_ShouldReturnZeroAndAllMarkers()
+    {
+        var outcome = new InstallSucceeded(AdminSeeded: true, CredFile: @"C:\x\admin-credentials.txt",
+            CredLocked: true, ServiceStarted: true, HealthOk: true);
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(0);
+        markers.Should().Contain("INDYPOS_MARKER RESULT=success");
+        markers.Should().Contain("INDYPOS_MARKER ADMIN_SEEDED=true");
+        markers.Should().Contain(@"INDYPOS_MARKER CRED_FILE=C:\x\admin-credentials.txt");
+        markers.Should().Contain("INDYPOS_MARKER CRED_LOCKED=true");
+        markers.Should().Contain("INDYPOS_MARKER SERVICE_STARTED=true");
+        markers.Should().Contain("INDYPOS_MARKER HEALTH=ok");
+    }
+
+    [Fact]
+    public void Map_WithUnlockedCredFile_ShouldStayZeroButFlagUnlocked()
+    {
+        var outcome = new InstallSucceeded(true, @"C:\x\admin-credentials.txt", CredLocked: false, true, true);
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(0);
+        markers.Should().Contain("INDYPOS_MARKER CRED_LOCKED=false");
+    }
+
+    [Fact]
+    public void Map_WithAdminAlreadyExisting_ShouldOmitCredFileAndEmitResetHint()
+    {
+        var outcome = new InstallSucceeded(AdminSeeded: false, CredFile: null, CredLocked: false,
+            ServiceStarted: true, HealthOk: false);
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(0);
+        markers.Should().Contain("INDYPOS_MARKER ADMIN_SEEDED=false");
+        markers.Should().NotContain(m => m.StartsWith("INDYPOS_MARKER CRED_FILE="));
+        markers.Should().Contain(m => m.StartsWith("INDYPOS_MARKER RESET_HINT="));
+        markers.Should().Contain("INDYPOS_MARKER HEALTH=failed");
+    }
+
+    [Fact]
+    public void Map_WithInstallFailed_ShouldReturnTwoAndOnlyResultMarker()
+    {
+        var (exit, markers) = SilentOutcomeMapper.Map(new InstallFailed("boom"));
+
+        exit.Should().Be(2);
+        markers.Should().ContainSingle().Which.Should().Be("INDYPOS_MARKER RESULT=failed");
+    }
+
+    [Fact]
+    public void Map_WithTimeout_ShouldReturnFour()
+    {
+        var (exit, markers) = SilentOutcomeMapper.Map(new InstallTimedOut());
+
+        exit.Should().Be(4);
+        markers.Should().ContainSingle().Which.Should().Be("INDYPOS_MARKER RESULT=timeout");
+    }
+
+    [Fact]
+    public void Map_WithUsageError_ShouldReturnOne()
+    {
+        SilentOutcomeMapper.Map(new UsageErrorOutcome("bad")).ExitCode.Should().Be(1);
+    }
+
+    [Fact]
+    public void Map_WithNotElevated_ShouldReturnThree()
+    {
+        SilentOutcomeMapper.Map(new NotElevatedOutcome()).ExitCode.Should().Be(3);
+    }
+}


### PR DESCRIPTION
## Silent Installer Mode

Adds a headless install path — `IndyPOS-Setup.exe --silent --store-id <ID>` — so the VM/CI clean-install cycle and unattended field installs run with no wizard.

A thin `SilentInstaller` driver reuses the existing `InstallationOrchestrator` **unchanged**. Pure units (arg parser, outcome→exit/marker mapper, secret scrubber) are TDD'd in isolation; the driver wires them plus a thread-safe stdout + ACL-locked-file logger and an overall watchdog. Because the exe is `WinExe` (GUI subsystem), the durable log file is the authoritative result channel and the caller reads the exit code.

### Contract
- **Exit codes:** `0` success · `1` usage error · `2` install failed · `3` not elevated · `4` timeout.
- **Markers** (prefixed `INDYPOS_MARKER `, consumers read the last occurrence): `RESULT`, `ADMIN_SEEDED`, `CRED_FILE`, `CRED_LOCKED`, `SERVICE_STARTED`, `HEALTH`; `REASON` on usage errors.
- **No admin secret on the command line.** The bootstrap password stays installer-generated and is never written to stdout or the log — only its ACL-locked file path (`CRED_FILE`).

### What's new
- `installer/IndyPOS.Bootstrapper/Silent/` — `SilentArgs`, `SilentOutcomeMapper`, `SecretScrubber`, `ConsoleAttach`, `SilentInstallLogger`, `Elevation`, `SilentInstaller`.
- `Installers/AdminCredentialFile` — shared ACL-locked cred-file writer, extracted from the wizard so both paths deliver the credential identically.
- Additive `InstallationResult.ServiceStarted` / `HealthOk`; `Program.Main` → `int` with a `--silent` branch (interactive wizard path unchanged).
- VM harness (`scripts/vm-testing/`) now drives the silent install (no vmconnect handoff), with a job-based outer watchdog.
- Also carries the tier-2 cleanup minors from the admin-provisioning work (post-#50): DRY password generators, orphaned-`.tmp` cleanup, extra test-rigor assertions.

### Notable fix (found by the whole-branch review)
The "silent" path could still hang on a clean/offline machine: when .NET 10 is absent **and** winget can't install it, `DotNetInstaller.InstallManually` popped a blocking `MessageBox` loop with nobody to click it (a Win32 modal never observes the cancellation token). Fixed with an `InstallationConfig.Interactive` flag — headless mode fails fast to exit 2 instead of showing a dialog — and the harness regained an outer timeout (`InstallTimeoutMinutes` 30→50, above the 45-min in-process watchdog).

### Verification
- Built via 9-task subagent-driven TDD; every task per-task reviewed; final whole-branch review **Ready to merge: Yes**.
- `dotnet build -c Release` 0 errors · `IndyPOS.Bootstrapper.Tests` **83 pass / 8 skip / 0 fail**.
- Installer rebuilt (190.3 MB). **Unattended VM clean-install PASSED** (9m27s, fully headless): verifier **18/18**, all markers correct, service Running, `/health/ready` 200, cred file ACL-locked.
- **Force-change modal confirmed live** in the VM (bootstrap login → forced rotation → POS opens).

https://claude.ai/code/session_011hMU62N6TyWFTDgyFeSkqc
