### PR TITLE
Fix installer config destruction on failed extraction, and three cleanup-v4 bugs

### DIFF
--- a/installer/IndyPOS.Bootstrapper/Installers/ConfigSnapshot.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/ConfigSnapshot.cs
@@ -1,0 +1,61 @@
+namespace IndyPOS.Bootstrapper.Installers;
+
+/// <summary>
+/// Remembers a config file's exact bytes so a failed step can put them back.
+/// <para>
+/// Extracting the StoreHub package overwrites <c>appsettings.json</c> with the shipped
+/// template, and <see cref="DatabaseSetup"/> only rewrites the real values afterwards. If
+/// extraction dies in between — as it does when a running service holds a DLL open — an
+/// upgraded store is left with a template config and cannot start after the next reboot.
+/// Restoring on failure keeps a failed upgrade non-destructive.
+/// </para>
+/// </summary>
+internal sealed class ConfigSnapshot
+{
+    private readonly string _path;
+    private readonly byte[]? _content;
+
+    private ConfigSnapshot(string path, byte[]? content)
+    {
+        _path = path;
+        _content = content;
+    }
+
+    /// <summary>Captures <paramref name="path"/>, or the fact that it did not exist.</summary>
+    public static ConfigSnapshot Capture(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var content = File.Exists(path) ? File.ReadAllBytes(path) : null;
+
+        return new ConfigSnapshot(path, content);
+    }
+
+    /// <summary>
+    /// Puts the captured state back. Deletes the file if it did not exist when captured,
+    /// so a failed first install does not leave a half-configured template behind.
+    /// Idempotent, and never throws — it runs on the failure path, where the original
+    /// error is the one worth reporting.
+    /// </summary>
+    public void Restore()
+    {
+        try
+        {
+            if (_content is null)
+            {
+                if (File.Exists(_path))
+                {
+                    File.Delete(_path);
+                }
+
+                return;
+            }
+
+            File.WriteAllBytes(_path, _content);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Nothing useful to do here: the caller is already failing the install.
+        }
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs
@@ -31,6 +31,8 @@ public class StoreHubInstaller
     {
         _config = config;
 
+        ConfigSnapshot? configSnapshot = null;
+
         try
         {
             log?.Report("Creating installation directory...");
@@ -39,19 +41,30 @@ public class StoreHubInstaller
                 Directory.CreateDirectory(Config.StoreHubInstallPath);
             }
 
+            // Must precede extraction: on an in-place upgrade the running service holds
+            // its own DLLs open, so extracting over them throws "being used by another
+            // process". A clean install has no service and this is a no-op.
+            log?.Report("Checking for existing service...");
+            await StopExistingServiceAsync(cancellationToken);
+
+            // Extraction overwrites appsettings.json with the package template and
+            // DatabaseSetup only rewrites the real values later, so a failure in between
+            // would strand an upgraded store on a config it cannot start from.
+            configSnapshot = ConfigSnapshot.Capture(
+                Path.Combine(Config.StoreHubInstallPath, "appsettings.json"));
+
             log?.Report("Extracting StoreHub binaries...");
             var extractResult = await ExtractStoreHubBinariesAsync(log, cancellationToken);
             if (!extractResult)
             {
+                configSnapshot.Restore();
+
                 return new StoreHubInstallerResult
                 {
                     Success = false,
                     ErrorMessage = "Failed to extract StoreHub binaries"
                 };
             }
-
-            log?.Report("Checking for existing service...");
-            await StopExistingServiceAsync(cancellationToken);
 
             log?.Report("Registering Windows Service...");
             var serviceResult = await CreateWindowsServiceAsync(log, cancellationToken);
@@ -68,6 +81,10 @@ public class StoreHubInstaller
         }
         catch (Exception ex)
         {
+            // The locked-DLL failure arrives here as an IOException, so this is the path
+            // that actually protects a live store's config.
+            configSnapshot?.Restore();
+
             return new StoreHubInstallerResult
             {
                 Success = false,

--- a/scripts/cleanup-v4.ps1
+++ b/scripts/cleanup-v4.ps1
@@ -19,10 +19,13 @@
     DATABASE CREDENTIALS:
     The Postgres superuser password is generated randomly during install and
     not persisted, so we recover the v4 app-user credentials from
-    appsettings.json. The app user owns the database, so it can
-    DROP DATABASE on its own. The role itself is preserved (installer is
-    idempotent on existing roles). Pass -PostgresPassword to also DROP ROLE,
-    or pass -SkipDatabase to leave the DB intact.
+    appsettings.json - DPAPI-unsealing the connection string first, since the
+    installer stores it as "DPAPI:<base64>" (LocalMachine scope, per-key
+    entropy). Decryption only works on the machine that installed it. The app
+    user owns the database, so it can DROP DATABASE on its own. The role itself
+    is preserved (installer is idempotent on existing roles). Pass
+    -PostgresPassword to also DROP ROLE, or pass -SkipDatabase to leave the DB
+    intact.
 
     REQUIRES ADMINISTRATOR PRIVILEGES.
 
@@ -303,11 +306,61 @@ function Remove-VelopackApp {
 }
 
 # --- Step 3: database ---
+function Unprotect-ConfigValue {
+    # Mirror of IndyPOS.Vault SecretProtector.Unprotect (see src/IndyPOS.Vault/
+    # SecretProtector.cs): DPAPI at LocalMachine scope, with per-key entropy
+    # SHA256("IndyPOS:<configKey>") binding each ciphertext to its config key.
+    #
+    # Needed because the installer DPAPI-seals the connection string in
+    # appsettings.json. Feeding "DPAPI:<base64>" straight to a connection-string
+    # builder throws, which used to make this script silently skip the database
+    # drop - so a smoke-test loop without -RemovePostgres left the old database
+    # in place and the next install quietly reused stale data.
+    param(
+        [Parameter(Mandatory)] [string]$Key,
+        [Parameter(Mandatory)] [string]$Value
+    )
+
+    if (-not $Value.StartsWith('DPAPI:', [System.StringComparison]::Ordinal)) {
+        return $Value   # unprotected (dev/Aspire) values pass through, as the C# does
+    }
+
+    # PowerShell 5.1 needs System.Security loaded; on 7.x ProtectedData already resolves.
+    try { Add-Type -AssemblyName System.Security -ErrorAction SilentlyContinue } catch { }
+
+    try {
+        # SHA256.Create().ComputeHash, not the static HashData - the latter is
+        # .NET 5+ only and the Hyper-V guest runs PowerShell 5.1.
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $entropy = $sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes("IndyPOS:$Key"))
+        } finally {
+            $sha.Dispose()
+        }
+
+        $cipher = [Convert]::FromBase64String($Value.Substring('DPAPI:'.Length))
+        $plain = [System.Security.Cryptography.ProtectedData]::Unprotect(
+            $cipher, $entropy, [System.Security.Cryptography.DataProtectionScope]::LocalMachine)
+
+        return [System.Text.Encoding]::UTF8.GetString($plain)
+    } catch {
+        # Wrong machine, corrupt value, or ProtectedData unavailable. Caller degrades
+        # to the superuser path rather than failing the whole teardown.
+        Write-Warn "Could not decrypt '$Key' - $($_.Exception.Message)"
+        return $null
+    }
+}
+
 function Get-AppPasswordFromConfig {
     if (-not (Test-Path $AppsettingsPath)) { return $null }
     try {
         $json = Get-Content $AppsettingsPath -Raw | ConvertFrom-Json
         $connStr = $json.connectionStrings.'storehub-db'
+        if (-not $connStr) { return $null }
+
+        # The installer seals this value; unprotect before parsing. Key must match
+        # what StoreHub's UnprotectSecrets uses, or the entropy won't line up.
+        $connStr = Unprotect-ConfigValue -Key 'ConnectionStrings:storehub-db' -Value $connStr
         if (-not $connStr) { return $null }
 
         # Use DbConnectionStringBuilder for correct handling of escaped/quoted

--- a/scripts/cleanup-v4.ps1
+++ b/scripts/cleanup-v4.ps1
@@ -9,7 +9,7 @@
       1. Stop + delete Windows service 'IndyPOS.StoreHub.v4'
       2. Uninstall the Velopack WinForms app
       3. Drop the v4 PostgreSQL database
-      4. Remove C:\ProgramData\IndyPOS\v4.0.0\
+      4. Remove C:\ProgramData\IndyPOS\v4\ (major-only root; see Assert-V4Path)
       5. Remove %LOCALAPPDATA%\IndyPOS.POS.v4\
       6. (Opt-in) uninstall PostgreSQL 18 itself
 
@@ -80,7 +80,7 @@ $ManifestSource  = "defaults"
 function Read-InstallManifest {
     # Glob for install-manifest.json under any v*\ subdir of $ProgramDataRoot.
     # Each install version gets its own folder, so we can't assume which one
-    # is present — discovery lets cleanup work for v4.0.0, v4.0.1, etc.
+    # is present - discovery lets cleanup work for v4.0.0, v4.0.1, etc.
     # If none found, keep the baked-in defaults so cleanup still copes with
     # a half-installed system.
     if (-not (Test-Path $ProgramDataRoot)) { return }
@@ -141,9 +141,14 @@ function Test-IsAdmin {
 }
 
 function Assert-V4Path {
-    # Refuse anything that isn't a v<Major>.<Minor>.<Patch> subdirectory of
-    # the shared parent. Catches accidental SystemRoot collapses, typos, and
-    # future-version drift.
+    # Refuse anything that isn't a v-and-digits subdirectory of the shared
+    # parent. Catches accidental SystemRoot collapses, typos, and version drift.
+    #
+    # Accepts both the current major-only root (v4) and the legacy
+    # v<Major>.<Minor>.<Patch> form (v4.0.0). InstallationConfig.SystemRoot moved
+    # to major-only so the path survives Velopack patch updates; this guard was
+    # left demanding three parts, which made the script refuse to clean the very
+    # layout the installer produces.
     param([Parameter(Mandatory)] [string]$Path)
     $resolved = [System.IO.Path]::GetFullPath($Path).TrimEnd('\').ToLowerInvariant()
     $parentResolved = [System.IO.Path]::GetFullPath($ProgramDataRoot).TrimEnd('\').ToLowerInvariant()
@@ -152,8 +157,8 @@ function Assert-V4Path {
         throw "Safety guard: '$Path' is not a v-prefixed subdirectory of '$ProgramDataRoot'."
     }
     $suffix = $resolved.Substring($parentResolved.Length + 1)
-    if ($suffix -notmatch '^v\d+\.\d+\.\d+(\\|$)') {
-        throw "Safety guard: '$Path' does not match v<Major>.<Minor>.<Patch> pattern."
+    if ($suffix -notmatch '^v\d+(\.\d+\.\d+)?(\\|$)') {
+        throw "Safety guard: '$Path' does not match v<Major> or v<Major>.<Minor>.<Patch> pattern."
     }
 }
 
@@ -167,7 +172,7 @@ function Assert-SafetyGuards {
 
 # --- Step 1: service ---
 function Wait-ServiceGone {
-    # sc.exe delete is async — SCM marks for deletion but the entry survives
+    # sc.exe delete is async - SCM marks for deletion but the entry survives
     # until all handles close. A follow-up install would then see the stale
     # entry and skip recreation. Poll until Get-Service stops finding it.
     param([string]$Name, [int]$TimeoutSeconds = 30)
@@ -195,7 +200,7 @@ function Remove-StoreHubService {
             Stop-Service -Name $ServiceName -Force -ErrorAction Stop
             $svc.WaitForStatus('Stopped', '00:00:30')
         } catch {
-            Write-Warn "Stop-Service failed: $($_.Exception.Message). Continuing — sc.exe delete will try anyway."
+            Write-Warn "Stop-Service failed: $($_.Exception.Message). Continuing - sc.exe delete will try anyway."
         }
     }
 

--- a/tests/IndyPOS.Bootstrapper.Tests/Installers/ConfigSnapshotTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Installers/ConfigSnapshotTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Tests.Installers;
+
+public class ConfigSnapshotTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "indypos-cfgsnap-" + Guid.NewGuid().ToString("N"));
+
+    public ConfigSnapshotTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+    }
+
+    private string WriteFile(string name, string content)
+    {
+        var path = Path.Combine(_dir, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void Restore_AfterFileWasOverwritten_ShouldBringBackOriginalContent()
+    {
+        var path = WriteFile("appsettings.json", """{"ConnectionStrings":{"storehub-db":"DPAPI:abc"}}""");
+        var snapshot = ConfigSnapshot.Capture(path);
+
+        File.WriteAllText(path, """{"AllowedHosts":"*"}""");
+        snapshot.Restore();
+
+        File.ReadAllText(path).Should().Be("""{"ConnectionStrings":{"storehub-db":"DPAPI:abc"}}""");
+    }
+
+    [Fact]
+    public void Restore_WhenFileWasAbsentAtCapture_ShouldNotCreateIt()
+    {
+        // A fresh install has no config yet; restoring must not fabricate one.
+        var path = Path.Combine(_dir, "appsettings.json");
+        var snapshot = ConfigSnapshot.Capture(path);
+
+        snapshot.Restore();
+
+        File.Exists(path).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Restore_WhenFileWasAbsentAtCaptureButCreatedSince_ShouldRemoveIt()
+    {
+        // Extraction dropped a template where there was nothing: leaving it behind
+        // would make a failed first install look half-configured.
+        var path = Path.Combine(_dir, "appsettings.json");
+        var snapshot = ConfigSnapshot.Capture(path);
+        File.WriteAllText(path, """{"AllowedHosts":"*"}""");
+
+        snapshot.Restore();
+
+        File.Exists(path).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Restore_CalledTwice_ShouldBeIdempotent()
+    {
+        var path = WriteFile("appsettings.json", "original");
+        var snapshot = ConfigSnapshot.Capture(path);
+        File.WriteAllText(path, "clobbered");
+
+        snapshot.Restore();
+        snapshot.Restore();
+
+        File.ReadAllText(path).Should().Be("original");
+    }
+
+    [Fact]
+    public void Restore_ShouldPreserveExactBytes()
+    {
+        // The connection string is DPAPI base64; a re-encoding would corrupt it.
+        var path = Path.Combine(_dir, "appsettings.json");
+        var original = new byte[] { 0xEF, 0xBB, 0xBF, 0x7B, 0x22, 0x61, 0x22, 0x7D };
+        File.WriteAllBytes(path, original);
+        var snapshot = ConfigSnapshot.Capture(path);
+
+        File.WriteAllText(path, "clobbered");
+        snapshot.Restore();
+
+        File.ReadAllBytes(path).Should().Equal(original);
+    }
+}


### PR DESCRIPTION
Three bugs found while trying to run an upgrade smoke test on a real store image in the Hyper-V VM. All pre-existing, none related to the payment-method cleanup batch. Each stands alone.

## 1. Installer destroyed a store's config when extraction failed

`StoreHubInstaller.InstallAsync` extracted the StoreHub payload **before** calling `StopExistingServiceAsync`, so on an in-place upgrade the running service held its own DLLs open:

```
ERROR: StoreHub installation failed: The process cannot access the file
'...\v4\StoreHub\Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.dll'
because it is being used by another process.
```

A clean install has no running service, which is why the 18-check suite never caught this.

Reordered so the stop precedes extraction. It's a no-op on a fresh machine — the helper already swallows the "service doesn't exist" case.

The worse half was collateral: extraction overwrites `appsettings.json` with the package template, and `DatabaseSetup` only rewrites the real values afterwards. A failure in between strands a store on a config it cannot start from — observed as a template config with an empty `Store:Id`. New `ConfigSnapshot` captures the file before extraction and restores it on failure, **including the exception path**, which is the one the locked DLL actually takes.

5 tests, TDD'd: byte-exact restore, absent-at-capture, cleanup of a template dropped where nothing existed, and idempotency.

This is a strict improvement to the fresh-install path too — any extraction failure now leaves config intact.

## 2. `cleanup-v4.ps1` refused to clean the layout the installer produces

```
Safety guard: 'C:\ProgramData\IndyPOS\v4' does not match v<Major>.<Minor>.<Patch> pattern.
```

`SystemRoot` moved to a major-only root (`v4`) in May so the path survives Velopack patch updates. The script's default path was updated then; `Assert-V4Path` was not, so the documented teardown command was inoperable.

Now accepts `v<Major>` as well as the legacy three-part form. Verified `v`, `vfoo` and empty are still refused, so the guard against a `SystemRoot` collapse is intact.

## 3. `cleanup-v4.ps1` was unparseable inside the Hyper-V guest

Three em-dashes, one of them inside a double-quoted string. The file has no BOM, so PowerShell 5.1 reads it in the ANSI codepage — the dev box is UTF-8 but **the guest is Windows-1252**, which mangled those bytes, unbalanced the string, and surfaced as a bogus `Missing closing '}'` at the enclosing function.

Now pure ASCII: parses in the guest with no BOM needed.

## 4. `cleanup-v4.ps1` silently skipped the database drop

It fed `appsettings.json`'s connection string straight into a `DbConnectionStringBuilder`. Since the June vault work the installer stores that value as `DPAPI:<base64>`, so the builder threw and the script reported "No app-user credentials available" — then skipped the drop entirely. Its own docstring still claimed it recovers credentials from `appsettings.json`.

Harmless with `-RemovePostgres` (Postgres goes anyway), but the fast smoke loop (`-Force` alone) left `indypos_storehub` in place, so the next install silently reused stale data and could invalidate a test run.

Added `Unprotect-ConfigValue`, mirroring `SecretProtector.Unprotect`: LocalMachine DPAPI with per-key entropy `SHA256("IndyPOS:<configKey>")`. Unprotected values pass through unchanged, as the C# does, so dev/Aspire configs still work. Uses `SHA256.Create().ComputeHash` rather than the static `HashData`, which is .NET 5+ only — this script now also runs inside the guest on PowerShell 5.1.

## Verification

```
Release build of IndyPOS.sln     0 errors
IndyPOS.Bootstrapper.Tests     101 pass / 8 skip   (was 96/8)
cleanup-v4.ps1                   parses on host (7.6) and guest (5.1); 0 non-ASCII bytes
```

**Fresh-install regression, VM: 18/18 PASS in 3m09s.** This is the check that matters for #1, since the reordered stop and the config guard sit on the path that ships to stores. Run against a rebuilt clean baseline, and because that rebuild removed the leftover PostgreSQL data directory and the bundled fonts, the run genuinely exercised the from-scratch PostgreSQL install and the font-install path.

**DPAPI fix, unit level:** round-trip against a value sealed exactly as `SecretProtector` does, plus every failure mode degrading to `null` rather than throwing — wrong key, corrupt base64, truncated ciphertext — so a config from another machine falls through to the superuser path instead of killing the teardown. Per-key entropy binding confirmed enforced.

**DPAPI fix, end-to-end in the VM** against a real sealed install: `Recovered 'indypos_app' credentials from appsettings.json` → `Database 'indypos_storehub' dropped`, where it previously skipped.

## Not included

In-place upgrade support itself. Fix #1 gets extraction past the locked DLLs, but the run then stops at `DatabaseSetup`, which refuses because an already-installed PostgreSQL has no known superuser password — the installer is fresh-install-only by design. That's a design gap with its own spec (`docs/superpowers/specs/2026-07-25-installer-upgrade-support-design.md`, on a separate branch) and it is not urgent: the three live stores are still on v3.7.0, so no store is exposed to it.

https://claude.ai/code/session_01DuxS2pEX8SM8s1CGPAAqQi
