### PR TITLE
feat(installer): in-place upgrade support with verified rollback

### DIFF
--- a/.claude/STATUS.md
+++ b/.claude/STATUS.md
@@ -7,6 +7,7 @@
 | Field | Value |
 |-------|-------|
 | **Branch** | `development` @ `7c7c5cf` (pushed). Feature/cleanup branches merged + deleted. |
+| **Commit identity** | `Purin Tavilsup <purin.tavilsup@gmail.com>`, set in `.git/config` 2026-07-27 — IndyPOS is a personal repo, so it no longer commits as `purin-mimica`. History was **not** rewritten. A fresh clone reverts to the work identity from global config. |
 | **Sprint** | Sprint 7 |
 | **Phase** | ✅ **Epic M SHIPPED + VM-VALIDATED**, ✅ **Product-type restriction SHIPPED (2026-07-19)**, ✅ **Cosmetic-minors cleanup batch MERGED (PR #52, 2026-07-25)**. |
 | **Blocked?** | Not blocked. All code merged + pushed. **Only the VM smoke remains** (4-item checklist below). |

--- a/.claude/STATUS.md
+++ b/.claude/STATUS.md
@@ -2,11 +2,115 @@
 
 > Quick checkpoint for session start / context handoff
 
+## ⏯️ RESUME HERE (2026-07-29) — Installer in-place upgrade: **14/14 + VM cases 1 & 2 PASS**
+
+**Branch:** `feat/installer-upgrade-support` @ `30393e7` (local only, not pushed).
+**Plan:** `docs/superpowers/plans/2026-07-26-installer-upgrade-support.md` (all 14 tasks done).
+
+### VM validation (2026-07-29)
+
+| Case | Result |
+|------|--------|
+| **1 — happy upgrade** (`--silent -AssertDatabase`) | ✅ **PASS 22/22, 82s.** `MODE=upgrade`, `RESULT=success`, `HEALTH=ok`, `BACKUP_LOCKED=true`. `Store:Id=Rungrat-001` + `Store:Type=GeneralHardware` **preserved**, conn still `DPAPI:`, `initialAdmin` absent. Dump 24,941 B + 483-file tree readable. Catalogue: PayLater kind=3, WelfareCard kind=2 enabled, exactly one store id. |
+| **2 — forced rollback** (`--simulate-failure=deploy -ExpectRollback`) | ✅ **PASS.** `ROLLED_BACK=true`, `SERVICE_STARTED=true`, `HEALTH=ok`. Independently verified: config restored, service Running, health 200, live tree 483 files, and `payment_method` still **pre-migration** (PayLater kind=1) — proving the migration is exactly what distinguishes the two cases. |
+| **3 — fresh regression** (`Clean-Windows-Ready`) | ✅ **PASS 18/18, 3m29s.** `MODE=fresh`, `RESULT=success`, `ADMIN_SEEDED=true`, `CRED_LOCKED=true`, `HEALTH=ok`. The frozen fresh path is unregressed by the whole branch. |
+
+**VM left RUNNING** on the case-3 fresh install (service Running, health 200, POS + desktop
+shortcut present, catalogue seeded) — deliberately, so the owed PR #52 visual smoke can be done
+without another cycle. Bootstrap admin credential:
+`C:\ProgramData\IndyPOS\v4\Config\admin-credentials.txt` in the guest (ACL-locked, single-use,
+force-rotated on first login). Park it with:
+`Stop-VM IndyPOS-Test -Force -TurnOff; Restore-VMSnapshot -VMName IndyPOS-Test -Name 'Pre-Upgrade-2026-07-25' -Confirm:$false`
+
+**⚠️ NOT yet proven — needs a version bump.** Cases 1/2 ran with `FROM_VERSION=TO_VERSION=4.0.0`
+because `Directory.Build.props` still pins 4.0.0, so they exercised the **same-version repair**
+path (spec-valid, exit 0, `POS_UPDATED=false` correctly reported). A real `FROM≠TO` upgrade and
+`POS_UPDATED=true` are still unexercised. **Bump the version and re-run case 1 before shipping
+to the 3 stores.**
+
+### 4 real bugs the VM gate caught (all fixed, all with tests)
+
+1. **`c49d481`..`4485ce8` → `7d6f2d8`: upgrade failures reported no reason.** `UpgradeFailed.Message`
+   reached neither log nor markers, so the first failure said only "failed". Now `REASON=`, scrubbed
+   (pg_dump and Npgsql quote the connection string back).
+2. **`7d6f2d8`: `StopServiceAsync`'s result was discarded** → a service that refuses to stop went on
+   to deploy over its own locked DLLs, the exact failure this design exists to prevent. Now terminal.
+3. **`184e102`: backup directories were locked with non-inheritable ACEs.** Guest SDDL proved it:
+   stamp `D:PAI(A;;FA;;;SY)(A;;FA;;;BA)` (no `OICI`), tree `D:AI` (**empty DACL**). Protecting a
+   directory drops its inherited ACEs and Windows recomputes its children's, so the freshly copied
+   483-file tree became readable by nobody — and `LockTree` then walked it. New
+   `DatabaseSetup.TryRestrictDirectoryPermissions` uses `ContainerInherit|ObjectInherit`; the
+   per-file walk is gone (failure site + 483 redundant ACL writes). Also fixes latent `Prune`
+   breakage — recursive delete could not traverse empty-DACL dirs.
+   **Lesson:** the plan predicted this risk but expected a *throw*; the real failure was silent.
+   The old tests faked the lock seam (`p => true`), which is why it reached the VM.
+4. **`30393e7`: the harness could report a green run that never happened.** A comma-joined
+   `-InstallerArgs` element reached the installer as one malformed argument → fell through to the
+   wizard → crashed headless (`0xE0434352`). The marker read then took the newest `install-*.log`,
+   but the snapshot **ships with its own 2026-07-19 log**, so a crashed run was graded
+   `RESULT=success, ADMIN_SEEDED=true`. Now: malformed args rejected up front, and only a log
+   absent before the run counts — its absence is a hard error.
+
+**Flagged follow-up (NOT done, needs Pond's call):** an unknown argument makes
+`IndyPOS-Setup.exe` silently launch the wizard; headless that is a bare CLR crash with **no log
+at all**. A try/catch in `Program.Main` writing to the log dir would close it. Outside the plan's
+14 tasks, so not silently added.
+
+**Why this branch exists:** running `IndyPOS-Setup.exe` on a live store reproduced two
+failures (locked DLLs, and `DatabaseSetup` clobbering the real config with the package
+template). Fix = a **separate upgrade algorithm**, not a variation on the fresh path.
+
+**What shipped (this session: Tasks 9-14, commits `c49d481`..`4485ce8`):**
+- **T9** `UpgradePreflight` — downgrade refusal, POS-running check, free space, pg_dump
+  major-asserted lookup. Added a `Func<>` seam so the Postgres probe isn't machine-dependent.
+- **T10** upgrade outcomes + markers: `UpgradeSucceeded` / `UpgradeFailed` / `UnusableInstall`
+  / `DowngradeRefused`, exit codes **5** (unusable) and **6** (downgrade), `MODE=` marker.
+  Fresh-path `ADMIN_SEEDED`/`RESET_HINT`/`CRED_FILE` deliberately suppressed on an upgrade.
+- **T11** `UpgradeOrchestrator` + `IUpgradeSteps` seam + `WindowsUpgradeSteps` + the
+  `--simulate-failure` hook. **Mutation line**: steps 0-3 touch nothing, 4-7 roll back,
+  step 8 (POS app) does not. Rollback re-probes health — starting the service is not
+  evidence it came back. Also added `StoreHubConfigReader.ReadConnectionString` rather
+  than a second, case-sensitive JSON parser.
+- **T12** one router in `SilentInstaller` (fresh / upgrade / unusable from ONE detection
+  result); `--store-id` now optional (an upgrade adopts the detected id, and a *mismatched*
+  one is refused); the **wizard now detects and refuses** instead of reproducing the bugs.
+- **T13** VM harness: `-SnapshotName`, `-InstallerArgs`, `-ExpectRollback`, `-AssertDatabase`.
+  Reads the **fresh timestamped log**, not `install-latest.log` (which can hold a prior
+  `RESULT=success`). Scripts are parse-clean and now pure ASCII.
+- **T14** `docs/operations/upgrade-procedure.md` (exit codes, marker table, per-rule
+  unusable recovery, `pg_restore` block) + forward-only-migration **release gate** in CLAUDE.md.
+
+**Verified:** Release build **0 errors**. Bootstrapper **209 pass / 8 skip**, Domain **8/8**,
+Application **274/274**. Frozen-fresh-path gate re-confirmed: `FreshInstallOrchestrator`
+differs from `development` only by the rename, the doc comment, and the `HealthProbe`
+delegation — no reordering, no new conditionals.
+
+**⏭️ NEXT:**
+1. **Case 3** result (running). Then park the VM:
+   `Stop-VM IndyPOS-Test -Force -TurnOff; Restore-VMSnapshot -VMName IndyPOS-Test -Name 'Pre-Upgrade-2026-07-25' -Confirm:$false`
+2. **Version-bump run** — bump `Directory.Build.props`, rebuild, re-run case 1, confirm
+   `FROM≠TO` and `POS_UPDATED=true`. Required before distributing to the 3 stores.
+3. **Owed PR #52 smoke — needs Pond at vmconnect** (visual): payment-button caption clipping on
+   `บัตรสวัสดิการแห่งรัฐ`, 195×129 button with ~100px icon + `ImageAboveText` leaves <30px for text.
+4. Whole-branch review → PR to `development` (branch protection: PRs only).
+5. Then **Epic I (Cloud)** — see the Epic I section below and
+   `docs/architecture/IndyPOS_Production_Infrastructure_Guide.md`.
+
+**Re-run commands** (note the `@(...)` — a comma-joined arg list is now rejected):
+```powershell
+# case 1
+./scripts/vm-testing/Reset-AndInstall.ps1 -SnapshotName 'Pre-Upgrade-2026-07-25' -InstallerArgs @('--silent') -AssertDatabase -KeepRunning
+# case 2
+./scripts/vm-testing/Reset-AndInstall.ps1 -SnapshotName 'Pre-Upgrade-2026-07-25' -InstallerArgs @('--silent','--simulate-failure=deploy') -ExpectRollback -KeepRunning
+```
+
+---
+
 ## Current State
 
 | Field | Value |
 |-------|-------|
-| **Branch** | `development` @ `7c7c5cf` (pushed). Feature/cleanup branches merged + deleted. |
+| **Branch** | `feat/installer-upgrade-support` @ `4485ce8` (local). Base: `development` @ `7c7c5cf` (pushed). |
 | **Commit identity** | `Purin Tavilsup <purin.tavilsup@gmail.com>`, set in `.git/config` 2026-07-27 — IndyPOS is a personal repo, so it no longer commits as `purin-mimica`. History was **not** rewritten. A fresh clone reverts to the work identity from global config. |
 | **Sprint** | Sprint 7 |
 | **Phase** | ✅ **Epic M SHIPPED + VM-VALIDATED**, ✅ **Product-type restriction SHIPPED (2026-07-19)**, ✅ **Cosmetic-minors cleanup batch MERGED (PR #52, 2026-07-25)**. |

--- a/.claude/STATUS.md
+++ b/.claude/STATUS.md
@@ -151,6 +151,46 @@ cannot fix tool-written rows either.
   Standard method, not a government campaign. v4's catalogue already had this right; the campaign
   group is WelfareCard / M33WeLove / FiftyFifty / WeWin (legacy ids 3, 4, 7, 8). No change needed.
 
+### 🛑 FOUR MORE migration defects found 2026-07-29 (NOT fixed — need a decision)
+
+Audited the other entities against the real store DB after the payment finding. Roles are the
+only thing that checks out (legacy 1/2/3 = v4 `Cashier`/`StoreManager`/`SystemAdmin` ✅).
+
+**1. PayLater migration cannot run at all — it queries columns that do not exist.**
+`SELECT PayLaterId, InvoiceId, UserId, CustomerName, PaymentAmount, ...` but the real table is
+`PaymentId, Description, InvoiceId, IsCompleted, DateCreated, DateUpdated, PayLaterAmount, PaidAmount`.
+Four of eight names are wrong. The query sits **outside** any try, so it throws `SQLiteException`
+and aborts the whole migration. **5,181 rows / ฿836k of customer credit.** Also note the legacy
+table distinguishes `PayLaterAmount` from `PaidAmount` (partial repayments); the code models a
+single `PaymentAmount`, so the outstanding-balance semantics need designing, not just renaming.
+
+**2. Every migrated timestamp is 7 hours off.** Legacy writes `datetime('now','localtime')` —
+Thai local, UTC+7 (confirmed: latest invoice `2026-03-03 07:56:26`). `ParseDate` does
+`DateTime.SpecifyKind(result, DateTimeKind.Utc)`: it **relabels** local time as UTC without
+converting. Reports then convert UTC→SE Asia for day boundaries, so an 18:00 sale lands at 01:00
+the next day. Silent, affects **all 139,680 invoices** plus products/payments, and corrupts every
+daily/monthly total. Fix is `TimeZoneInfo.ConvertTimeToUtc(..., "SE Asia Standard Time")`.
+
+**3. Product `Category` is migrated as a raw numeric id, not a name.** `LegacyProduct.Category`
+is `long?` and the code does `Category = product.Category?.ToString()` → v4 stores `"10"`…`"54"`.
+The real `ProductCategory` table holds 16 Thai names (เบ็ดเตล็ด, เครื่องดื่ม, วัสดุก่อสร้าง…). Same class as
+the payment bug: an id written where a name belongs. **Worse than cosmetic** — the id ranges are
+meaningful (10–20 general goods, 50–54 hardware `วัสดุ*`), and Epic M's product-type restriction
+plus the category pickers gate on category, so all 10,590 products land uncategorised.
+
+**4. Discount history is dropped.** `InvoiceProduct` has 17 columns; the migrator selects 7,
+discarding `OriginalUnitPrice`, `GroupPrice`, `IsGroupProduct`, `Note`, `Priority`.
+**165,690 of 325,780 line items (51%) have `OriginalUnitPrice <> UnitPrice`** — i.e. they were
+discounted, and the record of that is lost.
+
+`Customers` and `Installments` are empty in this store, so skipping them is currently harmless —
+**verify per store** before each cutover.
+
+**Provenance note:** the real DB is `.planning/indypos-overhaul/sqlite_database/Store.db`, which is
+**gitignored** (`.gitignore:485 *.db`) — local to Pond's box, not committed. So
+`RealDatabaseSchemaTests` (and the two guards added in `6c63a6d`) silently `return` on any machine
+without it, including CI. Those guards protect Pond's machine only.
+
 **⚠️ Related smell, NOT addressed:** `tests/IndyPOS.Migration.Tests` builds a SQLite schema
 (`InvoicePayment`, `AccountsReceivablePayment`, no `PaymentType`) that does **not** match any real
 store (`Payment`, `PayLater`, `PaymentType`), and carries its own `MigrationService.cs` — it appears

--- a/.claude/STATUS.md
+++ b/.claude/STATUS.md
@@ -22,11 +22,31 @@ without another cycle. Bootstrap admin credential:
 force-rotated on first login). Park it with:
 `Stop-VM IndyPOS-Test -Force -TurnOff; Restore-VMSnapshot -VMName IndyPOS-Test -Name 'Pre-Upgrade-2026-07-25' -Confirm:$false`
 
-**⚠️ NOT yet proven — needs a version bump.** Cases 1/2 ran with `FROM_VERSION=TO_VERSION=4.0.0`
-because `Directory.Build.props` still pins 4.0.0, so they exercised the **same-version repair**
-path (spec-valid, exit 0, `POS_UPDATED=false` correctly reported). A real `FROM≠TO` upgrade and
-`POS_UPDATED=true` are still unexercised. **Bump the version and re-run case 1 before shipping
-to the 3 stores.**
+**✅ Real upgrade proven.** Version bumped to **4.1.0** (`Directory.Build.props`, commit on branch)
+and case 1 re-run: `FROM_VERSION=4.0.0 → TO_VERSION=4.1.0`, **`POS_UPDATED=true`**, 22/22 PASS in
+1m58s. The earlier 4.0.0→4.0.0 runs had only proven the same-version repair path.
+
+### ⚠️ DEPLOYMENT REFRAMED (Pond, 2026-07-29): the 3 live stores are on **v3.7.0**, not v4
+
+So rolling out to the stores is a **fresh v4 install** (v4 lives side-by-side with v3.7.0), NOT an
+upgrade. That means:
+
+- **What gates the store rollout is VM case 3** (fresh, 18/18 PASS), not cases 1/2.
+- **The upgrade path's value is future releases** (v4.1.0 → v4.2.0 …), which is exactly what the
+  4.0.0→4.1.0 run proved.
+- Detection classifies a v3.7.0-only machine as **Fresh** — pinned by
+  `Detect_OnAMachineRunningOnlyV3_ShouldReturnFresh` (`a658d77`). v3.7.0 predates the versioned
+  layout: no v4 manifest, no StoreHub config, SQLite not Postgres. Unusable would have blocked
+  every store.
+- **`--store-type` adoption on upgrade was NOT built** (and its `StoreHubConfigWriter` was dropped
+  unshipped). It only mattered for a v4 store installed before Epic M wrote `Store:Type`; with no
+  live v4 store anywhere, no such machine exists. The plan's strict refusal stands.
+
+**Remaining gap (low risk, worth one check):** v3.7.0 **coexistence** is covered by the unit test
+above plus the older Stage 3 dev-box run (31/31, v3 footprint untouched) — but has NOT been
+re-validated on this branch against a real v3.7.0 footprint. Detection reasoning: `v*` probing
+finds no `v3` dir (legacy layout is unversioned), so no false "foreign database". Worth confirming
+on one real store box, or by planting a v3-shaped footprint in the VM before a case-3 run.
 
 ### 4 real bugs the VM gate caught (all fixed, all with tests)
 
@@ -85,15 +105,35 @@ Application **274/274**. Frozen-fresh-path gate re-confirmed: `FreshInstallOrche
 differs from `development` only by the rename, the doc comment, and the `HealthProbe`
 delegation — no reordering, no new conditionals.
 
+### Whole-branch review: DONE (2026-07-29) — 6 findings, all fixed
+
+1. **`fcdddc2` — a timeout inside the mutating region skipped rollback entirely.** Cancellation was
+   excluded from the catch, so the 45-min watchdog firing during deploy/migrate left new binaries
+   on a stopped service reporting only `RESULT=timeout`. Recovery now runs on
+   `CancellationToken.None` (rolling back with the token that just fired cannot work).
+2. **`fcdddc2` — a timeout during the *backup* left the till DOWN.** Above the mutation line, but
+   the service was already stopped, so "a failure there is a non-event" was false. Both that and
+   the backup-failure path now go through `ResumeWithoutChangesAsync`.
+3. **`fcdddc2` — preflight asserted `HEALTH=ok` without probing.** Every other path probes; an
+   unverified recovery claim is what the rollback probe exists to rule out.
+4. **`fcdddc2` — `--simulate-failure=stop` stranded the store down.** A recovery-testing hook must
+   not itself leave a till dead.
+5. **`cb6a756` — prerequisite installs discarded `.Success`.** Threw away the stated reason they run
+   above the mutation line: a missing .NET 10 runtime would have surfaced as a service that will
+   not start *after* the swap. Font stays advisory (fallback face is cosmetic).
+6. **`52b5199` — the `Store:Type` recovery advised a flag that does nothing.** Both the detector
+   message and the operator doc said "re-run with `--store-type`"; detection refuses before
+   arguments are consulted. Corrected to the edit that works. (Now moot — see reframing above.)
+
 **⏭️ NEXT:**
-1. **Case 3** result (running). Then park the VM:
-   `Stop-VM IndyPOS-Test -Force -TurnOff; Restore-VMSnapshot -VMName IndyPOS-Test -Name 'Pre-Upgrade-2026-07-25' -Confirm:$false`
-2. **Version-bump run** — bump `Directory.Build.props`, rebuild, re-run case 1, confirm
-   `FROM≠TO` and `POS_UPDATED=true`. Required before distributing to the 3 stores.
-3. **Owed PR #52 smoke — needs Pond at vmconnect** (visual): payment-button caption clipping on
+1. **Owed PR #52 smoke — needs Pond at vmconnect** (visual): payment-button caption clipping on
    `บัตรสวัสดิการแห่งรัฐ`, 195×129 button with ~100px icon + `ImageAboveText` leaves <30px for text.
-4. Whole-branch review → PR to `development` (branch protection: PRs only).
-5. Then **Epic I (Cloud)** — see the Epic I section below and
+   VM is running a fresh 4.1.0 install; park it afterwards:
+   `Stop-VM IndyPOS-Test -Force -TurnOff; Restore-VMSnapshot -VMName IndyPOS-Test -Name 'Pre-Upgrade-2026-07-25' -Confirm:$false`
+2. **PR to `development`** (branch protection: PRs only). Review is done; 20+ commits.
+3. **Store rollout = fresh v4 installs** (`--silent --store-id <ID> [--store-type Minimart]`),
+   gated by case 3. Optionally plant a v3-shaped footprint first to confirm coexistence.
+4. Then **Epic I (Cloud)** — see the Epic I section below and
    `docs/architecture/IndyPOS_Production_Infrastructure_Guide.md`.
 
 **Re-run commands** (note the `@(...)` — a comma-joined arg list is now rejected):

--- a/.claude/STATUS.md
+++ b/.claude/STATUS.md
@@ -138,9 +138,24 @@ Also note the reconciliation EF migration `20260719051546_MapLegacyPaymentValues
 (`Transfer`→`MoneyTransfer`) runs **during install**, i.e. BEFORE the tool imports data, so it
 cannot fix tool-written rows either.
 
-**NOT fixed — separate epic, needs Pond's confirmation of the id→method semantics.** Fix is small
-(rewrite `MapPaymentType` to `PaymentMethodCodes`, decide `ผ่อนชำระ`, add per-method count/sum
-assertions to the verifier, re-run against the real DB).
+**✅ FIXED (`6c63a6d`)** — mapping confirmed by Pond; ids 4 and 6 were never used and are deprecated.
+- `LegacyPaymentTypeMap` — one shared table (migrator + verifier), documented against the real
+  lookup, returns `null` for ids with no equivalent instead of guessing.
+- Migrator **refuses** an unmapped row and records an error → `MigrationResult.IsSuccess` false.
+  No more `"Other"`.
+- `MigrationVerifier` compares **count AND amount per catalogue method**, and flags a method
+  present in PostgreSQL that no legacy type maps to. PayLater uses `>=` because it also migrates
+  from its own legacy table.
+- Real-DB guards: every id in use must map; the Thai labels must still sit at the assumed ids.
+- **`MoneyTransfer` = the CASHLESS bucket** (debit tap, Apple Pay, Google Pay) per Pond — a
+  Standard method, not a government campaign. v4's catalogue already had this right; the campaign
+  group is WelfareCard / M33WeLove / FiftyFifty / WeWin (legacy ids 3, 4, 7, 8). No change needed.
+
+**⚠️ Related smell, NOT addressed:** `tests/IndyPOS.Migration.Tests` builds a SQLite schema
+(`InvoicePayment`, `AccountsReceivablePayment`, no `PaymentType`) that does **not** match any real
+store (`Payment`, `PayLater`, `PaymentType`), and carries its own `MigrationService.cs` — it appears
+to test an older parallel implementation. Its 15 tests pass but validate a schema no store has, so
+the invoice/product paths may rest on the same sand. Worth a look before the cutover.
 
 ### Whole-branch review: DONE (2026-07-29) — 6 findings, all fixed
 

--- a/.claude/STATUS.md
+++ b/.claude/STATUS.md
@@ -105,6 +105,43 @@ Application **274/274**. Frozen-fresh-path gate re-confirmed: `FreshInstallOrche
 differs from `development` only by the rename, the doc comment, and the `HealthProbe`
 delegation — no reordering, no new conditionals.
 
+### 🛑 BLOCKER for the store rollout — MigrationTool payment mapping is scrambled (2026-07-29)
+
+Found while checking SQLite→Postgres drift, using the **real store DB** at
+`.planning/indypos-overhaul/sqlite_database/Store.db` (66 MB). Its `PaymentType` lookup vs
+`SqliteMigrationService.MapPaymentType` (line ~507):
+
+| legacy id | Thai label | actually means | tool maps to | correct code | real rows | real ฿ |
+|---|---|---|---|---|---|---|
+| 1 | เงินสด | Cash | `Cash` ✅ | `Cash` | 121,669 | 18,021,632.50 |
+| 2 | ลงบัญชี | **PayLater** | `Card` ❌ | `PayLater` | 5,182 | 836,083 |
+| 3 | บัตรสวัสดิการแห่งรัฐ | **WelfareCard** | `Transfer` ❌ | `WelfareCard` | 887 | 254,990 |
+| 4 | ม.33 | **M33WeLove** | `PayLater` ❌ | `M33WeLove` | 0 | 0 |
+| 5 | โอนเข้าบัญชี | **MoneyTransfer** | `WelfareCard` ❌ | `MoneyTransfer` | 12,458 | 1,834,823 |
+| 6 | ผ่อนชำระ | Installments | `Other` ❌ | (none exists) | 0 | 0 |
+| 7 | คนละครึ่ง | **FiftyFifty** | `Other` ❌ | `FiftyFifty` | 1,272 | 226,538 |
+| 8 | เราชนะ | **WeWin** | `Other` ❌ | `WeWin` | 4 | 940 |
+
+**Only id=1 is correct.** ~19,800 payments / **฿3.15M of ฿21.2M (15%)** would be attributed to the
+wrong method, and `Card`/`Transfer`/`Other` are not catalogue codes at all
+(`PaymentMethodCodes` = Cash, MoneyTransfer, WelfareCard, PayLater, M33WeLove, FiftyFifty, WeWin).
+Worst case is **PayLater**: ฿836k of customer credit lands as `Card`, invisible to PayLater tracking
+— the most operationally sensitive method in these stores.
+
+Corroborated by the project's own records, not just translation: STATUS notes Pond renaming
+PayLater → `ลงบัญชี` in the v4 admin screen, and `บัตรสวัสดิการแห่งรัฐ` is the WelfareCard button caption.
+
+**The verifier cannot catch this** — `MigrationVerifier` compares only row COUNTs and
+`SUM(Invoice.Total)`, so a scrambled migration reports success.
+
+Also note the reconciliation EF migration `20260719051546_MapLegacyPaymentValuesToCodes`
+(`Transfer`→`MoneyTransfer`) runs **during install**, i.e. BEFORE the tool imports data, so it
+cannot fix tool-written rows either.
+
+**NOT fixed — separate epic, needs Pond's confirmation of the id→method semantics.** Fix is small
+(rewrite `MapPaymentType` to `PaymentMethodCodes`, decide `ผ่อนชำระ`, add per-method count/sum
+assertions to the verifier, re-run against the real DB).
+
 ### Whole-branch review: DONE (2026-07-29) — 6 findings, all fixed
 
 1. **`fcdddc2` — a timeout inside the mutating region skipped rollback entirely.** Cancellation was

--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -1,436 +1,216 @@
 # IndyPOS Overhaul - Implementation Plan
 
-**Last Updated:** 2026-04-27
-**Progress:** ~98% Complete (Local Ready, Cloud Infrastructure Pending)
+**Last Updated:** 2026-07-29
+**Where we actually are:** v4 is feature-complete and VM-validated, but **no store is running it yet**.
+All three stores still run v3.7.0 on SQLite. The critical path is getting them onto v4 with their
+history intact — not cloud infrastructure.
+
+> **This replaces the 2026-04-27 revision**, which claimed "~98% complete (Local Ready, Cloud
+> Infrastructure Pending)". That framing was wrong on the most important axis: local deployment had
+> never been exercised on a real store, and three months of installer, security and store-type work
+> has landed since.
 
 ---
 
-## Epic Overview
+## The critical path
 
-| Epic | Name | Status |
+| # | Epic | Status | Why this order |
+|---|------|--------|----------------|
+| 1 | **Product categories + MimyShop** | 📋 Spec pending | The migration needs a category model to map into. Blocks 2 |
+| 2 | **SQLite → PostgreSQL migration hardening** | 📋 Spec pending | 6 known defects + 3 divergent legacy schemas. The risky half of the rollout |
+| 3 | **Store rollout** (fresh v4 install + migrate, per store) | ⏳ Blocked by 2 | Where the business value lands: stores off a 3.7.0-era system |
+| 4 | **Epic I: Cloud infrastructure** | 🔴 Not started | Additive. No longer on the critical path — see "Legacy history" below |
+| 5 | **Epic MCP: agent-facing API** | 🔴 Not started | Depends on 4 |
+
+**Legacy history reaches the cloud for free.** After migration each store's own v4 PostgreSQL holds
+its full legacy history, so ordinary sync carries it upward. There is no separate legacy→cloud
+pipeline to build. The consequence is that "the cloud needs legacy history" is not a new component —
+it is a **correctness requirement on epic 2**.
+
+---
+
+## Shipped since the last revision (2026-05 → 2026-07)
+
+All merged to `development`. Specs in `docs/superpowers/specs/`, plans in `docs/superpowers/plans/`,
+per-task ledger in `.superpowers/sdd/progress.md`.
+
+| Epic | What | Merged |
 |------|------|--------|
-| 0 | Extract Business Logic | Complete |
-| A | Prepare Codebase | Complete |
-| B | Remove Deprecated PG Report | Complete |
-| C | StoreHub Service + Aspire | Complete |
-| D | Schema Design | Complete |
-| E | Outbox + SyncWorker | Complete |
-| F | Cloud API | Complete |
-| G | Desktop Integration | Complete |
-| H | Testing & Rollout | Complete |
-| L | Local Deployment Readiness | Complete |
-| V | Velopack Integration | Complete |
-| I | Cloud Infrastructure | Not Started |
-| S | Security Hardening | 5/9 Complete |
-| M | Multi-Store Type Support | 🟢 Ready |
+| **Vault (DPAPI)** | `IndyPOS.Vault` + `SecretProtector`; connection string and JWT key DPAPI-protected at rest, machine scope, `DPAPI:` marker; plaintext `storehub.key` dropped; `appsettings.json` ACL-locked | 2026-06 |
+| **Admin provisioning** | Random single-use bootstrap credential, server-side force-rotate on first login (`must_change` JWT claim + middleware gate), `POST /auth/change-password`, `reset-admin` CLI recovery | PR #50 |
+| **Silent installer** | `IndyPOS-Setup.exe --silent --store-id <ID>`; ACL-locked log, `INDYPOS_MARKER` lines, exit codes 0/1/2/3/4 | PR #51 |
+| **Epic M: data-driven payment methods** | `payment_method` catalogue replaces the hardcoded `PaymentType` enum; store-type gating; `PaymentMethodKind` taxonomy (`Standard`/`GovernmentCampaign`/`Special`); admin management screen; fixed the silent-GeneralHardware default | 2026-07-19 |
+| **Product-type restriction** | `GET /store/features`; server rejects Hardware products on general-only stores; WinForms hides Hardware affordances | 2026-07-19 |
+| **Cosmetic-minors batch** | Kind taxonomy re-spec, Thai Kind labels, grid refresh, payment-button icons, `PUT /products/{id}` → 404, one-shot features-error dialog | PR #52 |
+| **Installer upgrade support** | In-place upgrade with verified rollback. See below | PR #54 (open) |
 
-> For detailed epic history, see `completed/` folder
+### Installer upgrade support (PR #54, open)
 
----
+14 planned tasks plus 7 bugs found by the VM gate and whole-branch review. Design's load-bearing
+idea is a **mutation line**: steps 0–3 touch nothing, 4–7 roll back and *prove* recovery with a
+health probe, step 8 (POS app) does not roll back. `DatabaseSetup` never runs on an upgrade, which
+is what makes the config-clobbering bug disappear rather than be worked around.
 
-## Recently Completed
+VM-validated: happy upgrade 4.0.0 → 4.1.0 (22/22, `POS_UPDATED=true`), forced mid-upgrade rollback
+(store came back healthy), fresh-install regression (18/18). Version is now **4.1.0**.
 
-### Epic L: Local Deployment Readiness ✅
-
-**Goal:** Get the system ready for local machine deployment and testing
-
-| Task | Description | Priority | Status |
-|------|-------------|----------|--------|
-| L1 | Add StoreHub config to WinForms appsettings.json | HIGH | ✅ Complete |
-| L2 | Create StoreHub appsettings.Production.json | HIGH | ✅ Complete |
-| L3 | Create publish script (build release binaries) | MEDIUM | ✅ Complete |
-| L4 | Create install-config.ps1 script | MEDIUM | ✅ Complete |
-| L5 | End-to-end test: WinForms → StoreHub → PostgreSQL | HIGH | ✅ Complete |
-| L6 | Create setup guide: Local Machine Deployment | MEDIUM | ✅ Complete |
-
-**Bonus: Velopack Prep**
-| Task | Description | Status |
-|------|-------------|--------|
-| Version system | `Directory.Build.props`, `AppVersion.cs` | ✅ Complete |
-| Version endpoint | `GET /version` in StoreHub | ✅ Complete |
-| Bruno request | `get-version.bru` | ✅ Complete |
-| Versioning docs | `docs/versioning.md` | ✅ Complete |
-
-**Deployment Scenarios:**
-- **Dev/Test (Aspire):** `dotnet run --project src/IndyPOS.AppHost` - API testing with Bruno
-- **Local Production:** WinForms + StoreHub + PostgreSQL on same machine
+Notable finds worth remembering: locking a directory with non-inheritable ACEs leaves its children
+with an **empty DACL** (broke every backup silently); and the VM harness could report a green run
+that never happened, by grading a crashed run against an `install-*.log` baked into the snapshot.
 
 ---
 
-#### L1: WinForms appsettings.json - StoreHub Config ✅
+## Epic 1: Product categories + MimyShop 📋
 
-**What was done:** Added StoreHub config section to WinForms appsettings.json. Removed the legacy `Enabled` flag since StoreHub is now the only option (SQLite removed). Also removed unused `Database` section.
+**Problem.** `ProductCategory { GeneralGoods = 10, Hardware = 50 }` is hardcoded, and `Product.Category`
+stores the enum *name*. The real stores have 16 / 11 / 17 fine-grained Thai categories, and **the ids
+collide with different meanings across store types**:
 
-**Files modified:**
-- `src/IndyPOS.Windows.Forms/appsettings.json` - Added StoreHub config
-- `src/IndyPOS.Infrastructure/Services/StoreHub/StoreHubOptions.cs` - Removed `Enabled` property
-- `src/IndyPOS.Infrastructure/ConfigureServices.cs` - Removed conditional check
-- `src/IndyPOS.Windows.Forms/appsettings.README.md` - Created config documentation
+| id | GeneralHardware | MimyMart | MimyShop |
+|----|-----------------|----------|----------|
+| 10 | เบ็ดเตล็ด (misc) | เบ็ดเตล็ด | **ของขวัญ (gifts)** |
+| 11 | เครื่องดื่ม (drinks) | เครื่องดื่ม | **ของเล่น (toys)** |
+| 18 | ของเล่น (toys) | ของเล่น | **ของใช้ในบ้าน (household)** |
+| 50–54 | วัสดุ* (hardware) | — | — |
 
----
+So any global id→category mapping corrupts one store to fix another.
 
-#### L2: StoreHub appsettings.Production.json ✅
+**Approach (approved):** mirror Epic M. A store-scoped `product_category` table —
+`StoreId, Code, DisplayName, Kind, DisplayOrder, IsEnabled` — with readable English `Code`s
+(`Gifts`, `PlumbingMaterials`, `Services`), Thai `DisplayName`, and
+`Kind ∈ { GeneralGoods, Hardware, Service }`. `Kind` replaces the
+`string.Equals(category, nameof(ProductCategory.Hardware))` comparisons in the create/update handlers
+and the legacy sales-summary handler. The enum and `HardcodedStoreConstants.ProductCategories` go away.
 
-**What was done:** Created production config template with all necessary settings and comprehensive documentation.
+Shared codes where meanings genuinely match (`Toys`, `Household`, `Miscellaneous`) make cross-store
+reporting a plain `GROUP BY code` — which legacy-id codes would have made silently wrong.
 
-**Files created:**
-- `src/IndyPOS.StoreHub/appsettings.Production.json` - Production config template
-- `src/IndyPOS.StoreHub/appsettings.Production.README.md` - Detailed property documentation
+**Store types:** add `MimyShop = 4` with Minimart-equivalent flags (no PayLater, single product type).
+**Remove `CoffeeShop`** — Pond's call: its products and services differ enough to deserve a dedicated
+app. Check no persisted config or DB row carries `Type=CoffeeShop` before deleting; do not reuse `3`.
 
----
+**Out of scope (YAGNI):** an admin category screen (campaigns churn, categories don't), and any
+non-stock/service *behaviour* — `Kind=Service` is data only for now.
 
-#### L3: Publish Script ✅
-
-**What was done:** Created comprehensive publish script that builds self-contained releases for all components.
-
-**Files created:**
-- `scripts/publish.ps1` - Builds StoreHub, WinForms, MigrationTool
-
----
-
-#### L4: install-config.ps1 Script ✅
-
-**What was done:** Created installation script that automates PostgreSQL setup, directory creation, JWT key generation, and config file creation.
-
-**Files created:**
-- `scripts/install-config.ps1` - Full installation automation
+**Anticipated later divergence for MimyShop** (do not build now): it sells services, and its
+reporting/receipt needs differ. Payment methods will *converge* — MimyMart is expected to offer
+MimyShop's set eventually.
 
 ---
 
-#### L5: End-to-End Test ✅
+## Epic 2: SQLite → PostgreSQL migration hardening 📋
 
-**What was done:** Created comprehensive smoke test script covering all major API flows.
+**This is the risky half of the rollout.** The tool was written against an assumed schema and appears
+never to have been run end-to-end against a real store database.
 
-**Test Coverage:**
-| Category | Tests |
-|----------|-------|
-| **Health** | `/health/live`, `/health/ready`, `/version` |
-| **Auth** | Login (valid/invalid), `/auth/me` |
-| **Products** | Create, update, search, barcode lookup |
-| **Inventory** | Adjust quantity |
-| **Sales** | Complete sale, verify inventory deducted, verify in reports |
-| **Pay Later** | Create pay later sale, list accounts, record payment |
-| **Reports** | Sales summary, invoices, product sales, pay later report |
-| **Cleanup** | Delete test product |
+**Evidence base:** real store DBs now at `.planning/indypos-overhaul/sqlite_database/{GeneralHardware,MimyMart,MimyShop}/Store.db`
+(gitignored). Volumes: 139,680 / 97,293 / 15 invoices.
 
-**Files created:**
-- `scripts/smoke-test.ps1` - Comprehensive E2E smoke test
-- `.bruno/StoreHub/health/get-version.bru` - Bruno request for version endpoint
+### Legacy schema divergence — confirmed, not assumed
+
+All three share 11 tables. GeneralHardware alone adds `PayLater`, `Customers`, `Installments` —
+i.e. the divergence *is* the PayLater feature. `PaymentType` is identical in all three (8 rows), so
+the payment mapping is store-agnostic.
+
+`Customers` and `Installments` are **never used** (0 rows where present) — out of scope permanently.
+Legacy payment id 6 `ผ่อนชำระ` is dead with them.
+
+### Defects
+
+| # | Defect | Impact | Status |
+|---|--------|--------|--------|
+| 1 | Payment mapping **shifted**: PayLater→`"Card"`, WelfareCard→`"Transfer"`, MoneyTransfer→`"WelfareCard"`, campaigns→`"Other"` | ~15% of ฿21.2M attributed to the wrong method; ฿836k of PayLater credit invisible | ✅ Fixed `6c63a6d` |
+| 2 | `MigratePayLaterAsync` selects `PayLaterId, UserId, CustomerName, PaymentAmount` — **none exist** (real: `PaymentId, Description, PayLaterAmount, PaidAmount`) | Throws; aborts the whole migration. 5,181 rows / ฿836k | ❌ |
+| 3 | Same method queries `FROM PayLater` **unconditionally** | Throws "no such table" on MimyMart and MimyShop | ❌ |
+| 4 | `ParseDate` does `SpecifyKind(..., Utc)` on `datetime('now','localtime')` values | **Every timestamp 7h off**; corrupts all daily/monthly totals | ❌ |
+| 5 | `Category = product.Category?.ToString()` writes the raw numeric id | All products uncategorised; breaks the Hardware gate and pickers | ❌ (needs Epic 1) |
+| 6 | `InvoiceProduct` selects 7 of 17 columns, dropping `OriginalUnitPrice`, `GroupPrice`, `IsGroupProduct`, `Note`, `Priority` | **165,690 of 325,780 line items (51%)** were discounted; the record is lost | ❌ |
+| 7 | v4 `Core.Product` has no `IsTrackable`; legacy does (21/7/1 non-trackable products) | Services would be stock-tracked and inventory-deducted | ❌ |
+
+v4's `PayLater` entity is already a field-for-field match for the legacy table
+(`PaymentId, Description, PayLaterAmount, PaidAmount, IsCompleted` + calculated `RemainingAmount`),
+so defect 2 is a rename, not a redesign.
+
+### Why none of it was caught
+
+- `MigrationVerifier` compared only row **counts** and `SUM(Invoice.Total)` — both reconcile
+  perfectly under a scrambled mapping. Now compares count *and* amount **per method** (`6c63a6d`).
+- **No test anywhere creates a `Payment` table.** `tests/IndyPOS.Migration.Tests` builds
+  `InvoicePayment` / `AccountsReceivablePayment` and carries its own `MigrationService.cs` — it
+  appears to test an older parallel implementation. Its 15 tests pass while validating a schema no
+  store has. **The invoice and product paths may rest on the same sand.**
+- The real-DB tests skip silently when the `.db` files are absent — including in CI.
 
 ---
 
-#### L6: Setup Guide - Local Machine Deployment ✅
+## Epic 3: Store rollout ⏳
 
-**What was done:** Created comprehensive setup guide with architecture diagrams, step-by-step instructions, and troubleshooting sections.
+Per store: fresh v4 install (`--silent --store-id <ID> --store-type <T>`), then migrate, then verify.
+v4 installs **alongside** v3.7.0 — detection classifies a v3-only machine as `Fresh`
+(pinned by `Detect_OnAMachineRunningOnlyV3_ShouldReturnFresh`).
 
-**Guide Sections:**
-1. Overview with architecture diagrams
-2. Prerequisites (hardware, software, network)
-3. PostgreSQL Setup
-4. StoreHub Service Setup (with Windows Service installation)
-5. Data Migration (SQLite → PostgreSQL)
-6. WinForms Client Setup
-7. Multi-Terminal Setup
-8. Backup Configuration
-9. Maintenance and Troubleshooting
-
-**Files created:**
-- `docs/operations/store-installation-guide.md` - Comprehensive store deployment guide
+Owed before the first store: PR #52's visual smoke (payment-button caption clipping on
+`บัตรสวัสดิการแห่งรัฐ`), and one v3.7.0-coexistence check against a real v3 footprint.
 
 ---
 
-### Epic S: Security Hardening (Partial)
+## Epic I: Cloud Infrastructure 🔴
 
-**Completed:**
-- S1: POS offline authentication (BCrypt, JWT)
-- S2: Local user cache (sync from cloud)
-- S3: RBAC implementation (capability-based)
-- S4: CloudApi user management
-- S5: RSA key signing + DPAPI secrets
+**Goal (revised):** central reporting, an agent-facing API, and an off-site copy of all three stores'
+history — including migrated legacy data.
 
-**Remaining (LOW priority):**
+**Schema recommendation:** one managed PostgreSQL, **one schema shaped like StoreHub's, every row
+carrying `StoreId`**. Reasoning:
+
+- The StoreHub schema is *already* multi-store-shaped (`Product.StoreId`, `Invoice.StoreId`, store-scoped
+  `payment_method`), so sync is a row copy rather than a translation — and translation layers are where
+  the payment-mapping class of bug breeds.
+- ~237k invoices / ~600k lines total. Volume forces nothing exotic.
+- Store-type differences need no DDL divergence: PayLater is simply *absent rows*; category sets are
+  *rows* in a store-scoped table.
+- Cross-store reporting and MCP both want one table to `GROUP BY`, not a union of per-type tables.
+
+"Different tables" is right in one sense — the cloud will likely want **additional** denormalised
+rollups / materialised views alongside the synced tables. That is additive and later.
+
+Rejected: per-store-type tables or per-store PostgreSQL schemas. No entity-shape difference, one
+owner (no tenancy isolation need), and every cross-store report would become a cross-schema query.
+
 | Task | Description | Priority |
 |------|-------------|----------|
-| S6 | Key rotation support | LOW |
-| S7 | Security audit logging | LOW |
-| S8 | Rate limiting | LOW |
-| S9 | Secrets management | LOW (covered by S5) |
+| I0 | Dockerfile for CloudApi + compose stack | HIGH |
+| I1 | Provision DigitalOcean Droplet (Singapore) | HIGH |
+| I2 | Provision DO Managed PostgreSQL | HIGH |
+| I3 | Deploy CloudApi | HIGH |
+| I4 | Configure SyncWorker against the real CloudApi | HIGH |
+| I5 | Multi-store sync testing (3 store types) | MEDIUM |
+| I6 | Backfill migrated legacy history to cloud | MEDIUM |
+| I7 | Central reporting | LOW |
+| I8 | Cloud deployment guide | MEDIUM |
 
-### Epic M: Multi-Store Type Support 🟢 Ready
-
-**Goal:** Support multiple store types (GeneralHardware, Minimart, CoffeeShop) with different feature sets.
-
-**Key Decisions:**
-| Aspect | Decision |
-|--------|----------|
-| StoreHub Location | Local per store |
-| Offline Support | Local PostgreSQL required (offline-first) |
-| StoreId Generation | Manual UUID by System Admin |
-| Central Database | One DB per store type |
-| Migration | Migrate existing 1 store → `generalHardware` DB |
-
-**Tasks:**
-| Task | Description | Complexity |
-|------|-------------|------------|
-| M1 | Add `StoreType` enum and `StoreTypeFeatures` to Domain | Low |
-| M2 | Update `StoreConfiguration` schema | Low |
-| M3 | Add `StoreId` column to all entities | Medium |
-| M4 | Update repositories to filter by StoreId | Medium |
-| M5 | Update StoreHub API for StoreId | Low |
-| M6 | Add feature validation in Application | Medium |
-| M7 | Update First-Run Wizard | Medium |
-| M8 | Update WinForms UI for feature flags | Medium |
-| M9 | Update CloudApi store registry + DB routing | Medium |
-| M10 | Update Bootstrapper | Low |
-| M11 | Database migrations | Medium |
-| M12 | Migrate existing store | Medium |
-| M13 | Tests + Documentation | Medium |
-
-**Dependencies:** Requires Epic I (Cloud Infrastructure) for central database routing. M1-M8 can be done locally.
-
-**Full Plan:** `.planning/indypos-overhaul/drafts/epic-m-multi-store-type.md`
+**Specs:** sizing, firewall ports, scaling roadmap and rejected alternatives in
+`docs/architecture/IndyPOS_Production_Infrastructure_Guide.md` — read before I1–I2.
+Droplet ~$12/mo + managed PG ~$15/mo ≈ **$27/mo**.
 
 ---
 
-### Epic I: Cloud Infrastructure (Not Started) 🔴 BLOCKING FOR CLOUD TESTING
+## Epic MCP: agent-facing API 🔴
 
-**Prerequisites:** Epic L (Local Deployment) complete ✅
+**New requirement (2026-07-29).** An MCP server so an AI agent can query store data — sales,
+inventory, cross-store comparisons. Depends on Epic I.
 
-**Goal:** Deploy CloudApi to DigitalOcean Singapore and enable store-to-cloud sync.
-
-| Task | Description | Priority | Status |
-|------|-------------|----------|--------|
-| I0 | Create Dockerfile for CloudApi | HIGH | ❌ |
-| I1 | Provision DigitalOcean Droplet | HIGH | ❌ |
-| I2 | Provision DO Managed PostgreSQL | HIGH | ❌ |
-| I3 | Deploy CloudApi to Droplet | HIGH | ❌ |
-| I4 | Configure SyncWorker with real CloudApi | HIGH | ❌ |
-| I5 | Multi-store sync testing | MEDIUM | ❌ |
-| I6 | Central reporting dashboard | LOW | ❌ |
-| I7 | Create setup guide: Cloud Deployment | MEDIUM | ❌ |
-
-**Cloud Specs:**
-- Droplet: Basic Premium AMD (2 GB RAM, 1 vCPU, 50 GB SSD) - ~$12/mo
-- Managed PostgreSQL: Smallest tier (1 GB RAM) - ~$15/mo
-- Region: Singapore (closest to Thailand stores)
-- Monthly cost: ~$27 USD
+Not yet designed. Open questions when we get there: read-only or write-capable; per-store or
+cross-store scoping; auth model; whether it fronts CloudApi or the database directly.
 
 ---
 
-#### I0: Create Dockerfile for CloudApi ❌
+## Epic S: Security Hardening (5/9)
 
-**Why:** Required for containerized deployment to DigitalOcean.
+Landed via the Vault and admin-provisioning epics: DPAPI at-rest secrets, ACL-locked config and
+credential files, single-use bootstrap admin with forced rotation, capability-based authorization
+(`CapabilityRequirement` + named policies, not role names).
 
-**Deliverables:**
-- `src/IndyPOS.CloudApi/Dockerfile` - Multi-stage build
-- `docker-compose.cloudapi.yml` - CloudApi + PostgreSQL stack
-- Update `scripts/publish.ps1` to include CloudApi publishing
-
-**Dockerfile spec:**
-```dockerfile
-# Build stage
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
-WORKDIR /src
-COPY . .
-RUN dotnet publish src/IndyPOS.CloudApi -c Release -o /app
-
-# Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:10.0
-WORKDIR /app
-COPY --from=build /app .
-EXPOSE 8080
-HEALTHCHECK CMD curl --fail http://localhost:8080/health/live || exit 1
-ENTRYPOINT ["dotnet", "IndyPOS.CloudApi.dll"]
-```
-
----
-
-#### I1: Provision DigitalOcean Droplet ❌
-
-**Steps:**
-1. Create DO account (if needed) and project
-2. Create Droplet:
-   - Image: Ubuntu 24.04 LTS
-   - Plan: Basic Premium AMD ($12/mo)
-   - Datacenter: Singapore (SGP1)
-   - Add SSH key
-3. Configure firewall:
-   - Allow 22 (SSH) from admin IPs only
-   - Allow 443 (HTTPS) from anywhere
-   - Allow 5432 (PostgreSQL) from Droplet only
-4. Point domain/subdomain to Droplet IP (e.g., `api.indypos.app`)
-5. Install Docker + Docker Compose
-
----
-
-#### I2: Provision DO Managed PostgreSQL ❌
-
-**Steps:**
-1. Create Managed PostgreSQL cluster:
-   - Plan: Basic ($15/mo, 1 GB RAM, 10 GB storage)
-   - Datacenter: Singapore (SGP1)
-   - Database name: `indypos_cloud`
-2. Configure trusted sources (Droplet IP only)
-3. Create database user for CloudApi
-4. Note connection string for I3
-
----
-
-#### I3: Deploy CloudApi to Droplet ❌
-
-**Steps:**
-1. SSH to Droplet
-2. Clone repo or copy Docker image
-3. Create `appsettings.Production.json`:
-   ```json
-   {
-     "ConnectionStrings": {
-       "CloudDb": "Host=<managed-pg>;Database=indypos_cloud;Username=<user>;Password=<pass>;SSL Mode=Require"
-     },
-     "Jwt": {
-       "RsaSigningKey": "<base64-encoded-rsa-private-key>"
-     },
-     "OpenIddict": {
-       "EncryptionKey": "<base64-encoded-256-bit-key>"
-     }
-   }
-   ```
-4. Generate RSA key: `scripts/generate-rsa-key.ps1`
-5. Run with Docker Compose
-6. Set up SSL with Let's Encrypt (Caddy or nginx reverse proxy)
-7. Verify health: `curl https://api.indypos.app/health/ready`
-
----
-
-#### I4: Configure SyncWorker with Real CloudApi ❌
-
-**Steps:**
-1. Register store as OAuth2 client in CloudApi:
-   ```bash
-   POST /admin/stores/register
-   {
-     "storeId": "550e8400-e29b-41d4-a716-446655440001",
-     "storeName": "Bangkok Store 1",
-     "storeType": "GeneralHardware"
-   }
-   ```
-   Response: `{ "clientId": "...", "clientSecret": "..." }`
-
-2. Update StoreHub `appsettings.Production.json`:
-   ```json
-   {
-     "CloudApi": {
-       "BaseUrl": "https://api.indypos.app",
-       "ClientId": "<from-step-1>",
-       "ClientSecret": "<from-step-1>"
-     },
-     "SyncWorker": {
-       "Enabled": true
-     }
-   }
-   ```
-
-3. Restart StoreHub and verify sync:
-   - Check logs for successful token acquisition
-   - Make a sale and verify event synced to CloudApi
-   - Check CloudApi logs for event ingestion
-
----
-
-#### I5: Multi-Store Sync Testing ❌
-
-**Test scenarios:**
-- [ ] Two stores sync to same CloudApi independently
-- [ ] Events from Store A don't appear in Store B queries
-- [ ] Concurrent sync from multiple stores
-- [ ] Offline → Online sync recovery
-- [ ] Large batch sync (100+ events)
-
----
-
-#### I6: Central Reporting Dashboard ❌
-
-**Low priority** - Can use direct SQL queries initially.
-
-**Future options:**
-- Grafana dashboard connected to CloudApi PostgreSQL
-- Custom admin UI in CloudApi
-- Metabase or similar BI tool
-
----
-
-#### I7: Cloud Deployment Guide ❌
-
-**File:** `docs/operations/setup-cloud.md`
-
-**Sections:**
-1. Overview & Architecture
-2. DigitalOcean Infrastructure Setup
-3. CloudApi Deployment
-4. SSL/TLS Configuration
-5. OAuth2 Client Registration
-6. Store Configuration for Cloud Sync
-7. Monitoring & Maintenance
-8. Troubleshooting
-
----
-
-#### I7: Setup Guide - Cloud Deployment
-
-**Why:** Document the cloud deployment process for future reference and handoff.
-
-**Audience:** Developer/IT admin setting up cloud infrastructure
-
-**Guide Structure:**
-```
-docs/operations/setup-cloud.md
-
-1. Overview
-   - Architecture diagram (Stores → CloudApi → Central PostgreSQL)
-   - Why cloud sync? (central reporting, backup, multi-store)
-   - Data flow: Outbox pattern + SyncWorker
-
-2. Cloud Infrastructure
-   - DigitalOcean Droplet setup (specs, region, OS)
-   - Managed PostgreSQL setup
-   - Firewall rules (ports 443, 5432)
-   - Domain + SSL certificate
-
-3. CloudApi Deployment
-   - Build and publish CloudApi
-   - Configure appsettings.Production.json
-   - Set up as systemd service (Linux)
-   - Health check verification
-
-4. OAuth2 Client Setup
-   - Register store clients in CloudApi
-   - Generate client credentials
-   - Distribute to stores securely
-
-5. Store Configuration for Cloud Sync
-   - Configure StoreHub with CloudApi credentials
-   - Enable SyncWorker
-   - Verify sync status
-
-6. Central Database
-   - Schema overview (multi-tenant with StoreId)
-   - Querying across stores
-   - Reporting queries
-
-7. Monitoring & Maintenance
-   - Health check endpoints
-   - Log aggregation
-   - Database backups (managed PostgreSQL snapshots)
-   - Scaling considerations
-
-8. Troubleshooting
-   - Sync failures
-   - Authentication issues
-   - Network connectivity
-```
-
-**Files:**
-- Create: `docs/operations/setup-cloud.md`
+Remaining items in `.planning/indypos-overhaul/security/`.
 
 ---
 
@@ -438,185 +218,45 @@ docs/operations/setup-cloud.md
 
 | Item | Description | Priority |
 |------|-------------|----------|
-| Migration `--sync-to-cloud` | Create outbox events for migrated invoices | LOW |
-| **Auto-Update System** | Remote update capability for StoreHub + WinForms | Future |
-| MAUI Migration | Replace WinForms with MAUI | Future |
-| Legacy Report Cleanup | Remove int-based report methods | MAUI Migration |
+| `Migration.Tests` schema audit | Its SQLite schema matches no real store; invoice/product coverage may be illusory | **HIGH** — see Epic 2 |
+| Headless installer crash | An unknown argument silently launches the wizard; headless that is a bare CLR crash with no log | MEDIUM |
+| Migration `--sync-to-cloud` | Outbox events for migrated invoices (folds into I6) | LOW |
+| **Auto-Update System (Epic U)** | Remote updates for StoreHub + WinForms. Superseded in part by the installer upgrade path — revisit scope | Future |
+| MAUI Migration | Replace WinForms | Future |
+| Legacy Report Cleanup | Remove int-based report methods | With MAUI |
 
----
+### Auto-Update (Epic U) — status note
 
-## Future: Auto-Update System
-
-**Goal:** Enable remote updates for StoreHub and WinForms without manual intervention.
-
-### Why Auto-Update?
-
-- 3 stores × 1-2 terminals = 5-6 machines to update
-- Manual updates require physical access or remote desktop
-- Minimize downtime during business hours
-- Ensure all stores run consistent versions
-
-### Architecture Options
-
-#### Option A: CloudApi as Update Server (Recommended)
-
-```
-┌─────────────┐     Check for updates     ┌─────────────┐
-│  StoreHub   │ ──────────────────────────▶│  CloudApi   │
-│  WinForms   │                            │             │
-└─────────────┘                            │  /updates   │
-       │                                   │  /download  │
-       │         Download new version      └─────────────┘
-       ▼                                          │
-┌─────────────┐                            ┌──────▼──────┐
-│  Local      │                            │   Azure     │
-│  Installer  │                            │   Blob /    │
-└─────────────┘                            │   S3 / DO   │
-                                           └─────────────┘
-```
-
-**Pros:** Centralized control, version tracking per store, rollback support
-**Cons:** Requires CloudApi to be deployed first
-
-#### Option B: GitHub Releases + Squirrel
-
-```
-┌─────────────┐     Check releases        ┌─────────────┐
-│  StoreHub   │ ──────────────────────────▶│   GitHub    │
-│  WinForms   │                            │  Releases   │
-└─────────────┘                            └─────────────┘
-       │                                          │
-       │         Download .nupkg                  │
-       ▼                                          │
-┌─────────────┐                            ┌──────▼──────┐
-│  Squirrel   │◀───────────────────────────│   Assets    │
-│  Installer  │                            │  (.nupkg)   │
-└─────────────┘                            └─────────────┘
-```
-
-**Pros:** Simple, works without CloudApi, familiar tooling
-**Cons:** Less control over which stores get updates
-
-### Components Needed
-
-| Component | Description |
-|-----------|-------------|
-| **Version Endpoint** | CloudApi endpoint to check latest version |
-| **Update Package** | Signed .nupkg or .zip with new binaries |
-| **Update Service** | Background service in StoreHub to check/apply updates |
-| **Update UI** | WinForms notification + manual trigger option |
-| **Rollback** | Keep previous version, restore on failure |
-
-### Implementation Tasks (Epic U)
-
-| Task | Description | Complexity |
-|------|-------------|------------|
-| U1 | Add version endpoint to CloudApi (`GET /updates/latest`) | Low |
-| U2 | Add update check to StoreHub (background, configurable interval) | Medium |
-| U3 | Create update download + extract logic | Medium |
-| U4 | Handle StoreHub self-update (stop service, replace, restart) | High |
-| U5 | Add update notification to WinForms | Low |
-| U6 | Create signed update packages in CI/CD | Medium |
-| U7 | Add rollback capability | Medium |
-| U8 | Admin UI in CloudApi to manage rollouts | Medium |
-
-### Update Flow (StoreHub)
-
-```
-1. StoreHub checks CloudApi every N hours
-2. CloudApi returns: { version: "1.2.0", url: "...", hash: "sha256:..." }
-3. If newer version available:
-   a. Download to temp directory
-   b. Verify hash
-   c. Schedule update (next restart or off-hours)
-4. On scheduled update:
-   a. Stop StoreHub service
-   b. Backup current binaries
-   c. Extract new binaries
-   d. Start StoreHub service
-   e. Health check - if fails, rollback
-5. Report update status to CloudApi
-```
-
-### Update Flow (WinForms)
-
-```
-1. On startup, check StoreHub for available updates
-2. If update available:
-   a. Show notification to user
-   b. "Update available (v1.2.0) - Install now?"
-3. If user accepts:
-   a. Download update package
-   b. Close WinForms
-   c. Run installer/updater
-   d. Restart WinForms
-```
-
-### Configuration
-
-```json
-// StoreHub appsettings.json
-{
-  "AutoUpdate": {
-    "Enabled": true,
-    "CheckIntervalHours": 6,
-    "UpdateWindowStart": "02:00",
-    "UpdateWindowEnd": "05:00",
-    "AutoInstall": true
-  }
-}
-```
-
-### Security Considerations
-
-- [ ] Sign update packages (code signing certificate)
-- [ ] Verify package hash before applying
-- [ ] HTTPS only for downloads
-- [ ] Rate limiting on update endpoints
-- [ ] Audit log of all updates
-
-### Libraries to Consider
-
-| Library | Purpose |
-|---------|---------|
-| [Squirrel.Windows](https://github.com/Squirrel/Squirrel.Windows) | WinForms auto-updater (mature, widely used) |
-| [Velopack](https://github.com/velopack/velopack) | Modern Squirrel fork, cross-platform |
-| [NetSparkle](https://github.com/NetSparkleUpdater/NetSparkle) | .NET updater framework |
-| Custom | Roll your own for full control |
-
-### Rollout Strategy
-
-1. **Canary** - Update one store first, monitor for issues
-2. **Staged** - Roll out to remaining stores over days
-3. **Emergency** - Force update all stores (security patches)
-
-### Dependencies
-
-- Requires Epic I (Cloud Infrastructure) for Option A
-- Can start with Option B (GitHub) while waiting for CloudApi
+PR #54 delivers in-place upgrade via `IndyPOS-Setup.exe --silent`, and the POS app already
+self-updates through Velopack. What Epic U would add is the **trigger**: stores checking a server
+rather than someone running the installer. Option A (CloudApi as update server) still stands and now
+depends only on Epic I. The U1–U8 task list in the previous revision remains broadly valid but
+should be re-scoped against what the installer now does.
 
 ---
 
 ## Technical Debt
 
-### StoreHubReportService Legacy Methods
-Stub implementations return empty collections. Address during MAUI migration:
-- `GetInvoicesByPeriodAsync()`, `GetInvoicesByDateRangeAsync()`
-- `GetPayLaterPaymentsByPeriodAsync()`, `GetPayLaterPaymentsAsync()`
-- `GetInvoiceProductsByDateAsync()`, `GetInvoiceProductsByDateRangeAsync()`
-- `GetInvoiceProductsByInvoiceIdAsync(int)`, `GetPaymentsByInvoiceIdAsync(int)`
-- `GetInvoiceInfoAsync(int)`
+### StoreHubReportService legacy methods
+Stubs returning empty collections; address during MAUI migration:
+`GetInvoicesByPeriodAsync`, `GetInvoicesByDateRangeAsync`, `GetPayLaterPaymentsByPeriodAsync`,
+`GetPayLaterPaymentsAsync`, `GetInvoiceProductsByDateAsync`, `GetInvoiceProductsByDateRangeAsync`,
+`GetInvoiceProductsByInvoiceIdAsync(int)`, `GetPaymentsByInvoiceIdAsync(int)`, `GetInvoiceInfoAsync(int)`.
 
 ---
 
-## Statistics
+## Test state (2026-07-29)
 
-| Metric | Value |
-|--------|-------|
-| Total Epics | 10 |
-| Completed Epics | 9 |
-| Total Tests | 306 |
-| Build Status | 0 Errors, 0 Warnings |
+| Suite | Count |
+|-------|-------|
+| IndyPOS.Bootstrapper.Tests | 223 pass / 8 skip (admin-required) |
+| IndyPOS.Application.Tests | 274 |
+| IndyPOS.StoreHub.IntegrationTests | 76 (real PostgreSQL) |
+| IndyPOS.MigrationTool.Tests | 36 / 1 skip |
+| IndyPOS.Migration.Tests | 15 ⚠️ *validates a schema no store has* |
+| IndyPOS.Domain.Tests | 8 |
+| IndyPOS.Vault.Tests | 17 |
+| Release build | 0 errors |
 
 ---
 
@@ -625,11 +265,14 @@ Stub implementations return empty collections. Address during MAUI migration:
 | Doc | Location |
 |-----|----------|
 | Current status | `.claude/STATUS.md` |
-| Session history | `.claude/session-log.md` |
-| Completed epics | `.planning/indypos-overhaul/completed/` |
+| Specs | `docs/superpowers/specs/` |
+| Plans | `docs/superpowers/plans/` |
+| SDD ledger | `.superpowers/sdd/progress.md` |
+| Completed epics (through H) | `.planning/indypos-overhaul/completed/` |
+| Cloud target infrastructure | `docs/architecture/IndyPOS_Production_Infrastructure_Guide.md` |
+| Upgrade procedure | `docs/operations/upgrade-procedure.md` |
 | Security spec | `.planning/indypos-overhaul/security/` |
 | Diagrams | `.planning/indypos-overhaul/diagrams/` |
-| Operations docs | `docs/operations/` |
 
 ---
 
@@ -637,26 +280,21 @@ Stub implementations return empty collections. Address during MAUI migration:
 
 ```
 src/
-  Core/
-    IndyPOS.Domain
-    IndyPOS.Application
-    IndyPOS.Infrastructure
-  DesktopApp/
-    IndyPOS.Windows.Forms
-  Services/
-    IndyPOS.StoreHub
-    IndyPOS.CloudApi
-  DevAppHost/
-    IndyPOS.AppHost
-    IndyPOS.ServiceDefaults
-  Tools/
-    IndyPOS.MigrationTool
+  IndyPOS.Domain            # Entities, value objects, domain logic
+  IndyPOS.Application       # Use cases, interfaces, DTOs
+  IndyPOS.Infrastructure    # Repositories, EF, external services
+  IndyPOS.Vault             # DPAPI secret protection
+  IndyPOS.Windows.Forms     # Desktop UI (legacy)
+  IndyPOS.StoreHub          # Local API service
+  IndyPOS.CloudApi          # Central cloud API
+  IndyPOS.AppHost           # Aspire orchestrator
+  IndyPOS.ServiceDefaults   # Health checks, OpenTelemetry
+  IndyPOS.MigrationTool     # SQLite -> PostgreSQL migration
 
-tests/
-  Core/ -> IndyPOS.Application.Tests
-  DesktopApp/ -> IndyPOS.Windows.Forms.Tests
-  Services/ -> IndyPOS.StoreHub.IntegrationTests
-  Tools/ -> IndyPOS.Migration.Tests, IndyPOS.MigrationTool.Tests
+installer/
+  IndyPOS.Bootstrapper      # Fresh install + in-place upgrade
+
+tests/                      # See test-state table above
 ```
 
 ---
@@ -664,13 +302,7 @@ tests/
 ## Quick Commands
 
 ```bash
-# Run tests
-dotnet test
-
-# Build
-dotnet build
-
-# Run with Aspire (requires Docker)
-dotnet run --project src/IndyPOS.AppHost --launch-profile https
-# Dashboard: https://localhost:17222
+dotnet test                 # all suites (Docker needed for integration/migration)
+dotnet build IndyPOS.sln -c Release
+dotnet run --project src/IndyPOS.AppHost --launch-profile https   # Aspire, needs Docker
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,19 @@ docs/                        # Architecture docs, operations
 - All new entities use `Guid Id` (UUID primary keys)
 - All entities: `DateTime CreatedUtc`, `DateTime LastModifiedUtc`
 
+### Database Migrations - Forward-Only (release gate)
+
+An upgrade rolls back binaries and config, **not schema**. Every migration in a release
+must therefore be runnable against the *previous* release's binaries:
+
+- Additive only. New columns nullable or with a default.
+- No renames, no drops, no type narrowing.
+- No new `NOT NULL` column without a default - the restored binaries' INSERT would fail
+  and the till could not complete a sale.
+
+A migration that breaks this makes the installer's rollback claim false.
+See `docs/operations/upgrade-procedure.md`.
+
 ### Method Chaining Style
 ```csharp
 // Good - dots vertically aligned

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,14 +10,14 @@
   -->
   <PropertyGroup>
     <!-- Semantic Version: MAJOR.MINOR.PATCH -->
-    <Version>4.0.0</Version>
+    <Version>4.1.0</Version>
 
     <!-- Assembly versioning (used by .NET runtime) -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <FileVersion>4.0.0.0</FileVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <FileVersion>4.1.0.0</FileVersion>
 
     <!-- Informational version (can include pre-release tags) -->
-    <InformationalVersion>4.0.0</InformationalVersion>
+    <InformationalVersion>4.1.0</InformationalVersion>
 
     <!-- Product info -->
     <Product>IndyPOS</Product>

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -226,7 +226,8 @@ powershell.exe -ExecutionPolicy Bypass -File "C:\ProgramData\IndyPOS\ops\health-
 | [Smoke Test Script](smoke-test.ps1) | Automated health verification |
 | [Post-Deployment Monitoring](post-deployment-monitoring.md) | Metrics and alerting |
 | [Troubleshooting Guide](troubleshooting-guide.md) | Common issues and fixes |
-| [Update Procedure](update-procedure.md) | How to apply updates |
+| [Upgrade Procedure](upgrade-procedure.md) | **In-place upgrade of a live v4 store** (`--silent`) + unusable-install recovery |
+| [Update Procedure](update-procedure.md) | Manual binary-swap / migration mechanics (background) |
 | [Rollback Plan](rollback-plan.md) | Emergency recovery |
 
 ---

--- a/docs/operations/update-procedure.md
+++ b/docs/operations/update-procedure.md
@@ -1,5 +1,10 @@
 # IndyPOS StoreHub - Update Procedure
 
+> **For a store already running IndyPOS v4, use [upgrade-procedure.md](upgrade-procedure.md)
+> instead.** `IndyPOS-Setup.exe --silent` performs the whole sequence below - backup,
+> deploy, config restore, migrate, verify, and rollback on failure - and is the authoritative
+> in-place upgrade path. This document remains as background on the underlying mechanics.
+
 ## Overview
 This document describes the procedure for updating IndyPOS StoreHub to a new version.
 

--- a/docs/operations/upgrade-procedure.md
+++ b/docs/operations/upgrade-procedure.md
@@ -1,0 +1,228 @@
+# IndyPOS - In-Place Upgrade Procedure
+
+> Authoritative procedure for upgrading a store that is **already running IndyPOS v4**.
+
+## When to use this
+
+| Situation | Use |
+|-----------|-----|
+| The store already runs IndyPOS v4 and you want a newer build | **This document** |
+| A brand-new machine with no IndyPOS on it | [Store Installation Guide](store-installation-guide.md) |
+| Manual binary-swap / migration mechanics (background reading) | [Update Procedure](update-procedure.md) |
+
+The installer detects which case it is looking at and refuses to guess. A double-clicked
+`IndyPOS-Setup.exe` on a live store now shows a message telling you to use the command
+below instead of running the fresh-install wizard.
+
+---
+
+## The command
+
+Run from an **elevated** command prompt on the Store Hub PC:
+
+```
+IndyPOS-Setup.exe --silent
+```
+
+That is the whole command. Notes:
+
+- **Do not pass `--store-id`.** The upgrade adopts the store id already in the installed
+  config. If you do pass it, it must match exactly, or the run refuses rather than
+  rewriting store identity (which would orphan the store's sales history).
+- **`--store-type` is only needed** if the store was installed before 2026-07-18 and its
+  `appsettings.json` has no `Store:Type` key. The run will tell you (exit code 5) if so.
+  Re-run with `--store-type GeneralHardware` or `--store-type Minimart`.
+- Close the POS application on this machine first. The upgrade refuses while it is running,
+  because two Velopack processes on one install root can leave the POS unlaunchable.
+
+The POS app on **other** terminals updates itself; it does not need the installer.
+
+---
+
+## Exit codes
+
+| Code | Meaning | What to do |
+|------|---------|------------|
+| 0 | Success | Check `POS_UPDATED` (see below), then you are done |
+| 1 | Usage error | Fix the command line |
+| 2 | Failed | Read `ROLLED_BACK` in the log - it says whether the store came back |
+| 3 | Not elevated | Re-run as administrator |
+| 4 | Timed out | Read the log; the store may be mid-upgrade. Do not re-run blind |
+| 5 | Unusable install | Read `REASON`, then see [Unusable-install recovery](#unusable-install-recovery) |
+| 6 | Downgrade refused | This installer is older than what is installed. Use the newer installer |
+
+---
+
+## Reading the result
+
+Everything the run decided is in:
+
+```
+C:\ProgramData\IndyPOS\v4\logs\install-latest.log
+```
+
+Lines beginning `INDYPOS_MARKER` are the machine-readable summary:
+
+| Marker | Meaning |
+|--------|---------|
+| `MODE` | `fresh`, `upgrade` or `unusable` - which path actually ran |
+| `RESULT` | `success`, `failed` or `timeout` |
+| `FROM_VERSION` | Version that was installed before (or `unknown`) |
+| `TO_VERSION` | Version this installer delivered |
+| `SERVICE_STARTED` | Whether the StoreHub Windows service was started |
+| `HEALTH` | `ok` only if `/health/ready` actually answered |
+| `BACKUP_DIR` | Where the pre-upgrade dump and binaries were saved |
+| `BACKUP_LOCKED` | Whether the backup was ACL-locked (see [Backups](#backups)) |
+| `POS_UPDATED` | Whether the POS app package version changed |
+| `ROLLED_BACK` | On a failure: whether the previous version was restored |
+
+**`POS_UPDATED=false` alongside `RESULT=success` is not a failure.** It means the POS app
+was already at this version, so Velopack had nothing to do. The installer reports it from
+the package version before and after, because the Velopack exit code is 0 either way.
+
+**`ROLLED_BACK=true` with `HEALTH=failed`** is the one line that needs immediate attention:
+the upgrade was undone but the store did not come back. Go to
+[Restoring the database dump](#restoring-the-database-dump).
+
+---
+
+## Unusable-install recovery
+
+Exit code 5 means the machine is neither cleanly installable nor safely upgradeable. The
+`REASON` marker names which case. **None of these are fixed by `cleanup-v4.ps1`** - that
+script drops the `indypos_storehub` database, which is the store's sales history.
+
+### A database from another IndyPOS major version
+
+> "An IndyPOS database exists on this machine but belongs to another IndyPOS major version."
+
+**Do not remove PostgreSQL.** It holds the store's sales history. The database name is not
+version-scoped, so a newer installer can see an older store's data.
+
+Look under `C:\ProgramData\IndyPOS\` for the `v<N>` folder that owns the existing install,
+and run the installer for **that** major version instead.
+
+### The connection string cannot be decrypted
+
+> "The StoreHub connection string is missing, empty, or cannot be decrypted on this machine."
+
+Restore `appsettings.json` from the newest backup:
+
+```
+C:\ProgramData\IndyPOS\v4\backups\<stamp>\StoreHub\appsettings.json
+```
+
+A `DPAPI:`-prefixed value is sealed to the machine that wrote it. If the config came from a
+different PC, it can never be decrypted here - you need this machine's own backup, or a
+fresh install plus a database restore.
+
+### `Store:Id` is missing
+
+> "Store:Id is missing from appsettings.json."
+
+Set it to the store's real id before upgrading. The authoritative value is in the database:
+
+```powershell
+# From an elevated prompt, with PGPASSWORD set as in the restore section below.
+& 'C:\Program Files\PostgreSQL\18\bin\psql.exe' -h 127.0.0.1 -U indypos_app `
+    -d indypos_storehub -w -c 'SELECT DISTINCT store_id FROM store_user;'
+```
+
+Upgrading without it would seed a second payment-method catalogue under a fallback id and
+orphan the store's history.
+
+### `Store:Type` is missing
+
+Stores installed before 2026-07-18 have no such key. It cannot be defaulted: the default is
+the most permissive store type and would silently re-enable restricted features. Re-run:
+
+```
+IndyPOS-Setup.exe --silent --store-type GeneralHardware
+```
+
+(or `Minimart` - use the store's real type.)
+
+### The service is not registered, or points elsewhere
+
+> "The StoreHub service is not registered, or its ImagePath does not resolve under ..."
+
+Re-register it against the real binary, then re-run the upgrade:
+
+```powershell
+sc.exe create IndyPOS.StoreHub.v4 `
+    binPath= "C:\ProgramData\IndyPOS\v4\StoreHub\IndyPOS.StoreHub.exe" `
+    start= auto DisplayName= "IndyPOS StoreHub v4"
+```
+
+### A config with no manifest
+
+> "A StoreHub configuration exists but there is no install manifest."
+
+A previous install did not finish. Inspect `C:\ProgramData\IndyPOS\v4\StoreHub\` and decide
+deliberately: if there is no data worth keeping, a clean install is correct; if the database
+holds real sales, restore the config from a backup first.
+
+---
+
+## Restoring the database dump
+
+**This is always a human decision.** The installer never restores the dump automatically -
+rolling back binaries is safe, silently replacing a live database is not.
+
+```powershell
+# Stop the service first, then restore into the existing database.
+Stop-Service IndyPOS.StoreHub.v4
+$env:PGPASSWORD = '<indypos_app password from the connection string>'
+& 'C:\Program Files\PostgreSQL\18\bin\pg_restore.exe' `
+    --host=127.0.0.1 --port=5432 --username=indypos_app `
+    --dbname=indypos_storehub --clean --if-exists --no-owner --no-password `
+    'C:\ProgramData\IndyPOS\v4\backups\<stamp>\storehub.dump'
+Start-Service IndyPOS.StoreHub.v4
+```
+
+Then confirm the store is actually serving:
+
+```powershell
+Invoke-RestMethod 'http://localhost:5000/health/ready'
+```
+
+---
+
+## Backups
+
+Every upgrade takes a backup **before** it changes anything:
+
+```
+C:\ProgramData\IndyPOS\v4\backups\<yyyyMMdd-HHmmss>\
+    storehub.dump        <- pg_dump of the whole store database
+    StoreHub\            <- a full copy of the binaries and config
+```
+
+- The **last 2 stamps** are kept; older ones are pruned. Each is roughly 130 MB.
+- They are **ACL-locked to Administrators + LocalSystem**, because the dump contains the
+  full sales history and the admin BCrypt hashes.
+- `BACKUP_LOCKED=false` in the log means that lock failed. Fix the ACL before leaving the
+  store - by default `C:\ProgramData` grants read to `BUILTIN\Users`.
+
+---
+
+## Known limitations
+
+1. **The POS app is installed per-user.** The installer updates the POS for the account it
+   runs under. A cashier who logs in with a different Windows account keeps their own copy
+   until it self-updates.
+2. **The POS app self-updates independently** of StoreHub. A terminal can briefly run a
+   newer or older POS than the machine you upgraded.
+3. **One machine per run.** There is no fan-out; visit each Store Hub PC.
+4. **An upgrade does not create `StoreConfiguration.json`.** A store missing it was missing
+   it before the upgrade too - see the [Store Installation Guide](store-installation-guide.md).
+5. **Schema is never rolled back.** A failed upgrade restores binaries and config only,
+   which is why every migration must be forward-only (see `CLAUDE.md`).
+
+---
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-07-29 | Initial in-place upgrade procedure |

--- a/docs/operations/upgrade-procedure.md
+++ b/docs/operations/upgrade-procedure.md
@@ -47,7 +47,7 @@ The POS app on **other** terminals updates itself; it does not need the installe
 | 1 | Usage error | Fix the command line |
 | 2 | Failed | Read `ROLLED_BACK` in the log - it says whether the store came back |
 | 3 | Not elevated | Re-run as administrator |
-| 4 | Timed out | Read the log; the store may be mid-upgrade. Do not re-run blind |
+| 4 | Timed out | Only before the backup completes - nothing was changed and the service was restarted. Read `HEALTH` |
 | 5 | Unusable install | Read `REASON`, then see [Unusable-install recovery](#unusable-install-recovery) |
 | 6 | Downgrade refused | This installer is older than what is installed. Use the newer installer |
 
@@ -79,6 +79,11 @@ Lines beginning `INDYPOS_MARKER` are the machine-readable summary:
 **`POS_UPDATED=false` alongside `RESULT=success` is not a failure.** It means the POS app
 was already at this version, so Velopack had nothing to do. The installer reports it from
 the package version before and after, because the Velopack exit code is 0 either way.
+
+**A timeout is not a special case.** If the watchdog fires after the upgrade starts changing
+things, the run rolls back like any other failure and reports `RESULT=failed` with
+`ROLLED_BACK=true` (exit 2), not exit 4 - because what you need to know is whether the store came
+back, not which clock ran out. Exit 4 means it timed out before anything was changed.
 
 **`ROLLED_BACK=true` with `HEALTH=failed`** is the one line that needs immediate attention:
 the upgrade was undone but the store did not come back. Go to

--- a/docs/operations/upgrade-procedure.md
+++ b/docs/operations/upgrade-procedure.md
@@ -8,6 +8,7 @@
 |-----------|-----|
 | The store already runs IndyPOS v4 and you want a newer build | **This document** |
 | A brand-new machine with no IndyPOS on it | [Store Installation Guide](store-installation-guide.md) |
+| **The store still runs v3.7.0** | [Store Installation Guide](store-installation-guide.md) - v4 installs *alongside* v3.7.0, so this is a fresh install, not an upgrade. The installer detects that correctly and takes the fresh path |
 | Manual binary-swap / migration mechanics (background reading) | [Update Procedure](update-procedure.md) |
 
 The installer detects which case it is looking at and refuses to guess. A double-clicked

--- a/docs/operations/upgrade-procedure.md
+++ b/docs/operations/upgrade-procedure.md
@@ -139,13 +139,28 @@ orphan the store's history.
 ### `Store:Type` is missing
 
 Stores installed before 2026-07-18 have no such key. It cannot be defaulted: the default is
-the most permissive store type and would silently re-enable restricted features. Re-run:
+the most permissive store type and would silently re-enable restricted features.
+
+**`--store-type` does not currently fix this on an upgrade** - the run is refused before any
+argument is consulted. Add the key by hand, then re-run. `appsettings.json` is ACL-locked to
+Administrators, so use an elevated editor:
 
 ```
-IndyPOS-Setup.exe --silent --store-type GeneralHardware
+C:\ProgramData\IndyPOS\v4\StoreHub\appsettings.json
 ```
 
-(or `Minimart` - use the store's real type.)
+```json
+  "store": {
+    "id": "Rungrat-001",
+    "type": "GeneralHardware"
+  },
+```
+
+Use the store's real type (`GeneralHardware` or `Minimart`). Then:
+
+```
+IndyPOS-Setup.exe --silent
+```
 
 ### The service is not registered, or points elsewhere
 

--- a/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
+++ b/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
@@ -1063,13 +1063,21 @@ Spec §2. Both paths stop the service and lay down the payload, but in a differe
 **Interfaces:**
 - Consumes: `InstallationConfig.ServiceName`, `InstallationConfig.StoreHubInstallPath`
 - Produces:
+  - `sealed record ServiceControlResult(bool Success, string? ErrorMessage)` — a bare `bool` would
+    discard the Win32 text ("Access is denied.", "Time out has expired...") that the original
+    `StartServiceAsync` surfaced, and that text is the only lead in a store's install log after a
+    failed start
   - `sealed class ServiceControl(string serviceName)` with
-    `Task<bool> StopAsync(TimeSpan timeout, CancellationToken ct)`,
-    `Task<bool> StartAsync(TimeSpan timeout, CancellationToken ct)`,
+    `Task<ServiceControlResult> StopAsync(TimeSpan timeout, CancellationToken ct)`,
+    `Task<ServiceControlResult> StartAsync(TimeSpan timeout, CancellationToken ct)`,
     `bool Exists()`,
     `bool IsRunning()`
   - `static class StoreHubPayload` with
-    `static Task<bool> ExtractAsync(string destinationPath, IProgress<string>? log, CancellationToken ct)`
+    `static Task<bool> ExtractAsync(string destinationPath, IProgress<string>? log = null, CancellationToken ct = default, string resourceName = ResourceName, string? probeDirectory = null)` —
+    the last two are optional test seams whose defaults reproduce production behaviour exactly.
+    Without them the "no payload available" tests fail on any machine that has run
+    `build-installer.ps1`, because it stages `Resources/StoreHub.zip` into the source tree and
+    never cleans it up, and the csproj embeds `Resources\**\*` conditionally.
 
 - [ ] **Step 1: Write the failing test for the extractable seam**
 
@@ -3569,8 +3577,8 @@ public sealed class WindowsUpgradeSteps(InstallationConfig config, IProgress<str
         }
     }
 
-    public Task<bool> StopServiceAsync(CancellationToken ct) =>
-        _service.StopAsync(TimeSpan.FromSeconds(60), ct);
+    public async Task<bool> StopServiceAsync(CancellationToken ct) =>
+        (await _service.StopAsync(TimeSpan.FromSeconds(60), ct)).Success;
 
     public Task<BackupResult> BackupAsync(string pgDumpPath, string connectionString, CancellationToken ct) =>
         _backup.CreateAsync(pgDumpPath, connectionString, ct);
@@ -3587,8 +3595,8 @@ public sealed class WindowsUpgradeSteps(InstallationConfig config, IProgress<str
     public Task<MigrationRunResult> MigrateAsync(CancellationToken ct) =>
         MigrationRunner.RunAsync(config.StoreHubInstallPath, log, ct);
 
-    public Task<bool> StartServiceAsync(CancellationToken ct) =>
-        _service.StartAsync(TimeSpan.FromSeconds(60), ct);
+    public async Task<bool> StartServiceAsync(CancellationToken ct) =>
+        (await _service.StartAsync(TimeSpan.FromSeconds(60), ct)).Success;
 
     public Task<bool> HealthAsync(CancellationToken ct) =>
         HealthProbe.IsReadyAsync(config.HealthCheckPort, cancellationToken: ct);

--- a/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
+++ b/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
@@ -310,9 +310,11 @@ public static class StoreHubConfigReader
         {
             root = JsonNode.Parse(File.ReadAllText(appSettingsPath))?.AsObject();
         }
-        catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException)
+        catch (Exception ex) when (ex is JsonException or IOException
+                                         or UnauthorizedAccessException or InvalidOperationException)
         {
             // The file is there but unreadable — that is an Unusable store, not a fresh one.
+            // UnauthorizedAccessException is what a locked or ACL-denied file actually throws.
             return new StoreHubConfigFacts(Exists: true, false, null, null);
         }
 
@@ -360,9 +362,17 @@ public static class StoreHubConfigReader
         root.FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase))
             .Value as JsonObject;
 
-    private static string? Value(JsonObject? section, string name) =>
-        section?.FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase))
-               .Value?.GetValue<string>();
+    // Tolerant by design: a hand-edited `"id": 12345` is a wrong-typed node, not a crash.
+    // GetValue<string>() would throw InvalidOperationException on any non-string token,
+    // and this reader's contract is that a bad config degrades rather than throws.
+    private static string? Value(JsonObject? section, string name)
+    {
+        var node = section?
+            .FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase))
+            .Value;
+
+        return node is JsonValue value && value.TryGetValue<string>(out var text) ? text : null;
+    }
 
     private static string? NonBlank(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value;
@@ -823,9 +833,15 @@ public sealed class WindowsInstallProbe : IInstallProbe
         try
         {
             using var doc = JsonDocument.Parse(File.ReadAllText(manifestPath));
-            return doc.RootElement.TryGetProperty("installVersion", out var v) ? v.GetString() : null;
+
+            // ValueKind check, not a bare GetString(): that throws on a non-string token,
+            // and a hand-edited manifest must degrade to "unknown version", never crash.
+            return doc.RootElement.TryGetProperty("installVersion", out var v)
+                   && v.ValueKind == JsonValueKind.String
+                ? v.GetString()
+                : null;
         }
-        catch (Exception ex) when (ex is JsonException or IOException)
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
         {
             return null;
         }

--- a/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
+++ b/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
@@ -17,7 +17,7 @@
 - **The PostgreSQL superuser password is never persisted.** Decided 2026-07-25. No task may add storage for it.
 - **Migrations are forward-only.** Every migration in a release must be old-binary-compatible: additive only, new columns nullable or defaulted, no renames, no drops. Rollback restores binaries and config, not schema.
 - **Secrets never reach markers or logs.** All outbound text passes through `SecretScrubber.Scrub`. Markers are the `INDYPOS_MARKER <KEY>=<value>` format only.
-- **`RESULT` keeps exactly two values**, `success` and `failed`, so the existing harness gating rule is unchanged. Other markers say *what* succeeded.
+- **No new `RESULT` values.** The existing set is `success` / `failed` / `timeout` (`InstallTimedOut` already emits the third — the spec's "keeps its two values" predates checking the code). Every upgrade outcome reuses `success` or `failed`, so the harness gating rule is unchanged. Other markers say *what* succeeded.
 - **Exit codes are a frozen contract for 0–4**: `0` success, `1` usage error, `2` failed, `3` not elevated, `4` timeout. New outcomes take `5` and `6`.
 - **Config path constants:** StoreHub config lives at `<StoreHubInstallPath>\appsettings.json`. Its JSON is camelCase: `connectionStrings["storehub-db"]`, `store.id`, `store.type`. Read keys **case-insensitively** — ASP.NET config binding is case-insensitive and a hand-edited file may use PascalCase.
 - **DPAPI entropy** is `SHA256("IndyPOS:" + key)` at `LocalMachine` scope; the connection-string key is exactly `ConnectionStrings:storehub-db`.
@@ -3289,11 +3289,12 @@ public sealed class UpgradeOrchestrator(IUpgradeSteps steps, UpgradeStage? simul
 
         if (!backup.Success)
         {
-            // Nothing has been mutated, but the service is stopped — put it back.
-            await steps.StartServiceAsync(cancellationToken);
+            // Nothing has been mutated, but the service is stopped — put it back, and
+            // report what actually happened rather than assuming it came up.
+            var restarted = await steps.StartServiceAsync(cancellationToken);
             return new UpgradeFailed(backup.ErrorMessage ?? "Backup failed.",
-                RolledBack: false, ServiceStarted: true,
-                HealthOk: await steps.HealthAsync(cancellationToken), BackupDir: null);
+                RolledBack: false, ServiceStarted: restarted,
+                HealthOk: restarted && await steps.HealthAsync(cancellationToken), BackupDir: null);
         }
 
         // ============ EVERYTHING BELOW THIS LINE MUTATES THE INSTALL ============
@@ -3727,14 +3728,7 @@ In `installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs`, add `using IndyPO
         return exit;
 ```
 
-Add the three helpers. `RunInstall` keeps its current body, renamed `RunFreshInstall`:
-
-```csharp
-    private static SilentOutcome BuildFreshConfig(SilentInstallOptions options) =>
-        throw new InvalidOperationException("placeholder — see below");
-```
-
-Replace that placeholder with the real pair:
+Rename the existing `RunInstall` to `RunFreshInstall`, changing only its first parameter from `InstallationConfig config` built inline to one passed in; its body is otherwise unchanged. Then add these two helpers:
 
 ```csharp
     // A fresh install still requires an explicit store id: there is nothing to adopt.

--- a/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
+++ b/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
@@ -570,7 +570,8 @@ public class InstallModeDetectorTests
 {
     private const string InstallPath = @"C:\ProgramData\IndyPOS\v4\StoreHub";
 
-    private sealed class FakeProbe : IInstallProbe
+    // A record, not a class: the tests below use `with { ... }` to vary one fact at a time.
+    private sealed record FakeProbe : IInstallProbe
     {
         public bool ManifestExists { get; init; }
         public string? ManifestInstallVersion { get; init; }
@@ -784,7 +785,6 @@ public sealed record DetectedInstall(
 Create `installer/IndyPOS.Bootstrapper/Upgrade/IInstallProbe.cs`:
 
 ```csharp
-using System.ServiceProcess;
 using System.Text.Json;
 using Microsoft.Win32;
 using IndyPOS.Bootstrapper.Installers;
@@ -842,6 +842,15 @@ public sealed class WindowsInstallProbe : IInstallProbe
 
             // ValueKind check, not a bare GetString(): that throws on a non-string token,
             // and a hand-edited manifest must degrade to "unknown version", never crash.
+            // TryGetProperty is the one that bites first: it throws InvalidOperationException
+            // when the root is not an object (a manifest whose top-level JSON is a bare
+            // string or array). A hand-edited manifest must degrade to "unknown version",
+            // never crash the probe's constructor.
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
             return doc.RootElement.TryGetProperty("installVersion", out var v)
                    && v.ValueKind == JsonValueKind.String
                 ? v.GetString()
@@ -868,32 +877,22 @@ public sealed class WindowsInstallProbe : IInstallProbe
         }
     }
 
-    // No superuser credential is available here, so this is a filesystem-and-config
-    // inference rather than a query: a usable connection string means a provisioned
-    // database, and a Postgres data directory means one could exist for another major.
-    private static bool DetectStoreDatabase(InstallationConfig config)
-    {
-        var appSettings = Path.Combine(config.StoreHubInstallPath, "appsettings.json");
-        if (StoreHubConfigReader.Read(appSettings).ConnectionStringUsable)
-        {
-            return true;
-        }
-
-        foreach (var major in new[] { "18", "17", "16" })
-        {
-            var dataDir = $@"C:\Program Files\PostgreSQL\{major}\data\base";
-            if (Directory.Exists(dataDir) && OtherMajorStoreConfigExists())
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    // Rule 1's question is narrow: does a store install belonging to a DIFFERENT IndyPOS
+    // major exist here? This major's own config is already captured in Config, and rules
+    // 2-4 consume it from there. Answering "yes" for our own leftover config would let
+    // rule 1 intercept a same-major partial install — one that crashed after DatabaseSetup
+    // wrote appsettings.json but before the manifest — and tell the operator to go run a
+    // different installer, which is wrong and hides rule 4's correct diagnosis.
+    //
+    // No superuser credential is available here, so this is a config inference rather than
+    // a query: a usable connection string under another major's root means a provisioned
+    // database that our non-version-scoped DatabaseName would collide with.
+    private static bool DetectStoreDatabase(InstallationConfig config) =>
+        OtherMajorStoreConfigExists(config.SystemRoot);
 
     // C:\ProgramData\IndyPOS\v{N}\StoreHub\appsettings.json for a major other than ours
     // is the v5-installer-on-a-v4-store case that rule 1 exists to catch.
-    private static bool OtherMajorStoreConfigExists()
+    private static bool OtherMajorStoreConfigExists(string ourSystemRoot)
     {
         var root = @"C:\ProgramData\IndyPOS";
         if (!Directory.Exists(root))
@@ -901,10 +900,26 @@ public sealed class WindowsInstallProbe : IInstallProbe
             return false;
         }
 
-        return Directory.EnumerateDirectories(root, "v*")
-            .Select(d => Path.Combine(d, "StoreHub", "appsettings.json"))
-            .Any(p => StoreHubConfigReader.Read(p).ConnectionStringUsable);
+        try
+        {
+            // Lazy enumeration throws mid-iteration on an ACL-restricted subdirectory, so
+            // this needs the same guard every other probe member has.
+            return Directory.EnumerateDirectories(root, "v*")
+                .Where(d => !SamePath(d, ourSystemRoot))
+                .Select(d => Path.Combine(d, "StoreHub", "appsettings.json"))
+                .Any(p => StoreHubConfigReader.Read(p).ConnectionStringUsable);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
     }
+
+    private static bool SamePath(string left, string right) =>
+        string.Equals(
+            Path.GetFullPath(left).TrimEnd(Path.DirectorySeparatorChar),
+            Path.GetFullPath(right).TrimEnd(Path.DirectorySeparatorChar),
+            StringComparison.OrdinalIgnoreCase);
 }
 ```
 
@@ -1011,7 +1026,11 @@ public static class InstallModeDetector
 
         var trimmed = imagePath.Trim().Trim('"');
 
-        return trimmed.StartsWith(installPath, StringComparison.OrdinalIgnoreCase);
+        // The trailing separator matters: a bare StartsWith would also accept a sibling
+        // like ...\v4\StoreHubOLD\IndyPOS.StoreHub.exe.
+        var prefix = installPath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+        return trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
     }
 }
 ```

--- a/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
+++ b/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
@@ -1339,11 +1339,22 @@ public static class StoreHubPayload
 In `installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs`:
 
 - Delete the private `ExtractStoreHubBinariesAsync`, `CopyDirectoryAsync`, and `StopExistingServiceAsync` methods.
-- Replace the `StopExistingServiceAsync(cancellationToken)` call inside `InstallAsync` with:
+- Replace the `StopExistingServiceAsync(cancellationToken)` call inside `InstallAsync` with the version below. **Do not discard the returned bool.** Originally a stop timeout threw and failed the install; `ServiceControl.StopAsync` swallows it and returns `false` instead (the upgrade path needs a non-throwing stop it can branch on), so the fresh path must fail explicitly or a still-running service silently proceeds into extraction — holding its own DLLs open, which is the exact locked-DLL failure the stop-before-extract ordering exists to prevent:
 
 ```csharp
-            await new ServiceControl(Config.ServiceName)
+            var stopped = await new ServiceControl(Config.ServiceName)
                 .StopAsync(TimeSpan.FromSeconds(30), cancellationToken);
+
+            if (!stopped)
+            {
+                return new StoreHubInstallerResult
+                {
+                    Success = false,
+                    ErrorMessage =
+                        $"Service '{Config.ServiceName}' did not stop within 30 seconds. " +
+                        "Extracting over a running service would fail on locked files."
+                };
+            }
 ```
 
 - Replace the `ExtractStoreHubBinariesAsync(log, cancellationToken)` call with:

--- a/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
+++ b/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
@@ -1,0 +1,4242 @@
+# Installer In-Place Upgrade Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `IndyPOS-Setup.exe --silent` upgrade a machine that already runs IndyPOS, instead of failing destructively, while leaving the fresh-install path byte-for-byte unchanged.
+
+**Architecture:** A detector classifies the machine as `Fresh` / `Upgrade` / `Unusable`, and a single router in the silent entry point picks one of two orchestrators. `InstallationOrchestrator` is renamed `FreshInstallOrchestrator` and frozen; a new `UpgradeOrchestrator` runs a different algorithm (back up → deploy → restore config → migrate → start → verify, with rollback). Both compose the same extracted step units: `ServiceControl`, `StoreHubPayload`, `MigrationRunner`, `HealthProbe`, `ConfigSnapshot`. `DatabaseSetup` never runs on an upgrade.
+
+**Tech Stack:** C# .NET 10 (`net10.0-windows`), xUnit + FluentAssertions + NSubstitute, PowerShell 7 on the host / PowerShell 5.1 in the guest, PostgreSQL 18 (`pg_dump`/`pg_restore`), Velopack 0.0.1298, DPAPI via `IndyPOS.Vault.SecretProtector`.
+
+**Spec:** `docs/superpowers/specs/2026-07-25-installer-upgrade-support-design.md` (no open questions; §12 resolved by the 2026-07-26 VM spike).
+
+## Global Constraints
+
+- **The fresh-install path must not change behaviour.** After the extraction tasks, `git diff` on `FreshInstallOrchestrator.cs` must show *only* the rename and delegation to extracted units — no reordering, no new conditionals. Its fresh-only branches (`sc create`, first-time directory creation, `DatabaseSetup`, the Postgres install) never execute on the upgrade VM snapshot, so no amount of upgrade testing would catch a regression there.
+- **`DatabaseSetup` is fresh-install only.** It must never be called from the upgrade path. The role, password and DPAPI connection string already exist on an upgrade.
+- **The PostgreSQL superuser password is never persisted.** Decided 2026-07-25. No task may add storage for it.
+- **Migrations are forward-only.** Every migration in a release must be old-binary-compatible: additive only, new columns nullable or defaulted, no renames, no drops. Rollback restores binaries and config, not schema.
+- **Secrets never reach markers or logs.** All outbound text passes through `SecretScrubber.Scrub`. Markers are the `INDYPOS_MARKER <KEY>=<value>` format only.
+- **`RESULT` keeps exactly two values**, `success` and `failed`, so the existing harness gating rule is unchanged. Other markers say *what* succeeded.
+- **Exit codes are a frozen contract for 0–4**: `0` success, `1` usage error, `2` failed, `3` not elevated, `4` timeout. New outcomes take `5` and `6`.
+- **Config path constants:** StoreHub config lives at `<StoreHubInstallPath>\appsettings.json`. Its JSON is camelCase: `connectionStrings["storehub-db"]`, `store.id`, `store.type`. Read keys **case-insensitively** — ASP.NET config binding is case-insensitive and a hand-edited file may use PascalCase.
+- **DPAPI entropy** is `SHA256("IndyPOS:" + key)` at `LocalMachine` scope; the connection-string key is exactly `ConnectionStrings:storehub-db`.
+- **Test naming:** `Method_Condition_ShouldExpectedBehavior`. xUnit `[Fact]` / `[Theory]` + `[InlineData]`, FluentAssertions, Arrange-Act-Assert separated by blank lines. No `#region`.
+- **Guest scripts must be ASCII or BOM-encoded.** The VM runs PowerShell 5.1 with a Windows-1252 codepage; em-dashes and other non-ASCII characters make a script unparseable there.
+- **Commit style:** conventional commits, one logical unit per commit.
+
+---
+
+## File Structure
+
+**New — `installer/IndyPOS.Bootstrapper/Upgrade/`**
+
+| File | Responsibility |
+|---|---|
+| `StoreHubConfigReader.cs` | Reads facts out of an existing `appsettings.json`: store id, store type, whether the connection string is usable. Shared by detection and preflight — one code path, per spec §3. |
+| `InstallMode.cs` | `InstallMode` enum + `DetectedInstall` record. Data only. |
+| `IInstallProbe.cs` | The machine-state seam the detector reads through (manifest, service ImagePath, Postgres/database presence, config facts) + its Windows implementation. |
+| `InstallModeDetector.cs` | The four ordered rules. Pure given a probe. |
+| `PosAppVersion.cs` | Reads Velopack's `current\sq.version` to derive `POS_UPDATED` (spec §12). |
+| `UpgradeBackup.cs` | `pg_dump` + StoreHub tree copy, ACL lock, integrity check, retention prune, and delete-then-copy restore. |
+| `UpgradePreflight.cs` | Step 1 of the sequence: downgrade refusal, `pg_dump` location, free space, running-app check, prerequisite ensures. |
+| `UpgradeOrchestrator.cs` | The upgrade sequence and its failure/rollback handling. |
+| `SimulatedFailure.cs` | Runtime-selected fault hook so one installer build serves VM cases 1 and 2. |
+
+**New — `installer/IndyPOS.Bootstrapper/Installers/`** (extracted shared units)
+
+| File | Responsibility |
+|---|---|
+| `ServiceControl.cs` | Stop / start / query the StoreHub Windows service. Used by both paths. |
+| `StoreHubPayload.cs` | Extract the embedded StoreHub payload over an install directory. Used by both paths. |
+| `MigrationRunner.cs` | Runs `IndyPOS.StoreHub.exe migrate`. Used by both paths. Deliberately *not* named `SchemaProvisioner` — `DatabaseSetup` is fresh-only and the two must never be confused. |
+| `HealthProbe.cs` | Polls `/health/ready`. Used by both paths. |
+
+**Modified**
+
+| File | Change |
+|---|---|
+| `Installers/InstallationOrchestrator.cs` → `Installers/FreshInstallOrchestrator.cs` | Rename + delegate to extracted units. Frozen thereafter. |
+| `Installers/StoreHubInstaller.cs` | Delegates to `ServiceControl` / `StoreHubPayload` / `MigrationRunner`. |
+| `Installers/DatabaseSetup.cs` | Fresh-only banner; superuser-guard message must stop recommending `cleanup-v4.ps1 -Force -RemovePostgres` when a store database exists (spec §8). |
+| `Installers/PostgresInstaller.cs` | Expose `FindPostgresInstallation` (currently `private static` returning a private nested type) so `UpgradePreflight` can fall back to it. |
+| `Silent/SilentOutcomeMapper.cs` | New sibling outcome records + exit codes; no widening of `InstallSucceeded`. |
+| `Silent/SilentArgs.cs` | `--store-id` optional; `--simulate-failure` hidden flag. |
+| `Silent/SilentInstaller.cs` | Becomes the single router: detect once, emit `MODE=`, dispatch. |
+| `UI/InstallationWizard.cs`, `Program.cs` | Wizard detects an existing install and refuses with the `--silent` command. |
+| `scripts/vm-testing/Reset-AndInstall.ps1` | `-SnapshotName`, expect-rollback mode, assert against the fresh timestamped log. |
+| `scripts/vm-testing/Test-IndyPOSInstallation.ps1` | Scripted database assertions via the DPAPI-decrypted connection string. |
+| `docs/operations/upgrade-procedure.md` (new), `update-procedure.md` | Operator runbook, `Unusable` recovery per rule, `pg_restore` command, forward-only migration release gate. |
+
+**Tests — `tests/IndyPOS.Bootstrapper.Tests/Upgrade/`**: one file per unit, matching the existing `Installers/` and `Silent/` layout.
+
+---
+
+## Task 1: StoreHubConfigReader
+
+The one code path that answers "what does this machine's existing StoreHub config say?". Detection (§3) and preflight (§4 step 1) both consume it, so a disagreement between them is impossible by construction.
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Upgrade/StoreHubConfigReader.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Upgrade/StoreHubConfigReaderTests.cs`
+
+**Interfaces:**
+- Consumes: `IndyPOS.Vault.SecretProtector.Unprotect(string key, string value)`, `IndyPOS.Domain.Enums.StoreType`
+- Produces:
+  - `sealed record StoreHubConfigFacts(bool Exists, bool ConnectionStringUsable, string? StoreId, StoreType? StoreType)`
+  - `static class StoreHubConfigReader` with `const string ConnectionStringKey = "ConnectionStrings:storehub-db"` and
+    `static StoreHubConfigFacts Read(string appSettingsPath, Func<string, string, string>? unprotect = null)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/IndyPOS.Bootstrapper.Tests/Upgrade/StoreHubConfigReaderTests.cs`:
+
+```csharp
+using System.Security.Cryptography;
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Upgrade;
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class StoreHubConfigReaderTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "indypos-cfgread-" + Guid.NewGuid().ToString("N"));
+
+    public StoreHubConfigReaderTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+    }
+
+    // Tests never touch real DPAPI: a machine-scoped blob cannot be authored
+    // portably, and the reader's contract is "whatever unprotect does".
+    private static string PassThrough(string key, string value) => value;
+
+    private static string Fail(string key, string value) =>
+        throw new CryptographicException("Key not valid for use in specified state.");
+
+    private string Write(string json)
+    {
+        var path = Path.Combine(_dir, "appsettings.json");
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    [Fact]
+    public void Read_WhenFileIsAbsent_ShouldReportNotExists()
+    {
+        var facts = StoreHubConfigReader.Read(Path.Combine(_dir, "appsettings.json"), PassThrough);
+
+        facts.Exists.Should().BeFalse();
+        facts.ConnectionStringUsable.Should().BeFalse();
+        facts.StoreId.Should().BeNull();
+        facts.StoreType.Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithARealStoreConfig_ShouldReturnEveryFact()
+    {
+        var path = Write("""
+        {
+          "connectionStrings": { "storehub-db": "DPAPI:AQAAANCM" },
+          "store": { "id": "Rungrat-001", "type": "Minimart" }
+        }
+        """);
+
+        var facts = StoreHubConfigReader.Read(path, PassThrough);
+
+        facts.Exists.Should().BeTrue();
+        facts.ConnectionStringUsable.Should().BeTrue();
+        facts.StoreId.Should().Be("Rungrat-001");
+        facts.StoreType.Should().Be(StoreType.Minimart);
+    }
+
+    [Fact]
+    public void Read_WithPascalCaseKeys_ShouldStillBindThem()
+    {
+        // ASP.NET config binding is case-insensitive, so a hand-edited file is valid.
+        var path = Write("""
+        {
+          "ConnectionStrings": { "storehub-db": "Host=127.0.0.1" },
+          "Store": { "Id": "Rungrat-001", "Type": "GeneralHardware" }
+        }
+        """);
+
+        var facts = StoreHubConfigReader.Read(path, PassThrough);
+
+        facts.StoreId.Should().Be("Rungrat-001");
+        facts.StoreType.Should().Be(StoreType.GeneralHardware);
+    }
+
+    [Fact]
+    public void Read_WhenDpapiValueFailsToDecrypt_ShouldReportUnusable()
+    {
+        // A value protected on another machine. That store is Unusable, not upgradeable.
+        var path = Write("""
+        {
+          "connectionStrings": { "storehub-db": "DPAPI:AQAAANCM" },
+          "store": { "id": "Rungrat-001", "type": "Minimart" }
+        }
+        """);
+
+        var facts = StoreHubConfigReader.Read(path, Fail);
+
+        facts.Exists.Should().BeTrue();
+        facts.ConnectionStringUsable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Read_WhenDpapiValueIsNotBase64_ShouldReportUnusable()
+    {
+        // Unprotect throws FormatException, not CryptographicException, on bad base64.
+        var path = Write("""{ "connectionStrings": { "storehub-db": "DPAPI:not-base64!!" } }""");
+
+        var facts = StoreHubConfigReader.Read(
+            path, (_, _) => throw new FormatException("Invalid base64."));
+
+        facts.ConnectionStringUsable.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Read_WithBlankConnectionString_ShouldReportUnusable(string value)
+    {
+        var path = Write($$"""{ "connectionStrings": { "storehub-db": "{{value}}" } }""");
+
+        StoreHubConfigReader.Read(path, PassThrough).ConnectionStringUsable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Read_WithBlankStoreId_ShouldReturnNullStoreId()
+    {
+        // Empty is as dangerous as absent: StoreIdentityService falls back to the
+        // machine name, which would orphan the store's sales history.
+        var path = Write("""{ "store": { "id": "   ", "type": "Minimart" } }""");
+
+        StoreHubConfigReader.Read(path, PassThrough).StoreId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithAbsentStoreType_ShouldReturnNullStoreType()
+    {
+        // Stores installed before 2026-07-18 have no Store:Type key.
+        var path = Write("""{ "store": { "id": "Rungrat-001" } }""");
+
+        StoreHubConfigReader.Read(path, PassThrough).StoreType.Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithUnparseableStoreType_ShouldReturnNullStoreType()
+    {
+        var path = Write("""{ "store": { "id": "Rungrat-001", "type": "Bakery" } }""");
+
+        StoreHubConfigReader.Read(path, PassThrough).StoreType.Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithMalformedJson_ShouldReportExistsButUnusable()
+    {
+        var path = Write("{ this is not json");
+
+        var facts = StoreHubConfigReader.Read(path, PassThrough);
+
+        facts.Exists.Should().BeTrue();
+        facts.ConnectionStringUsable.Should().BeFalse();
+        facts.StoreId.Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~StoreHubConfigReaderTests`
+Expected: FAIL — `StoreHubConfigReader` does not exist (compile error CS0246).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `installer/IndyPOS.Bootstrapper/Upgrade/StoreHubConfigReader.cs`:
+
+```csharp
+using System.Security.Cryptography;
+using System.Text.Json.Nodes;
+using IndyPOS.Domain.Enums;
+using IndyPOS.Vault;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>
+/// What an existing StoreHub <c>appsettings.json</c> says about the store on this
+/// machine. Detection (spec section 3) and upgrade preflight (section 4 step 1) both read
+/// through this one type, so the two can never disagree about whether a store is
+/// upgradeable.
+/// </summary>
+public sealed record StoreHubConfigFacts(
+    bool Exists,
+    bool ConnectionStringUsable,
+    string? StoreId,
+    StoreType? StoreType);
+
+public static class StoreHubConfigReader
+{
+    /// <summary>Config key the connection string is DPAPI-bound to. Entropy depends on it.</summary>
+    public const string ConnectionStringKey = "ConnectionStrings:storehub-db";
+
+    private static readonly StoreHubConfigFacts Absent = new(false, false, null, null);
+
+    /// <param name="unprotect">
+    /// Seam for the DPAPI round-trip, so tests need not author a machine-scoped blob.
+    /// Defaults to <see cref="SecretProtector.Unprotect"/>.
+    /// </param>
+    public static StoreHubConfigFacts Read(
+        string appSettingsPath,
+        Func<string, string, string>? unprotect = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(appSettingsPath);
+
+        if (!File.Exists(appSettingsPath))
+        {
+            return Absent;
+        }
+
+        JsonObject? root;
+        try
+        {
+            root = JsonNode.Parse(File.ReadAllText(appSettingsPath))?.AsObject();
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException)
+        {
+            // The file is there but unreadable — that is an Unusable store, not a fresh one.
+            return new StoreHubConfigFacts(Exists: true, false, null, null);
+        }
+
+        if (root is null)
+        {
+            return new StoreHubConfigFacts(Exists: true, false, null, null);
+        }
+
+        var store = Section(root, "store");
+
+        return new StoreHubConfigFacts(
+            Exists: true,
+            ConnectionStringUsable: IsConnectionStringUsable(root, unprotect ?? SecretProtector.Unprotect),
+            StoreId: NonBlank(Value(store, "id")),
+            StoreType: ParseStoreType(Value(store, "type")));
+    }
+
+    private static bool IsConnectionStringUsable(JsonObject root, Func<string, string, string> unprotect)
+    {
+        var value = Value(Section(root, "connectionStrings"), "storehub-db");
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        if (!SecretProtector.IsProtected(value))
+        {
+            return true;
+        }
+
+        try
+        {
+            return !string.IsNullOrWhiteSpace(unprotect(ConnectionStringKey, value));
+        }
+        catch (Exception ex) when (ex is CryptographicException or FormatException)
+        {
+            // Sealed on another machine. Nothing here can recover it.
+            return false;
+        }
+    }
+
+    // Config binding is case-insensitive, so a hand-edited PascalCase file must still bind.
+    private static JsonObject? Section(JsonObject root, string name) =>
+        root.FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase))
+            .Value as JsonObject;
+
+    private static string? Value(JsonObject? section, string name) =>
+        section?.FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase))
+               .Value?.GetValue<string>();
+
+    private static string? NonBlank(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+
+    // Only a defined enum NAME counts; Enum.TryParse would also accept "2".
+    private static StoreType? ParseStoreType(string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var matched = Enum.GetNames<StoreType>()
+            .FirstOrDefault(n => n.Equals(value, StringComparison.OrdinalIgnoreCase));
+
+        return matched is null ? null : Enum.Parse<StoreType>(matched);
+    }
+}
+```
+
+Add `using System.Text.Json;` for `JsonException`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~StoreHubConfigReaderTests`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Upgrade/StoreHubConfigReader.cs tests/IndyPOS.Bootstrapper.Tests/Upgrade/StoreHubConfigReaderTests.cs
+git commit -m "feat(installer): read store facts from an existing StoreHub config"
+```
+
+---
+
+## Task 2: Close the cleanup-script data-loss path
+
+Spec §8, and independent of everything else. The superuser guard currently tells the operator to run `scripts\cleanup-v4.ps1 -Force -RemovePostgres`, which calls `DROP DATABASE IF EXISTS indypos_storehub` unconditionally unless `-SkipDatabase`. An operator following the installer's own guidance destroys every sale the store has recorded.
+
+**Files:**
+- Modify: `installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs:9-18` (banner), `:38-50` (guard message)
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Installers/DatabaseSetupTests.cs`
+
+**Interfaces:**
+- Consumes: `StoreHubConfigReader.Read` (Task 1)
+- Produces: `internal static string DatabaseSetup.BuildSuperuserGuardMessage(bool storeDatabaseExists)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/IndyPOS.Bootstrapper.Tests/Installers/DatabaseSetupTests.cs` (keep the file's existing `using`s; add `using IndyPOS.Bootstrapper.Installers;` if absent):
+
+```csharp
+    [Fact]
+    public void BuildSuperuserGuardMessage_WhenAStoreDatabaseExists_ShouldNeverRecommendTheCleanupScript()
+    {
+        // cleanup-v4.ps1 drops indypos_storehub unconditionally unless -SkipDatabase.
+        // Recommending it to a live store destroys every sale ever recorded.
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: true);
+
+        message.Should().NotContain("cleanup-v4");
+        message.Should().NotContain("-RemovePostgres");
+    }
+
+    [Fact]
+    public void BuildSuperuserGuardMessage_WhenAStoreDatabaseExists_ShouldPointAtTheUpgradeCommand()
+    {
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: true);
+
+        message.Should().Contain("--silent");
+        message.Should().Contain("existing IndyPOS database");
+    }
+
+    [Fact]
+    public void BuildSuperuserGuardMessage_OnABareMachine_ShouldStillOfferTheCleanupScript()
+    {
+        // No store data to lose here, so the fast path stays available.
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: false);
+
+        message.Should().Contain("cleanup-v4.ps1");
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~DatabaseSetupTests`
+Expected: FAIL — `BuildSuperuserGuardMessage` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+In `installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs`, replace the class summary at lines 9-11 with the fresh-only banner:
+
+```csharp
+/// <summary>
+/// Handles database creation and configuration.
+/// <para>
+/// FRESH INSTALL ONLY. Never runs on an upgrade — the role, its password and the
+/// DPAPI-protected connection string already exist there, so asking the
+/// database-provisioning question at all is what produced the superuser-password
+/// failure this guard reports. See the upgrade design spec, sections 2 and 4.
+/// </para>
+/// </summary>
+```
+
+Replace the guard block at lines 38-50 with:
+
+```csharp
+        if (string.IsNullOrEmpty(postgresPassword))
+        {
+            var storeDatabaseExists = StoreHubConfigReader
+                .Read(Path.Combine(config.StoreHubInstallPath, "appsettings.json"))
+                .ConnectionStringUsable;
+
+            return new DatabaseSetupResult
+            {
+                Success = false,
+                ErrorMessage = BuildSuperuserGuardMessage(storeDatabaseExists)
+            };
+        }
+```
+
+Add the message builder next to `GenerateJwtSecret`:
+
+```csharp
+    /// <summary>
+    /// The superuser password is deliberately not persisted (spec section 1), so an existing
+    /// PostgreSQL cannot be provisioned into. What the operator should do next depends
+    /// entirely on whether there is a store database to protect.
+    /// </summary>
+    internal static string BuildSuperuserGuardMessage(bool storeDatabaseExists) =>
+        storeDatabaseExists
+            ? "PostgreSQL 18 is already installed and this machine has an existing IndyPOS database.\n" +
+              "Do NOT remove PostgreSQL — that would destroy the store's sales history.\n" +
+              "Upgrade in place instead:\n" +
+              "  IndyPOS-Setup.exe --silent\n" +
+              "See docs\\operations\\upgrade-procedure.md."
+            : "PostgreSQL 18 is already installed, but its superuser password is unknown " +
+              "(the installer doesn't persist it across runs). To proceed, either:\n" +
+              "  - Uninstall PostgreSQL: scripts\\cleanup-v4.ps1 -Force -RemovePostgres\n" +
+              "  - Or remove C:\\Program Files\\PostgreSQL\\18 manually,\n" +
+              "then re-run this installer for a clean Postgres install.";
+```
+
+Add `using IndyPOS.Bootstrapper.Upgrade;` to the file's usings.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~DatabaseSetupTests`
+Expected: PASS — the 3 new tests plus every pre-existing `DatabaseSetupTests` case.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs tests/IndyPOS.Bootstrapper.Tests/Installers/DatabaseSetupTests.cs
+git commit -m "fix(installer): stop recommending a cleanup that drops the store database"
+```
+
+---
+
+## Task 3: Install-mode detection
+
+Spec §3. Three outcomes, not two — a machine can be neither freshly installable nor upgradeable, and collapsing `Unusable` into `Fresh` sends the run *past* the mutation line.
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Upgrade/InstallMode.cs`, `installer/IndyPOS.Bootstrapper/Upgrade/IInstallProbe.cs`, `installer/IndyPOS.Bootstrapper/Upgrade/InstallModeDetector.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Upgrade/InstallModeDetectorTests.cs`
+
+**Interfaces:**
+- Consumes: `StoreHubConfigFacts` (Task 1), `InstallationConfig.SystemRoot` / `.StoreHubInstallPath` / `.ServiceName`, `InstallManifestWriter.ManifestFileName`
+- Produces:
+  - `enum InstallMode { Fresh, Upgrade, Unusable }`
+  - `sealed record DetectedInstall(InstallMode Mode, string? InstalledVersion, string? StoreId, StoreType? StoreType, string Reason)`
+  - `interface IInstallProbe { bool ManifestExists { get; } string? ManifestInstallVersion { get; } bool PostgresStoreDatabaseExists { get; } string? ServiceImagePath { get; } StoreHubConfigFacts Config { get; } }`
+  - `sealed class WindowsInstallProbe : IInstallProbe` with `WindowsInstallProbe(InstallationConfig config)`
+  - `static class InstallModeDetector` with `static DetectedInstall Detect(IInstallProbe probe, string storeHubInstallPath)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/IndyPOS.Bootstrapper.Tests/Upgrade/InstallModeDetectorTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Upgrade;
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class InstallModeDetectorTests
+{
+    private const string InstallPath = @"C:\ProgramData\IndyPOS\v4\StoreHub";
+
+    private sealed class FakeProbe : IInstallProbe
+    {
+        public bool ManifestExists { get; init; }
+        public string? ManifestInstallVersion { get; init; }
+        public bool PostgresStoreDatabaseExists { get; init; }
+        public string? ServiceImagePath { get; init; }
+        public StoreHubConfigFacts Config { get; init; } = new(false, false, null, null);
+    }
+
+    private static FakeProbe HealthyUpgrade() => new()
+    {
+        ManifestExists = true,
+        ManifestInstallVersion = "4.0.0",
+        PostgresStoreDatabaseExists = true,
+        ServiceImagePath = InstallPath + @"\IndyPOS.StoreHub.exe",
+        Config = new StoreHubConfigFacts(true, true, "Rungrat-001", StoreType.Minimart)
+    };
+
+    [Fact]
+    public void Detect_OnABareMachine_ShouldReturnFresh()
+    {
+        var result = InstallModeDetector.Detect(new FakeProbe(), InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Fresh);
+    }
+
+    [Fact]
+    public void Detect_OnAHealthyInstall_ShouldReturnUpgradeWithEveryDetectedValue()
+    {
+        var result = InstallModeDetector.Detect(HealthyUpgrade(), InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Upgrade);
+        result.InstalledVersion.Should().Be("4.0.0");
+        result.StoreId.Should().Be("Rungrat-001");
+        result.StoreType.Should().Be(StoreType.Minimart);
+    }
+
+    [Fact]
+    public void Detect_WithAStoreDatabaseButNoManifestForThisMajor_ShouldReturnUnusable()
+    {
+        // Rule 1, and it must beat rule 3. A v5 installer on a live v4 store finds no
+        // manifest under v5\ and would otherwise read as Fresh -- but DatabaseName is
+        // NOT version-scoped, so that "side-by-side" install collides with the v4 database.
+        var probe = new FakeProbe { PostgresStoreDatabaseExists = true, ManifestExists = false };
+
+        var result = InstallModeDetector.Detect(probe, InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Unusable);
+        result.Reason.Should().Contain("another IndyPOS major version");
+    }
+
+    [Fact]
+    public void Detect_WithAStoreDatabaseAndNoManifest_ShouldNotRecommendTheCleanupScript()
+    {
+        var probe = new FakeProbe { PostgresStoreDatabaseExists = true, ManifestExists = false };
+
+        InstallModeDetector.Detect(probe, InstallPath).Reason.Should().NotContain("cleanup-v4");
+    }
+
+    [Fact]
+    public void Detect_WithAnEmptyStoreId_ShouldReturnUnusable()
+    {
+        // StoreIdentityService falls back to STORE-{MachineName}, and payment_method is
+        // keyed on (StoreId, Code) -- the seeder would insert a second full catalogue and
+        // every later sale would be written against it.
+        var probe = HealthyUpgrade() with
+        {
+            Config = new StoreHubConfigFacts(true, true, null, StoreType.Minimart)
+        };
+
+        var result = InstallModeDetector.Detect(probe, InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Unusable);
+        result.Reason.Should().Contain("Store:Id");
+    }
+
+    [Fact]
+    public void Detect_WithAnAbsentStoreType_ShouldReturnUnusable()
+    {
+        // Added 2026-07-18. Absent binds to GeneralHardware -- the MOST permissive value --
+        // which would silently re-enable PayLater and Hardware products on a Minimart.
+        var probe = HealthyUpgrade() with
+        {
+            Config = new StoreHubConfigFacts(true, true, "Rungrat-001", null)
+        };
+
+        var result = InstallModeDetector.Detect(probe, InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Unusable);
+        result.Reason.Should().Contain("Store:Type");
+    }
+
+    [Fact]
+    public void Detect_WithAnUndecryptableConnectionString_ShouldReturnUnusable()
+    {
+        var probe = HealthyUpgrade() with
+        {
+            Config = new StoreHubConfigFacts(true, false, "Rungrat-001", StoreType.Minimart)
+        };
+
+        var result = InstallModeDetector.Detect(probe, InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Unusable);
+        result.Reason.Should().Contain("connection string");
+    }
+
+    [Fact]
+    public void Detect_WhenTheServiceIsNotRegistered_ShouldReturnUnusable()
+    {
+        var probe = HealthyUpgrade() with { ServiceImagePath = null };
+
+        var result = InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Unusable);
+    }
+
+    [Fact]
+    public void Detect_WhenTheServicePointsSomewhereElse_ShouldReturnUnusable()
+    {
+        var probe = HealthyUpgrade() with
+        {
+            ServiceImagePath = @"C:\Some\Other\Place\IndyPOS.StoreHub.exe"
+        };
+
+        InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Unusable);
+    }
+
+    [Fact]
+    public void Detect_WithAQuotedServiceImagePath_ShouldStillMatch()
+    {
+        // sc.exe records binPath with quotes when the path contains spaces.
+        var probe = HealthyUpgrade() with
+        {
+            ServiceImagePath = "\"" + InstallPath + "\\IndyPOS.StoreHub.exe\""
+        };
+
+        InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Upgrade);
+    }
+
+    [Fact]
+    public void Detect_WithAManifestButNoConfig_ShouldReturnUnusable()
+    {
+        // Rule 4. This is the exact state the second failed VM run left behind.
+        var probe = new FakeProbe
+        {
+            ManifestExists = true,
+            ManifestInstallVersion = "4.0.0",
+            ServiceImagePath = InstallPath + @"\IndyPOS.StoreHub.exe",
+            Config = new StoreHubConfigFacts(true, false, null, null)
+        };
+
+        InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Unusable);
+    }
+
+    [Fact]
+    public void Detect_WithConfigButNoManifest_ShouldReturnUnusableNotFresh()
+    {
+        // Rule 3 requires BOTH absent. A leftover config means this is not a bare machine.
+        var probe = new FakeProbe
+        {
+            Config = new StoreHubConfigFacts(true, true, "Rungrat-001", StoreType.Minimart)
+        };
+
+        InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Unusable);
+    }
+}
+```
+
+Note: the `Detect_WhenTheServiceIsNotRegistered_ShouldReturnUnusable` body above assigns to an unused local — write it as a plain expression statement:
+
+```csharp
+        InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Unusable);
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~InstallModeDetectorTests`
+Expected: FAIL — `InstallMode`, `IInstallProbe`, `InstallModeDetector` do not exist.
+
+- [ ] **Step 3: Write the data types**
+
+Create `installer/IndyPOS.Bootstrapper/Upgrade/InstallMode.cs`:
+
+```csharp
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>
+/// How this machine should be treated. Three outcomes, not two: a machine can be
+/// neither freshly installable nor upgradeable, and treating that as Fresh sends the
+/// run past the point where it starts mutating the install.
+/// </summary>
+public enum InstallMode
+{
+    Fresh,
+    Upgrade,
+    Unusable
+}
+
+/// <param name="InstalledVersion">From install-manifest.json. Null unless a manifest was found.</param>
+/// <param name="StoreId">From appsettings.json — the manifest does not record it.</param>
+/// <param name="Reason">Operator-facing explanation. Surfaced on Unusable.</param>
+public sealed record DetectedInstall(
+    InstallMode Mode,
+    string? InstalledVersion,
+    string? StoreId,
+    StoreType? StoreType,
+    string Reason);
+```
+
+- [ ] **Step 4: Write the probe**
+
+Create `installer/IndyPOS.Bootstrapper/Upgrade/IInstallProbe.cs`:
+
+```csharp
+using System.ServiceProcess;
+using System.Text.Json;
+using Microsoft.Win32;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>
+/// Everything <see cref="InstallModeDetector"/> needs to know about the machine.
+/// An interface so the ordered rules can be tested without a real install.
+/// </summary>
+public interface IInstallProbe
+{
+    bool ManifestExists { get; }
+    string? ManifestInstallVersion { get; }
+
+    /// <summary>
+    /// A PostgreSQL install carrying the IndyPOS database. Note DatabaseName is NOT
+    /// version-scoped, so this is true for a v4 store seen by a v5 installer.
+    /// </summary>
+    bool PostgresStoreDatabaseExists { get; }
+
+    /// <summary>The registered service's ImagePath, or null when no such service exists.</summary>
+    string? ServiceImagePath { get; }
+
+    StoreHubConfigFacts Config { get; }
+}
+
+/// <summary>Reads the real machine. Every member is evaluated once, at construction.</summary>
+public sealed class WindowsInstallProbe : IInstallProbe
+{
+    public WindowsInstallProbe(InstallationConfig config)
+    {
+        var manifestPath = Path.Combine(config.SystemRoot, InstallManifestWriter.ManifestFileName);
+        ManifestExists = File.Exists(manifestPath);
+        ManifestInstallVersion = ManifestExists ? ReadManifestVersion(manifestPath) : null;
+
+        Config = StoreHubConfigReader.Read(
+            Path.Combine(config.StoreHubInstallPath, "appsettings.json"));
+
+        ServiceImagePath = ReadServiceImagePath(config.ServiceName);
+        PostgresStoreDatabaseExists = DetectStoreDatabase(config);
+    }
+
+    public bool ManifestExists { get; }
+    public string? ManifestInstallVersion { get; }
+    public bool PostgresStoreDatabaseExists { get; }
+    public string? ServiceImagePath { get; }
+    public StoreHubConfigFacts Config { get; }
+
+    private static string? ReadManifestVersion(string manifestPath)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            return doc.RootElement.TryGetProperty("installVersion", out var v) ? v.GetString() : null;
+        }
+        catch (Exception ex) when (ex is JsonException or IOException)
+        {
+            return null;
+        }
+    }
+
+    // ServiceController does not expose ImagePath, so read the SCM registry key directly.
+    private static string? ReadServiceImagePath(string serviceName)
+    {
+        try
+        {
+            using var key = Registry.LocalMachine.OpenSubKey(
+                $@"SYSTEM\CurrentControlSet\Services\{serviceName}");
+            return key?.GetValue("ImagePath") as string;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    // No superuser credential is available here, so this is a filesystem-and-config
+    // inference rather than a query: a usable connection string means a provisioned
+    // database, and a Postgres data directory means one could exist for another major.
+    private static bool DetectStoreDatabase(InstallationConfig config)
+    {
+        var appSettings = Path.Combine(config.StoreHubInstallPath, "appsettings.json");
+        if (StoreHubConfigReader.Read(appSettings).ConnectionStringUsable)
+        {
+            return true;
+        }
+
+        foreach (var major in new[] { "18", "17", "16" })
+        {
+            var dataDir = $@"C:\Program Files\PostgreSQL\{major}\data\base";
+            if (Directory.Exists(dataDir) && OtherMajorStoreConfigExists())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // C:\ProgramData\IndyPOS\v{N}\StoreHub\appsettings.json for a major other than ours
+    // is the v5-installer-on-a-v4-store case that rule 1 exists to catch.
+    private static bool OtherMajorStoreConfigExists()
+    {
+        var root = @"C:\ProgramData\IndyPOS";
+        if (!Directory.Exists(root))
+        {
+            return false;
+        }
+
+        return Directory.EnumerateDirectories(root, "v*")
+            .Select(d => Path.Combine(d, "StoreHub", "appsettings.json"))
+            .Any(p => StoreHubConfigReader.Read(p).ConnectionStringUsable);
+    }
+}
+```
+
+`Microsoft.Win32.Registry` comes from the `Microsoft.Win32.Registry` package; on `net10.0-windows` it is already available via the Windows Desktop framework reference — verify the project builds and add the package only if it does not.
+
+- [ ] **Step 5: Write the detector**
+
+Create `installer/IndyPOS.Bootstrapper/Upgrade/InstallModeDetector.cs`:
+
+```csharp
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>
+/// Classifies a machine. Rules are evaluated IN ORDER and the first match wins —
+/// see the upgrade design spec, section 3. Reordering them reintroduces the data-loss
+/// path rule 1 exists to close.
+/// </summary>
+public static class InstallModeDetector
+{
+    public static DetectedInstall Detect(IInstallProbe probe, string storeHubInstallPath)
+    {
+        ArgumentNullException.ThrowIfNull(probe);
+
+        // Rule 1 — must precede the manifest lookup. SystemRoot is version-scoped but
+        // DatabaseName is not, so a newer major would read a live store as Fresh and
+        // then collide with its database.
+        if (probe.PostgresStoreDatabaseExists && !probe.ManifestExists)
+        {
+            return Unusable(probe,
+                "An IndyPOS database exists on this machine but belongs to another IndyPOS " +
+                "major version. Do not remove PostgreSQL — it holds the store's sales history. " +
+                "Run the installer for the version that owns that install root instead.");
+        }
+
+        // Rule 2 — everything an upgrade needs is present and coherent.
+        if (probe.ManifestExists)
+        {
+            if (!probe.Config.ConnectionStringUsable)
+            {
+                return Unusable(probe,
+                    "The StoreHub connection string is missing, empty, or cannot be decrypted on " +
+                    "this machine. Restore appsettings.json from a backup before upgrading.");
+            }
+
+            if (probe.Config.StoreId is null)
+            {
+                return Unusable(probe,
+                    "Store:Id is missing from appsettings.json. Upgrading without it would seed a " +
+                    "second payment-method catalogue under a fallback store id and orphan the " +
+                    "store's sales history. Set Store:Id to this store's real id first.");
+            }
+
+            if (probe.Config.StoreType is null)
+            {
+                return Unusable(probe,
+                    "Store:Type is missing from appsettings.json (stores installed before " +
+                    "2026-07-18 have no such key). It cannot be defaulted: the default is the most " +
+                    "permissive store type and would silently re-enable restricted features. " +
+                    "Re-run with --store-type <GeneralHardware|Minimart> to set it.");
+            }
+
+            if (!ImagePathResolvesUnder(probe.ServiceImagePath, storeHubInstallPath))
+            {
+                return Unusable(probe,
+                    "The StoreHub service is not registered, or its ImagePath does not resolve " +
+                    $"under {storeHubInstallPath}. Upgrading would deploy binaries the service " +
+                    "does not run.");
+            }
+
+            return new DetectedInstall(
+                InstallMode.Upgrade,
+                probe.ManifestInstallVersion,
+                probe.Config.StoreId,
+                probe.Config.StoreType,
+                "An existing IndyPOS install was detected and can be upgraded in place.");
+        }
+
+        // Rule 3 — a genuinely bare machine. BOTH must be absent.
+        if (!probe.Config.Exists)
+        {
+            return new DetectedInstall(InstallMode.Fresh, null, null, null,
+                "No existing IndyPOS install was found.");
+        }
+
+        // Rule 4 — anything else.
+        return Unusable(probe,
+            "A StoreHub configuration exists but there is no install manifest, so this machine " +
+            "is neither a clean install nor a complete one. Inspect " +
+            $"{storeHubInstallPath} before proceeding.");
+    }
+
+    private static DetectedInstall Unusable(IInstallProbe probe, string reason) =>
+        new(InstallMode.Unusable, probe.ManifestInstallVersion, probe.Config.StoreId,
+            probe.Config.StoreType, reason);
+
+    // sc.exe records binPath with surrounding quotes when the path contains spaces,
+    // and "C:\ProgramData\..." always does not — but a hand-registered service may.
+    private static bool ImagePathResolvesUnder(string? imagePath, string installPath)
+    {
+        if (string.IsNullOrWhiteSpace(imagePath))
+        {
+            return false;
+        }
+
+        var trimmed = imagePath.Trim().Trim('"');
+
+        return trimmed.StartsWith(installPath, StringComparison.OrdinalIgnoreCase);
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~InstallModeDetectorTests`
+Expected: PASS, 12 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Upgrade/ tests/IndyPOS.Bootstrapper.Tests/Upgrade/InstallModeDetectorTests.cs
+git commit -m "feat(installer): classify a machine as fresh, upgradeable, or unusable"
+```
+
+---
+
+## Task 4: Extract ServiceControl and StoreHubPayload
+
+Spec §2. Both paths stop the service and lay down the payload, but in a different order relative to everything else. Pulling them out of `StoreHubInstaller` is what lets the upgrade sequence reorder without touching the fresh path.
+
+**This is a pure refactor.** `StoreHubInstaller` must behave identically afterwards; its existing tests are the proof and must not be edited.
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Installers/ServiceControl.cs`, `installer/IndyPOS.Bootstrapper/Installers/StoreHubPayload.cs`
+- Modify: `installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs` (`StopExistingServiceAsync`, `StartServiceAsync`, `ExtractStoreHubBinariesAsync`, `CopyDirectoryAsync`)
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Installers/StoreHubPayloadTests.cs`
+
+**Interfaces:**
+- Consumes: `InstallationConfig.ServiceName`, `InstallationConfig.StoreHubInstallPath`
+- Produces:
+  - `sealed class ServiceControl(string serviceName)` with
+    `Task<bool> StopAsync(TimeSpan timeout, CancellationToken ct)`,
+    `Task<bool> StartAsync(TimeSpan timeout, CancellationToken ct)`,
+    `bool Exists()`,
+    `bool IsRunning()`
+  - `static class StoreHubPayload` with
+    `static Task<bool> ExtractAsync(string destinationPath, IProgress<string>? log, CancellationToken ct)`
+
+- [ ] **Step 1: Write the failing test for the extractable seam**
+
+`ServiceControl` wraps `ServiceController` and has no seam — it is VM-tested, per spec §10 ("No seam — the VM's job"). `StoreHubPayload` does have one: the external-folder fallback.
+
+Create `tests/IndyPOS.Bootstrapper.Tests/Installers/StoreHubPayloadTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Tests.Installers;
+
+public class StoreHubPayloadTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "indypos-payload-" + Guid.NewGuid().ToString("N"));
+
+    public StoreHubPayloadTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExtractAsync_WithNoPayloadAvailable_ShouldReturnFalse()
+    {
+        // The test host has no embedded StoreHub.zip and no sibling folder, so this
+        // exercises the "binaries not found" branch without a 67 MB fixture.
+        var dest = Path.Combine(_dir, "StoreHub");
+        Directory.CreateDirectory(dest);
+
+        var result = await StoreHubPayload.ExtractAsync(dest, log: null, CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_WithNoPayloadAvailable_ShouldReportEveryLocationItTried()
+    {
+        var messages = new List<string>();
+        var dest = Path.Combine(_dir, "StoreHub");
+        Directory.CreateDirectory(dest);
+
+        await StoreHubPayload.ExtractAsync(
+            dest, new Progress<string>(messages.Add), CancellationToken.None);
+
+        // Progress<T> marshals asynchronously; drain before asserting.
+        await Task.Delay(50);
+        messages.Should().Contain(m => m.Contains("StoreHub.zip"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~StoreHubPayloadTests`
+Expected: FAIL — `StoreHubPayload` does not exist.
+
+- [ ] **Step 3: Create ServiceControl**
+
+Create `installer/IndyPOS.Bootstrapper/Installers/ServiceControl.cs`. Move the bodies of `StoreHubInstaller.StopExistingServiceAsync` and `StartServiceAsync` verbatim — no behaviour changes:
+
+```csharp
+using System.ServiceProcess;
+
+namespace IndyPOS.Bootstrapper.Installers;
+
+/// <summary>
+/// Stop / start / query the StoreHub Windows service.
+/// <para>USED BY BOTH INSTALL PATHS — fresh install and in-place upgrade. A change here
+/// ships to every store on the next release, not just to upgrades.</para>
+/// </summary>
+public sealed class ServiceControl(string serviceName)
+{
+    private readonly string _serviceName = serviceName;
+
+    public bool Exists() =>
+        ServiceController.GetServices().Any(s => s.ServiceName == _serviceName);
+
+    public bool IsRunning()
+    {
+        try
+        {
+            using var sc = new ServiceController(_serviceName);
+            return sc.Status == ServiceControllerStatus.Running;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Returns true when the service is stopped afterwards, including when absent.</summary>
+    public async Task<bool> StopAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var sc = new ServiceController(_serviceName);
+
+            if (sc.Status is ServiceControllerStatus.Running or ServiceControllerStatus.StartPending)
+            {
+                sc.Stop();
+                await Task.Run(
+                    () => sc.WaitForStatus(ServiceControllerStatus.Stopped, timeout),
+                    cancellationToken);
+            }
+
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            // Service doesn't exist - that's fine.
+            return true;
+        }
+        catch (System.ServiceProcess.TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> StartAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var sc = new ServiceController(_serviceName);
+
+            if (sc.Status == ServiceControllerStatus.Running)
+            {
+                return true;
+            }
+
+            sc.Start();
+            await Task.Run(
+                () => sc.WaitForStatus(ServiceControllerStatus.Running, timeout),
+                cancellationToken);
+
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Create StoreHubPayload**
+
+Create `installer/IndyPOS.Bootstrapper/Installers/StoreHubPayload.cs`. Move `ExtractStoreHubBinariesAsync` and `CopyDirectoryAsync` verbatim, taking `destinationPath` as a parameter instead of reading `Config`:
+
+```csharp
+using System.IO.Compression;
+
+namespace IndyPOS.Bootstrapper.Installers;
+
+/// <summary>
+/// Lays the StoreHub payload down over an install directory.
+/// <para>USED BY BOTH INSTALL PATHS — fresh install and in-place upgrade.</para>
+/// <para>Extraction is per-entry with <c>overwrite: true</c> and has no clean step, so the
+/// result is old-union-new. Rollback must therefore delete before copying back
+/// (see the upgrade design spec, section 5).</para>
+/// </summary>
+public static class StoreHubPayload
+{
+    public const string ResourceName = "IndyPOS.Bootstrapper.Resources.StoreHub.zip";
+
+    public static async Task<bool> ExtractAsync(
+        string destinationPath,
+        IProgress<string>? log = null,
+        CancellationToken cancellationToken = default)
+    {
+        var assembly = typeof(StoreHubPayload).Assembly;
+
+        using var resourceStream = assembly.GetManifestResourceStream(ResourceName);
+
+        if (resourceStream != null)
+        {
+            log?.Report("Extracting from embedded resources...");
+
+            using var archive = new ZipArchive(resourceStream, ZipArchiveMode.Read);
+            foreach (var entry in archive.Entries)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (string.IsNullOrEmpty(entry.Name))
+                {
+                    continue;
+                }
+
+                var destPath = Path.Combine(destinationPath, entry.FullName);
+                var destDir = Path.GetDirectoryName(destPath);
+
+                if (!string.IsNullOrEmpty(destDir) && !Directory.Exists(destDir))
+                {
+                    Directory.CreateDirectory(destDir);
+                }
+
+                entry.ExtractToFile(destPath, overwrite: true);
+            }
+
+            return true;
+        }
+
+        var externalZip = Path.Combine(AppContext.BaseDirectory, "StoreHub.zip");
+
+        if (File.Exists(externalZip))
+        {
+            log?.Report("Extracting from external package...");
+            ZipFile.ExtractToDirectory(externalZip, destinationPath, overwriteFiles: true);
+            return true;
+        }
+
+        var externalFolder = Path.Combine(AppContext.BaseDirectory, "StoreHub");
+
+        if (Directory.Exists(externalFolder))
+        {
+            log?.Report("Copying from external folder...");
+            await CopyDirectoryAsync(externalFolder, destinationPath, cancellationToken);
+            return true;
+        }
+
+        log?.Report("ERROR: StoreHub binaries not found!");
+        log?.Report("Expected locations:");
+        log?.Report($"  - Embedded resource: {ResourceName}");
+        log?.Report($"  - External zip: {externalZip}");
+        log?.Report($"  - External folder: {externalFolder}");
+
+        return false;
+    }
+
+    private static async Task CopyDirectoryAsync(
+        string sourceDir,
+        string destDir,
+        CancellationToken cancellationToken)
+    {
+        if (!Directory.Exists(destDir))
+        {
+            Directory.CreateDirectory(destDir);
+        }
+
+        foreach (var file in Directory.GetFiles(sourceDir))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var destFile = Path.Combine(destDir, Path.GetFileName(file));
+            await using var sourceStream = File.OpenRead(file);
+            await using var destStream = File.Create(destFile);
+            await sourceStream.CopyToAsync(destStream, cancellationToken);
+        }
+
+        foreach (var dir in Directory.GetDirectories(sourceDir))
+        {
+            var destSubDir = Path.Combine(destDir, Path.GetFileName(dir));
+            await CopyDirectoryAsync(dir, destSubDir, cancellationToken);
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Point StoreHubInstaller at the extracted units**
+
+In `installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs`:
+
+- Delete the private `ExtractStoreHubBinariesAsync`, `CopyDirectoryAsync`, and `StopExistingServiceAsync` methods.
+- Replace the `StopExistingServiceAsync(cancellationToken)` call inside `InstallAsync` with:
+
+```csharp
+            await new ServiceControl(Config.ServiceName)
+                .StopAsync(TimeSpan.FromSeconds(30), cancellationToken);
+```
+
+- Replace the `ExtractStoreHubBinariesAsync(log, cancellationToken)` call with:
+
+```csharp
+            var extractResult = await StoreHubPayload.ExtractAsync(
+                Config.StoreHubInstallPath, log, cancellationToken);
+```
+
+- Replace the body of `StartServiceAsync` with a delegation that preserves its result shape:
+
+```csharp
+    public async Task<StoreHubInstallerResult> StartServiceAsync(CancellationToken cancellationToken = default)
+    {
+        var started = await new ServiceControl(Config.ServiceName)
+            .StartAsync(TimeSpan.FromSeconds(60), cancellationToken);
+
+        return started
+            ? new StoreHubInstallerResult { Success = true }
+            : new StoreHubInstallerResult
+            {
+                Success = false,
+                ErrorMessage = $"Failed to start service: {Config.ServiceName}"
+            };
+    }
+```
+
+Remove the now-unused `using System.ServiceProcess;` and `using System.IO.Compression;` if the compiler flags them.
+
+- [ ] **Step 6: Run the full bootstrapper suite**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests`
+Expected: PASS — the 2 new `StoreHubPayloadTests` plus the pre-existing baseline of **101 pass / 8 skip**, now 103 pass / 8 skip. Any pre-existing test that changed result means the refactor was not behaviour-preserving; fix the refactor, not the test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Installers/ServiceControl.cs installer/IndyPOS.Bootstrapper/Installers/StoreHubPayload.cs installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs tests/IndyPOS.Bootstrapper.Tests/Installers/StoreHubPayloadTests.cs
+git commit -m "refactor(installer): extract ServiceControl and StoreHubPayload as shared units"
+```
+
+---
+
+## Task 5: Extract MigrationRunner and HealthProbe
+
+Spec §2. `MigrationRunner` deliberately does **not** carry the name `SchemaProvisioner` — it runs on both paths, whereas `DatabaseSetup` is fresh-only, and shared vocabulary between the two invites exactly the confusion that produced both original failures.
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Installers/MigrationRunner.cs`, `installer/IndyPOS.Bootstrapper/Installers/HealthProbe.cs`
+- Modify: `installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs` (`ProvisionDatabaseAsync`), `installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs` (`VerifyStoreHubHealthAsync`)
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Installers/MigrationRunnerTests.cs`
+
+**Interfaces:**
+- Consumes: nothing new
+- Produces:
+  - `sealed record MigrationRunResult(bool Success, bool AdminSeeded, string? ErrorMessage)`
+  - `static class MigrationRunner` with
+    `static Task<MigrationRunResult> RunAsync(string storeHubInstallPath, IProgress<string>? log, CancellationToken ct)` and
+    `internal static bool ParseAdminSeeded(string stdout)`
+  - `static class HealthProbe` with
+    `static Task<bool> IsReadyAsync(int port, int attempts = 5, CancellationToken ct = default)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/IndyPOS.Bootstrapper.Tests/Installers/MigrationRunnerTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Tests.Installers;
+
+public class MigrationRunnerTests
+{
+    [Theory]
+    [InlineData("ADMIN_SEEDED=true", true)]
+    [InlineData("admin_seeded=TRUE", true)]
+    [InlineData("noise\nADMIN_SEEDED=true\nmore noise", true)]
+    [InlineData("ADMIN_SEEDED=false", false)]
+    [InlineData("", false)]
+    public void ParseAdminSeeded_WithVariousStdout_ShouldReturnExpected(string stdout, bool expected)
+    {
+        MigrationRunner.ParseAdminSeeded(stdout).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheExecutableIsMissing_ShouldFailWithTheProbedPath()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "indypos-no-such-" + Guid.NewGuid().ToString("N"));
+
+        var result = await MigrationRunner.RunAsync(missing, log: null, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("IndyPOS.StoreHub.exe");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~MigrationRunnerTests`
+Expected: FAIL — `MigrationRunner` does not exist.
+
+- [ ] **Step 3: Create MigrationRunner**
+
+Create `installer/IndyPOS.Bootstrapper/Installers/MigrationRunner.cs`, moving the body of `StoreHubInstaller.ProvisionDatabaseAsync` verbatim:
+
+```csharp
+using System.Diagnostics;
+
+namespace IndyPOS.Bootstrapper.Installers;
+
+public sealed record MigrationRunResult(bool Success, bool AdminSeeded, string? ErrorMessage);
+
+/// <summary>
+/// Runs the StoreHub app's one-shot <c>migrate</c> command (apply EF migrations, seed the
+/// initial admin, exit).
+/// <para>USED BY BOTH INSTALL PATHS — fresh install and in-place upgrade. This is NOT
+/// <see cref="DatabaseSetup"/>, which creates the role, the database and the connection
+/// string and runs on a fresh install only.</para>
+/// <para>Doing this as a console step BEFORE the service starts keeps the first service
+/// start instant, so a schema build can't overrun the 30s SCM start timeout (error 1053).</para>
+/// </summary>
+public static class MigrationRunner
+{
+    public static async Task<MigrationRunResult> RunAsync(
+        string storeHubInstallPath,
+        IProgress<string>? log = null,
+        CancellationToken cancellationToken = default)
+    {
+        var exePath = Path.Combine(storeHubInstallPath, "IndyPOS.StoreHub.exe");
+        if (!File.Exists(exePath))
+        {
+            return new MigrationRunResult(false, false, $"StoreHub executable not found at {exePath}");
+        }
+
+        try
+        {
+            log?.Report("Applying database migrations and seeding admin...");
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = exePath,
+                Arguments = "migrate",
+                WorkingDirectory = storeHubInstallPath,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            // Production is the host default when unset, but be explicit so a stray dev
+            // env var can't divert provisioning to the EnsureCreated path.
+            psi.Environment["ASPNETCORE_ENVIRONMENT"] = "Production";
+
+            using var process = new Process { StartInfo = psi };
+            process.Start();
+
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await Task.WhenAll(stdoutTask, stderrTask);
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
+            await process.WaitForExitAsync(cancellationToken);
+
+            return process.ExitCode != 0
+                ? new MigrationRunResult(false, false,
+                    $"Database provisioning failed (exit {process.ExitCode}): {stderr.Trim()}")
+                : new MigrationRunResult(true, ParseAdminSeeded(stdout), null);
+        }
+        catch (Exception ex)
+        {
+            return new MigrationRunResult(false, false, $"Database provisioning failed: {ex.Message}");
+        }
+    }
+
+    internal static bool ParseAdminSeeded(string stdout) =>
+        stdout.Contains("ADMIN_SEEDED=true", StringComparison.OrdinalIgnoreCase);
+}
+```
+
+- [ ] **Step 4: Create HealthProbe**
+
+Create `installer/IndyPOS.Bootstrapper/Installers/HealthProbe.cs`, moving `InstallationOrchestrator.VerifyStoreHubHealthAsync` verbatim:
+
+```csharp
+namespace IndyPOS.Bootstrapper.Installers;
+
+/// <summary>
+/// Polls StoreHub's readiness endpoint.
+/// <para>USED BY BOTH INSTALL PATHS — fresh install and in-place upgrade. The upgrade
+/// path also runs it AFTER a rollback: starting the service is not evidence it came
+/// back (see the upgrade design spec, section 5).</para>
+/// </summary>
+public static class HealthProbe
+{
+    public static async Task<bool> IsReadyAsync(
+        int port,
+        int attempts = 5,
+        CancellationToken cancellationToken = default)
+    {
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        // /health/ready is StoreHub's DB-aware readiness probe. /health and /alive are
+        // dev-only (Aspire's IsDevelopment() guard in ServiceDefaults).
+        var healthUrl = $"http://localhost:{port}/health/ready";
+
+        for (var i = 0; i < attempts; i++)
+        {
+            try
+            {
+                var response = await client.GetAsync(healthUrl, cancellationToken);
+                if (response.IsSuccessStatusCode)
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // Retry
+            }
+
+            await Task.Delay(2000, cancellationToken);
+        }
+
+        return false;
+    }
+}
+```
+
+- [ ] **Step 5: Point the callers at the extracted units**
+
+In `StoreHubInstaller.cs`, replace the body of `ProvisionDatabaseAsync` with a delegation that keeps its existing return type:
+
+```csharp
+    public async Task<ProvisionDatabaseResult> ProvisionDatabaseAsync(
+        IProgress<string>? log = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await MigrationRunner.RunAsync(Config.StoreHubInstallPath, log, cancellationToken);
+
+        return new ProvisionDatabaseResult
+        {
+            Success = result.Success,
+            AdminSeeded = result.AdminSeeded,
+            ErrorMessage = result.ErrorMessage
+        };
+    }
+```
+
+Keep `internal static bool ParseAdminSeeded(string stdout) => MigrationRunner.ParseAdminSeeded(stdout);` on `StoreHubInstaller` so its existing tests still compile. Remove `using System.Diagnostics;` if unused.
+
+In `InstallationOrchestrator.cs`, delete the private `VerifyStoreHubHealthAsync` and change its call site to:
+
+```csharp
+        var healthOk = await HealthProbe.IsReadyAsync(config.HealthCheckPort, cancellationToken: cancellationToken);
+```
+
+- [ ] **Step 6: Run the full bootstrapper suite**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests`
+Expected: PASS — 109 pass / 8 skip (103 + 6 new). No pre-existing test may change result.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Installers/MigrationRunner.cs installer/IndyPOS.Bootstrapper/Installers/HealthProbe.cs installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs tests/IndyPOS.Bootstrapper.Tests/Installers/MigrationRunnerTests.cs
+git commit -m "refactor(installer): extract MigrationRunner and HealthProbe as shared units"
+```
+
+---
+
+## Task 6: Rename InstallationOrchestrator to FreshInstallOrchestrator
+
+Spec §2, and deliberately **its own mechanical commit**. The unprefixed name reads as "the orchestrator" and the new one as a special case, which is precisely backwards.
+
+**This task changes no logic.** It is the refactor safety gate: after it, `git diff` on this file across Tasks 4–6 must show only the rename and the delegation edits already made, with no reordering and no new conditionals.
+
+**Files:**
+- Rename: `installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs` → `installer/IndyPOS.Bootstrapper/Installers/FreshInstallOrchestrator.cs`
+- Modify: `installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs:61`, `installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs:11,41`
+- Rename: `tests/IndyPOS.Bootstrapper.Tests/Installers/InstallationOrchestratorTests.cs` → `tests/IndyPOS.Bootstrapper.Tests/Installers/FreshInstallOrchestratorTests.cs`
+
+**Interfaces:**
+- Consumes: everything from Tasks 4–5
+- Produces: `class FreshInstallOrchestrator` with the unchanged
+  `Task<InstallationResult> InstallAsync(InstallationConfig config, IProgress<InstallationProgress> progress, CancellationToken ct)`.
+  `InstallationException` and `InstallationResult` keep their names and stay in this file.
+
+- [ ] **Step 1: Rename the file with git so history follows**
+
+```bash
+git mv installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs installer/IndyPOS.Bootstrapper/Installers/FreshInstallOrchestrator.cs
+git mv tests/IndyPOS.Bootstrapper.Tests/Installers/InstallationOrchestratorTests.cs tests/IndyPOS.Bootstrapper.Tests/Installers/FreshInstallOrchestratorTests.cs
+```
+
+- [ ] **Step 2: Rename the type and add the frozen-path note**
+
+In `FreshInstallOrchestrator.cs`, change `public class InstallationOrchestrator` to `public class FreshInstallOrchestrator` and replace the class summary with:
+
+```csharp
+/// <summary>
+/// Orchestrates a FRESH IndyPOS installation onto a machine with no existing install.
+/// <para>An in-place upgrade is a different algorithm with different safety requirements,
+/// not a variation on this one — see <c>UpgradeOrchestrator</c>. Forcing both through one
+/// flow is what produced the locked-DLL failure this design exists to fix.</para>
+/// <para>FROZEN: this is the only production-validated path, and its fresh-only branches
+/// (sc create, first-time directory creation, DatabaseSetup, the Postgres install) never
+/// execute on the upgrade VM snapshot. Change it only for a fresh-install reason.</para>
+/// </summary>
+```
+
+In `FreshInstallOrchestratorTests.cs`, rename the test class to `FreshInstallOrchestratorTests` and update every `new InstallationOrchestrator()` to `new FreshInstallOrchestrator()`.
+
+- [ ] **Step 3: Update the two call sites**
+
+`Silent/SilentInstaller.cs:61`:
+
+```csharp
+            result = new FreshInstallOrchestrator()
+```
+
+`UI/InstallationWizard.cs` — line 11 field declaration and line 41 construction:
+
+```csharp
+    private readonly FreshInstallOrchestrator _orchestrator;
+```
+
+```csharp
+        _orchestrator = new FreshInstallOrchestrator();
+```
+
+- [ ] **Step 4: Verify nothing still references the old name**
+
+Run: `git grep -n "InstallationOrchestrator"`
+Expected: no matches outside `docs/` and `.claude/`. If a match remains in `installer/` or `tests/`, fix it.
+
+- [ ] **Step 5: Run the build and the full bootstrapper suite**
+
+Run: `dotnet build installer/IndyPOS.Bootstrapper/IndyPOS.Bootstrapper.csproj -c Release`
+Expected: 0 errors.
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests`
+Expected: PASS — 109 pass / 8 skip, identical to Task 5.
+
+- [ ] **Step 6: Confirm the refactor gate**
+
+Run: `git diff --stat HEAD~3 -- installer/IndyPOS.Bootstrapper/Installers/FreshInstallOrchestrator.cs`
+Read the diff. It must contain only: the class rename, the doc comment, the `HealthProbe.IsReadyAsync` delegation, and the deleted `VerifyStoreHubHealthAsync`. **If it contains any step reordering, any new conditional, or any change to the fresh-only branches, revert and redo.**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A installer/IndyPOS.Bootstrapper tests/IndyPOS.Bootstrapper.Tests
+git commit -m "refactor(installer): rename InstallationOrchestrator to FreshInstallOrchestrator"
+```
+
+---
+
+## Task 7: Read the installed POS app version
+
+Spec §12. The 2026-07-26 spike measured exit code `0` for **both** a real upgrade and a same-version repair, so `POS_UPDATED` cannot be inferred from it. The app binaries keep their own build stamp regardless of the package version, so Velopack's `current\sq.version` is the only truthful record of what is installed.
+
+`sq.version` is a **nuspec XML document**, not a bare version string — the spike confirmed this. Parsing it as text would silently produce garbage.
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Upgrade/PosAppVersion.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Upgrade/PosAppVersionTests.cs`
+
+**Interfaces:**
+- Consumes: `InstallationConfig.VelopackInstallPath` (already ends in `current`)
+- Produces: `static class PosAppVersion` with
+  `const string VersionFileName = "sq.version"` and
+  `static string? Read(string velopackCurrentDirectory)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/IndyPOS.Bootstrapper.Tests/Upgrade/PosAppVersionTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Upgrade;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class PosAppVersionTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "indypos-sqver-" + Guid.NewGuid().ToString("N"));
+
+    public PosAppVersionTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+    }
+
+    // Verbatim shape captured from the VM on 2026-07-26.
+    private const string RealSqVersion = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+        <metadata>
+        <id>IndyPOS.POS.v4</id>
+        <title>IndyPOS.POS.v4</title>
+        <version>4.0.1</version>
+        <channel>stable</channel>
+        <mainExe>IndyPOS.Windows.Forms.exe</mainExe>
+        </metadata>
+        </package>
+        """;
+
+    [Fact]
+    public void Read_WithARealSqVersionFile_ShouldReturnThePackageVersion()
+    {
+        File.WriteAllText(Path.Combine(_dir, "sq.version"), RealSqVersion);
+
+        PosAppVersion.Read(_dir).Should().Be("4.0.1");
+    }
+
+    [Fact]
+    public void Read_WhenTheFileIsAbsent_ShouldReturnNull()
+    {
+        PosAppVersion.Read(_dir).Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WhenTheDirectoryIsAbsent_ShouldReturnNull()
+    {
+        PosAppVersion.Read(Path.Combine(_dir, "nope")).Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithMalformedXml_ShouldReturnNull()
+    {
+        // Never throw on the reporting path: POS_UPDATED is telemetry, not a gate.
+        File.WriteAllText(Path.Combine(_dir, "sq.version"), "<package><metadata>");
+
+        PosAppVersion.Read(_dir).Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithNoVersionElement_ShouldReturnNull()
+    {
+        File.WriteAllText(Path.Combine(_dir, "sq.version"),
+            """<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"><metadata><id>x</id></metadata></package>""");
+
+        PosAppVersion.Read(_dir).Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~PosAppVersionTests`
+Expected: FAIL — `PosAppVersion` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `installer/IndyPOS.Bootstrapper/Upgrade/PosAppVersion.cs`:
+
+```csharp
+using System.Xml.Linq;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>
+/// Reads the POS app version Velopack believes is installed.
+/// <para>A 2026-07-26 VM spike established that <c>Setup.exe --silent</c> exits 0 whether it
+/// upgraded the app or merely repaired the same version, and that the binaries keep their
+/// own build stamp regardless of the package version. Comparing this file before and after
+/// is therefore the only honest way to derive POS_UPDATED.</para>
+/// </summary>
+public static class PosAppVersion
+{
+    public const string VersionFileName = "sq.version";
+
+    /// <param name="velopackCurrentDirectory">
+    /// The Velopack <c>current</c> directory — i.e. <see cref="Installers.InstallationConfig.VelopackInstallPath"/>.
+    /// </param>
+    /// <returns>The package version, or null when it cannot be established.</returns>
+    public static string? Read(string velopackCurrentDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(velopackCurrentDirectory))
+        {
+            return null;
+        }
+
+        var path = Path.Combine(velopackCurrentDirectory, VersionFileName);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            // sq.version is a nuspec document, not a bare version string. Match on local
+            // name so the packaging namespace cannot break this.
+            var version = XDocument.Load(path)
+                .Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "version")
+                ?.Value
+                .Trim();
+
+            return string.IsNullOrWhiteSpace(version) ? null : version;
+        }
+        catch (Exception ex) when (ex is System.Xml.XmlException or IOException)
+        {
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~PosAppVersionTests`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Upgrade/PosAppVersion.cs tests/IndyPOS.Bootstrapper.Tests/Upgrade/PosAppVersionTests.cs
+git commit -m "feat(installer): read the installed POS version from Velopack sq.version"
+```
+
+---
+
+## Task 8: UpgradeBackup
+
+Spec §4 step 3, §5 and §6. This is the artifact a failed upgrade is recovered from, so every one of its guarantees is load-bearing: ACL-locked (the dump is the entire sales history plus BCrypt admin hashes), integrity-checked (a disk-full `pg_dump` leaves a truncated file that still satisfies "present"), pruned (roughly 130 MB per stamp, forever, on a small retail PC nobody watches), and restored **delete-then-copy** (extraction is per-entry overwrite with no clean step, so the post-deploy tree is old ∪ new).
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Upgrade/UpgradeBackup.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeBackupTests.cs`
+
+**Interfaces:**
+- Consumes: `DatabaseSetup.TryRestrictFilePermissions(string)` (existing, `internal static`, returns `bool`)
+- Produces:
+  - `interface IProcessRunner { Task<ProcessRunResult> RunAsync(string fileName, string arguments, IReadOnlyDictionary<string, string>? environment, CancellationToken ct); }`
+  - `sealed record ProcessRunResult(int ExitCode, string StandardOutput, string StandardError)`
+  - `sealed class ExternalProcessRunner : IProcessRunner`
+  - `sealed record BackupResult(bool Success, string? StampDirectory, bool Locked, string? ErrorMessage)`
+  - `sealed class UpgradeBackup` with constructor
+    `UpgradeBackup(string backupsDirectory, string storeHubInstallPath, IProcessRunner processRunner, Func<string> stampFactory, Func<string, bool>? lockPath = null)`
+    and members
+    `const int MinimumDumpBytes = 1024`, `const int RetainedStamps = 2`,
+    `Task<BackupResult> CreateAsync(string pgDumpPath, string connectionString, CancellationToken ct)`,
+    `void RestoreStoreHubTree(string stampDirectory)`,
+    `int Prune()`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeBackupTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Upgrade;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class UpgradeBackupTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "indypos-backup-" + Guid.NewGuid().ToString("N"));
+
+    private readonly string _backups;
+    private readonly string _storeHub;
+    private readonly List<string> _lockedPaths = [];
+
+    public UpgradeBackupTests()
+    {
+        _backups = Path.Combine(_root, "backups");
+        _storeHub = Path.Combine(_root, "StoreHub");
+        Directory.CreateDirectory(_backups);
+        Directory.CreateDirectory(_storeHub);
+        File.WriteAllText(Path.Combine(_storeHub, "IndyPOS.StoreHub.exe"), "old binary");
+        File.WriteAllText(Path.Combine(_storeHub, "appsettings.json"), """{"store":{"id":"Rungrat-001"}}""");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    // Writes a dump of the requested size instead of shelling out to pg_dump.
+    private sealed class FakePgDump(int exitCode, int dumpBytes) : IProcessRunner
+    {
+        public string? LastArguments { get; private set; }
+
+        public Task<ProcessRunResult> RunAsync(
+            string fileName, string arguments,
+            IReadOnlyDictionary<string, string>? environment, CancellationToken ct)
+        {
+            LastArguments = arguments;
+
+            // -f <path> is the last argument; mirror what pg_dump would produce.
+            var marker = "-f \"";
+            var start = arguments.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+            var path = arguments[start..arguments.IndexOf('"', start)];
+
+            if (dumpBytes > 0)
+            {
+                File.WriteAllBytes(path, new byte[dumpBytes]);
+            }
+
+            return Task.FromResult(new ProcessRunResult(exitCode, "", exitCode == 0 ? "" : "boom"));
+        }
+    }
+
+    private UpgradeBackup Build(IProcessRunner runner, string stamp = "20260726-010203") =>
+        new(_backups, _storeHub, runner, () => stamp, p => { _lockedPaths.Add(p); return true; });
+
+    private const string Conn = "Host=127.0.0.1;Port=5432;Database=indypos_storehub;Username=indypos_app;Password=s3cret";
+
+    [Fact]
+    public async Task CreateAsync_OnSuccess_ShouldCopyTheStoreHubTreeIntoTheStamp()
+    {
+        var result = await Build(new FakePgDump(0, 4096)).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        File.ReadAllText(Path.Combine(result.StampDirectory!, "StoreHub", "IndyPOS.StoreHub.exe"))
+            .Should().Be("old binary");
+    }
+
+    [Fact]
+    public async Task CreateAsync_OnSuccess_ShouldWriteTheDumpBesideTheTree()
+    {
+        var result = await Build(new FakePgDump(0, 4096)).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        File.Exists(Path.Combine(result.StampDirectory!, "storehub.dump")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateAsync_OnSuccess_ShouldLockTheStampAndBothArtifacts()
+    {
+        // BackupsDirectory inherits ProgramData's DACL, which grants BUILTIN\Users read.
+        // The dump is the whole sales history plus BCrypt admin hashes.
+        var result = await Build(new FakePgDump(0, 4096)).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        result.Locked.Should().BeTrue();
+        _lockedPaths.Should().Contain(result.StampDirectory!);
+        _lockedPaths.Should().Contain(Path.Combine(result.StampDirectory!, "storehub.dump"));
+        _lockedPaths.Should().Contain(Path.Combine(result.StampDirectory!, "StoreHub", "appsettings.json"));
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenPgDumpFails_ShouldReportFailure()
+    {
+        var result = await Build(new FakePgDump(1, 4096)).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("pg_dump");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenTheDumpIsTruncated_ShouldRejectIt()
+    {
+        // A disk-full pg_dump can exit 0 having written almost nothing; "present" is not
+        // "restorable", and BACKUP_DIR would otherwise advertise a dead artifact.
+        var result = await Build(new FakePgDump(0, 10)).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("too small");
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldNeverPutThePasswordOnTheCommandLine()
+    {
+        // A command line is visible to every local process.
+        var runner = new FakePgDump(0, 4096);
+        await Build(runner).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        runner.LastArguments.Should().NotContain("s3cret");
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldUseCustomFormatSoPgRestoreCanReadIt()
+    {
+        var runner = new FakePgDump(0, 4096);
+        await Build(runner).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        runner.LastArguments.Should().Contain("-Fc");
+    }
+
+    [Fact]
+    public void RestoreStoreHubTree_ShouldDeleteBeforeCopying()
+    {
+        // Extraction is per-entry overwrite with no clean step, so after a deploy the tree
+        // is old-union-new. Copying over that leaves new-version files behind.
+        var stamp = Path.Combine(_backups, "20260726-010203");
+        Directory.CreateDirectory(Path.Combine(stamp, "StoreHub"));
+        File.WriteAllText(Path.Combine(stamp, "StoreHub", "IndyPOS.StoreHub.exe"), "old binary");
+
+        File.WriteAllText(Path.Combine(_storeHub, "BrandNew.dll"), "from the failed upgrade");
+
+        Build(new FakePgDump(0, 4096)).RestoreStoreHubTree(stamp);
+
+        File.Exists(Path.Combine(_storeHub, "BrandNew.dll")).Should().BeFalse();
+        File.ReadAllText(Path.Combine(_storeHub, "IndyPOS.StoreHub.exe")).Should().Be("old binary");
+    }
+
+    [Fact]
+    public void RestoreStoreHubTree_WhenTheBackupIsMissing_ShouldThrow()
+    {
+        // Silently doing nothing here would report a rollback that never happened.
+        var act = () => Build(new FakePgDump(0, 4096))
+            .RestoreStoreHubTree(Path.Combine(_backups, "no-such-stamp"));
+
+        act.Should().Throw<DirectoryNotFoundException>();
+    }
+
+    [Fact]
+    public void Prune_WithMoreThanTheRetainedStamps_ShouldKeepOnlyTheNewest()
+    {
+        foreach (var stamp in new[] { "20260101-000000", "20260201-000000", "20260301-000000", "20260401-000000" })
+        {
+            Directory.CreateDirectory(Path.Combine(_backups, stamp));
+        }
+
+        var removed = Build(new FakePgDump(0, 4096)).Prune();
+
+        removed.Should().Be(2);
+        Directory.GetDirectories(_backups).Select(Path.GetFileName)
+            .Should().BeEquivalentTo("20260301-000000", "20260401-000000");
+    }
+
+    [Fact]
+    public void Prune_WithFewerThanTheRetainedStamps_ShouldRemoveNothing()
+    {
+        Directory.CreateDirectory(Path.Combine(_backups, "20260101-000000"));
+
+        Build(new FakePgDump(0, 4096)).Prune().Should().Be(0);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~UpgradeBackupTests`
+Expected: FAIL — `UpgradeBackup`, `IProcessRunner`, `ProcessRunResult` do not exist.
+
+- [ ] **Step 3: Write the process-runner seam**
+
+Create `installer/IndyPOS.Bootstrapper/Upgrade/IProcessRunner.cs`:
+
+```csharp
+using System.Diagnostics;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+public sealed record ProcessRunResult(int ExitCode, string StandardOutput, string StandardError);
+
+/// <summary>Seam over external tools (pg_dump, Velopack Setup.exe) so the sequence is testable.</summary>
+public interface IProcessRunner
+{
+    Task<ProcessRunResult> RunAsync(
+        string fileName,
+        string arguments,
+        IReadOnlyDictionary<string, string>? environment,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class ExternalProcessRunner : IProcessRunner
+{
+    public async Task<ProcessRunResult> RunAsync(
+        string fileName,
+        string arguments,
+        IReadOnlyDictionary<string, string>? environment,
+        CancellationToken cancellationToken = default)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        if (environment is not null)
+        {
+            foreach (var (key, value) in environment)
+            {
+                psi.Environment[key] = value;
+            }
+        }
+
+        using var process = new Process { StartInfo = psi };
+        process.Start();
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await Task.WhenAll(stdoutTask, stderrTask);
+        await process.WaitForExitAsync(cancellationToken);
+
+        return new ProcessRunResult(process.ExitCode, await stdoutTask, await stderrTask);
+    }
+}
+```
+
+- [ ] **Step 4: Write UpgradeBackup**
+
+Create `installer/IndyPOS.Bootstrapper/Upgrade/UpgradeBackup.cs`:
+
+```csharp
+using Npgsql;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+public sealed record BackupResult(bool Success, string? StampDirectory, bool Locked, string? ErrorMessage);
+
+/// <summary>
+/// Takes and restores the pre-upgrade recovery artifacts (see the upgrade design spec,
+/// sections 4, 5 and 6). Everything here runs ABOVE the mutation line except
+/// <see cref="RestoreStoreHubTree"/>, which runs on the rollback path.
+/// </summary>
+public sealed class UpgradeBackup(
+    string backupsDirectory,
+    string storeHubInstallPath,
+    IProcessRunner processRunner,
+    Func<string> stampFactory,
+    Func<string, bool>? lockPath = null)
+{
+    public const string DumpFileName = "storehub.dump";
+
+    /// <summary>A pg_dump that exits 0 having written less than this did not really succeed.</summary>
+    public const int MinimumDumpBytes = 1024;
+
+    /// <summary>Roughly 130 MB per stamp, forever, on a small unattended retail PC.</summary>
+    public const int RetainedStamps = 2;
+
+    private readonly Func<string, bool> _lockPath =
+        lockPath ?? DatabaseSetup.TryRestrictFilePermissions;
+
+    public async Task<BackupResult> CreateAsync(
+        string pgDumpPath,
+        string connectionString,
+        CancellationToken cancellationToken = default)
+    {
+        var stampDir = Path.Combine(backupsDirectory, stampFactory());
+
+        try
+        {
+            // BackupsDirectory exists in InstallationConfig and the manifest, but only
+            // DatabaseSetup.CreateDirectories guarantees it — and that never runs here.
+            Directory.CreateDirectory(stampDir);
+
+            var dumpPath = Path.Combine(stampDir, DumpFileName);
+            var dumpFailure = await RunPgDumpAsync(pgDumpPath, connectionString, dumpPath, cancellationToken);
+            if (dumpFailure is not null)
+            {
+                return new BackupResult(false, stampDir, false, dumpFailure);
+            }
+
+            var treeDestination = Path.Combine(stampDir, "StoreHub");
+            CopyDirectory(storeHubInstallPath, treeDestination);
+
+            var locked = LockTree(stampDir, dumpPath, treeDestination);
+
+            Prune();
+
+            return new BackupResult(true, stampDir, locked, null);
+        }
+        catch (Exception ex)
+        {
+            return new BackupResult(false, stampDir, false, ex.Message);
+        }
+    }
+
+    /// <returns>An error message, or null on success.</returns>
+    private async Task<string?> RunPgDumpAsync(
+        string pgDumpPath, string connectionString, string dumpPath, CancellationToken cancellationToken)
+    {
+        // NpgsqlConnectionStringBuilder, not string splitting: the password may contain
+        // anything, and a mis-split silently dumps the wrong database.
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+
+        var arguments =
+            $"--host={builder.Host} --port={builder.Port} --username={builder.Username} " +
+            $"--dbname={builder.Database} --no-password -Fc -f \"{dumpPath}\"";
+
+        // PGPASSWORD via the environment, never the command line: a command line is
+        // visible to every local process.
+        var environment = new Dictionary<string, string> { ["PGPASSWORD"] = builder.Password ?? "" };
+
+        var run = await processRunner.RunAsync(pgDumpPath, arguments, environment, cancellationToken);
+
+        if (run.ExitCode != 0)
+        {
+            return $"pg_dump failed (exit {run.ExitCode}): {run.StandardError.Trim()}";
+        }
+
+        if (!File.Exists(dumpPath))
+        {
+            return "pg_dump reported success but produced no file.";
+        }
+
+        var length = new FileInfo(dumpPath).Length;
+        return length < MinimumDumpBytes
+            ? $"pg_dump produced a file that is too small to be a valid dump ({length} bytes)."
+            : null;
+    }
+
+    private bool LockTree(string stampDir, string dumpPath, string treeDestination)
+    {
+        var locked = _lockPath(stampDir) & _lockPath(dumpPath);
+
+        foreach (var file in Directory.EnumerateFiles(treeDestination, "*", SearchOption.AllDirectories))
+        {
+            locked &= _lockPath(file);
+        }
+
+        return locked;
+    }
+
+    /// <summary>
+    /// Puts the backed-up StoreHub tree back. DELETE-then-copy: extraction overwrites
+    /// per entry with no clean step, so the failed tree is old-union-new and copying over
+    /// it would strand new-version files (see the design spec, section 5).
+    /// </summary>
+    public void RestoreStoreHubTree(string stampDirectory)
+    {
+        var source = Path.Combine(stampDirectory, "StoreHub");
+
+        if (!Directory.Exists(source))
+        {
+            throw new DirectoryNotFoundException(
+                $"No StoreHub backup at {source}; cannot roll back. The database dump, if any, " +
+                $"is still at {Path.Combine(stampDirectory, DumpFileName)}.");
+        }
+
+        if (Directory.Exists(storeHubInstallPath))
+        {
+            Directory.Delete(storeHubInstallPath, recursive: true);
+        }
+
+        CopyDirectory(source, storeHubInstallPath);
+    }
+
+    /// <summary>Keeps the newest <see cref="RetainedStamps"/> stamps. Returns how many it removed.</summary>
+    public int Prune()
+    {
+        if (!Directory.Exists(backupsDirectory))
+        {
+            return 0;
+        }
+
+        // Stamp names are yyyyMMdd-HHmmss, so ordinal descending IS newest-first, and it
+        // does not depend on directory timestamps a restore may have rewritten.
+        var stale = Directory.GetDirectories(backupsDirectory)
+            .OrderByDescending(Path.GetFileName, StringComparer.Ordinal)
+            .Skip(RetainedStamps)
+            .ToList();
+
+        foreach (var dir in stale)
+        {
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Retention is housekeeping; never fail an upgrade over it.
+            }
+        }
+
+        return stale.Count;
+    }
+
+    private static void CopyDirectory(string sourceDir, string destDir)
+    {
+        Directory.CreateDirectory(destDir);
+
+        foreach (var file in Directory.GetFiles(sourceDir))
+        {
+            File.Copy(file, Path.Combine(destDir, Path.GetFileName(file)), overwrite: true);
+        }
+
+        foreach (var dir in Directory.GetDirectories(sourceDir))
+        {
+            CopyDirectory(dir, Path.Combine(destDir, Path.GetFileName(dir)));
+        }
+    }
+}
+```
+
+`DatabaseSetup.TryRestrictFilePermissions` is `internal static` and both types are in the same assembly, so no accessibility change is needed. It is documented for files; confirm it also works on a directory — `FileInfo.GetAccessControl` on a directory path throws, so if the `_lockPath(stampDir)` call fails at runtime, add a `TryRestrictDirectoryPermissions` sibling using `DirectoryInfo`/`DirectorySecurity` with the same two SIDs and `SetAccessRuleProtection(true, false)`.
+
+Add `<PackageReference Include="Npgsql" />` to `installer/IndyPOS.Bootstrapper/IndyPOS.Bootstrapper.csproj` if it is not already referenced (check first: `git grep -n Npgsql installer/IndyPOS.Bootstrapper/IndyPOS.Bootstrapper.csproj`).
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~UpgradeBackupTests`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Upgrade/IProcessRunner.cs installer/IndyPOS.Bootstrapper/Upgrade/UpgradeBackup.cs installer/IndyPOS.Bootstrapper/IndyPOS.Bootstrapper.csproj tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeBackupTests.cs
+git commit -m "feat(installer): back up the database and StoreHub tree before an upgrade"
+```
+
+---
+
+## Task 9: UpgradePreflight
+
+Spec §4 step 1. Everything here runs **above the mutation line** — a failure means nothing has been touched and the store is still serving on its current version.
+
+The prerequisite ensures are not optional padding. The bundled FC Subject fonts were only added on 2026-07-14, so a store installed before that build would receive a UI-polish release and render it in a fallback face — a visible regression delivered *by* the upgrade. A future .NET major bump would otherwise deploy binaries the machine cannot run, surfacing as a dead service *after* the mutation line.
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Upgrade/UpgradePreflight.cs`
+- Modify: `installer/IndyPOS.Bootstrapper/Installers/PostgresInstaller.cs` (expose the finder)
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradePreflightTests.cs`
+
+**Interfaces:**
+- Consumes: `DetectedInstall` (Task 3), `InstallationConfig`, `FontInstaller.Install`, `DotNetInstaller.EnsureInstalledAsync`, `VCRedistInstaller.EnsureInstalledAsync`
+- Produces:
+  - `sealed record PreflightResult(bool Ok, string? PgDumpPath, string? ConnectionString, string? FailureReason, bool IsDowngrade)`
+  - `static class UpgradePreflight` with
+    `static (bool Ok, string? Reason, bool IsDowngrade) CheckVersions(string? installedVersion, string installerVersion)`,
+    `static bool IsPosAppRunning()`,
+    `static string? LocatePgDump(string manifestBinPath, int expectedMajor)`
+  - On `PostgresInstaller`: `internal static string? FindPostgresBinPath()` — a thin, testable wrapper over the existing private `FindPostgresInstallation()` that returns just `BinPath`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradePreflightTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Upgrade;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class UpgradePreflightTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "indypos-preflight-" + Guid.NewGuid().ToString("N"));
+
+    public UpgradePreflightTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CheckVersions_WhenTheInstallerIsNewer_ShouldPass()
+    {
+        var (ok, _, isDowngrade) = UpgradePreflight.CheckVersions("4.0.0", "4.1.0");
+
+        ok.Should().BeTrue();
+        isDowngrade.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CheckVersions_WithTheSameVersion_ShouldPassAsARepair()
+    {
+        // Directory.Build.props pins the version and needs a manual bump, so a
+        // same-version run is the common case during development. The 2026-07-26 spike
+        // measured it as a safe 2.5s repair.
+        var (ok, _, isDowngrade) = UpgradePreflight.CheckVersions("4.0.0", "4.0.0");
+
+        ok.Should().BeTrue();
+        isDowngrade.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CheckVersions_WhenTheInstallerIsOlder_ShouldRefuse()
+    {
+        var (ok, reason, isDowngrade) = UpgradePreflight.CheckVersions("4.1.0", "4.0.0");
+
+        ok.Should().BeFalse();
+        isDowngrade.Should().BeTrue();
+        reason.Should().Contain("4.1.0");
+    }
+
+    [Fact]
+    public void CheckVersions_WithAnUnreadableInstalledVersion_ShouldPass()
+    {
+        // A manifest without installVersion is decorative, not a blocker.
+        UpgradePreflight.CheckVersions(null, "4.0.0").Ok.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LocatePgDump_WhenTheManifestPathIsGood_ShouldUseIt()
+    {
+        var bin = Path.Combine(_dir, "18", "bin");
+        Directory.CreateDirectory(bin);
+        File.WriteAllText(Path.Combine(bin, "pg_dump.exe"), "");
+
+        UpgradePreflight.LocatePgDump(bin, expectedMajor: 18)
+            .Should().Be(Path.Combine(bin, "pg_dump.exe"));
+    }
+
+    [Fact]
+    public void LocatePgDump_WhenTheManifestPathIsStale_ShouldReturnNullRatherThanAWrongMajor()
+    {
+        // FindPostgresInstallation probes 18 -> 17 -> 16; a pg_dump from a different
+        // major can refuse the dump outright, so assert the major rather than guess.
+        var bin = Path.Combine(_dir, "16", "bin");
+        Directory.CreateDirectory(bin);
+        File.WriteAllText(Path.Combine(bin, "pg_dump.exe"), "");
+
+        UpgradePreflight.LocatePgDump(bin, expectedMajor: 18).Should().BeNull();
+    }
+
+    [Fact]
+    public void LocatePgDump_WhenTheManifestPathDoesNotExist_ShouldReturnNull()
+    {
+        UpgradePreflight.LocatePgDump(Path.Combine(_dir, "nope"), expectedMajor: 18).Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~UpgradePreflightTests`
+Expected: FAIL — `UpgradePreflight` does not exist.
+
+- [ ] **Step 3: Expose the Postgres finder**
+
+In `installer/IndyPOS.Bootstrapper/Installers/PostgresInstaller.cs`, add next to the existing private `FindPostgresInstallation()`:
+
+```csharp
+    /// <summary>
+    /// The bin directory of the PostgreSQL install this machine actually has, or null.
+    /// Exposed for the upgrade path's pg_dump fallback: the manifest's PostgresBinPath
+    /// can be stale. Note this probes 18 -> 17 -> 16, so callers must assert the major.
+    /// </summary>
+    internal static string? FindPostgresBinPath() => FindPostgresInstallation()?.BinPath;
+```
+
+- [ ] **Step 4: Write UpgradePreflight**
+
+Create `installer/IndyPOS.Bootstrapper/Upgrade/UpgradePreflight.cs`:
+
+```csharp
+using System.Diagnostics;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+public sealed record PreflightResult(
+    bool Ok,
+    string? PgDumpPath,
+    string? ConnectionString,
+    string? FailureReason,
+    bool IsDowngrade);
+
+/// <summary>
+/// Step 1 of the upgrade sequence. Everything here runs ABOVE the mutation line: a
+/// failure leaves the store untouched and still serving its current version.
+/// </summary>
+public static class UpgradePreflight
+{
+    /// <summary>Enough headroom for the dump plus a full copy of the StoreHub tree.</summary>
+    public const long RequiredFreeBytes = 2L * 1024 * 1024 * 1024;
+
+    private const string PosProcessName = "IndyPOS.Windows.Forms";
+
+    /// <summary>
+    /// Refuse a downgrade; allow a same-version repair. Rollback restores binaries and
+    /// config but not schema, so running older binaries against a newer schema is exactly
+    /// the state the forward-only migration rule cannot protect.
+    /// </summary>
+    public static (bool Ok, string? Reason, bool IsDowngrade) CheckVersions(
+        string? installedVersion, string installerVersion)
+    {
+        if (!Version.TryParse(installedVersion, out var installed) ||
+            !Version.TryParse(installerVersion, out var installing))
+        {
+            return (true, null, false);
+        }
+
+        return installing < installed
+            ? (false,
+               $"This installer is version {installerVersion} but the machine already runs " +
+               $"{installedVersion}. Downgrading is refused: it would leave older binaries " +
+               "against a newer database schema.",
+               true)
+            : (true, null, false);
+    }
+
+    /// <summary>
+    /// Two Velopack processes on one install root can leave the POS unlaunchable, and the
+    /// POS app self-updates independently, so it may be mid-update already.
+    /// </summary>
+    public static bool IsPosAppRunning() =>
+        Process.GetProcessesByName(PosProcessName).Length > 0;
+
+    /// <summary>
+    /// The manifest's PostgresBinPath can be stale, so fall back to probing — but assert
+    /// the major matches, because the fallback happily returns 17 or 16.
+    /// </summary>
+    public static string? LocatePgDump(string manifestBinPath, int expectedMajor)
+    {
+        var candidate = Probe(manifestBinPath, expectedMajor);
+        if (candidate is not null)
+        {
+            return candidate;
+        }
+
+        var discovered = PostgresInstaller.FindPostgresBinPath();
+        return discovered is null ? null : Probe(discovered, expectedMajor);
+    }
+
+    private static string? Probe(string binPath, int expectedMajor)
+    {
+        if (string.IsNullOrWhiteSpace(binPath))
+        {
+            return null;
+        }
+
+        var exe = Path.Combine(binPath, "pg_dump.exe");
+        if (!File.Exists(exe))
+        {
+            return null;
+        }
+
+        // Layout is ...\PostgreSQL\<major>\bin, so the grandparent names the major.
+        var majorDir = Path.GetFileName(Path.GetDirectoryName(binPath.TrimEnd(Path.DirectorySeparatorChar)));
+
+        return int.TryParse(majorDir, out var major) && major == expectedMajor ? exe : null;
+    }
+
+    public static bool HasFreeSpace(string path)
+    {
+        try
+        {
+            return new DriveInfo(Path.GetPathRoot(Path.GetFullPath(path))!).AvailableFreeSpace
+                   >= RequiredFreeBytes;
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException)
+        {
+            // Unknowable is not the same as insufficient; let the dump's own integrity
+            // check be the backstop rather than blocking a legitimate upgrade.
+            return true;
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~UpgradePreflightTests`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Upgrade/UpgradePreflight.cs installer/IndyPOS.Bootstrapper/Installers/PostgresInstaller.cs tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradePreflightTests.cs
+git commit -m "feat(installer): add upgrade preflight checks above the mutation line"
+```
+
+---
+
+## Task 10: Upgrade outcomes and markers
+
+Spec §7. `SilentOutcomeMapper.Map` ends in `_ => throw new ArgumentOutOfRangeException`, so every new outcome needs an explicit arm. New **sibling records** rather than widening `InstallSucceeded`, which is already a five-field positional record belonging to the frozen fresh path.
+
+The admin-marker suppression is not cosmetic: `SuccessMarkers` always emits `ADMIN_SEEDED`, which on an upgrade is necessarily `false` (a fresh install stripped the `InitialAdmin` block, so the seeder skips), and the `else` branch then emits `RESET_HINT=run "IndyPOS.StoreHub.exe reset-admin"…` — advising a bootstrap-password reissue on a store whose admin is perfectly fine.
+
+**Files:**
+- Modify: `installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs`
+
+**Interfaces:**
+- Consumes: nothing new
+- Produces, all `: SilentOutcome`:
+  - `sealed record UpgradeSucceeded(string? FromVersion, string ToVersion, bool ServiceStarted, bool HealthOk, string BackupDir, bool BackupLocked, bool PosUpdated)`
+  - `sealed record UpgradeFailed(string Message, bool RolledBack, bool ServiceStarted, bool HealthOk, string? BackupDir)`
+  - `sealed record UnusableInstall(string Reason)`
+  - `sealed record DowngradeRefused(string InstalledVersion, string InstallerVersion)`
+  - `static string SilentOutcomeMapper.ModeMarker(InstallMode mode)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs` (add `using IndyPOS.Bootstrapper.Upgrade;`):
+
+```csharp
+    [Fact]
+    public void Map_WithUpgradeSucceeded_ShouldReturnZeroAndTheUpgradeMarkers()
+    {
+        var outcome = new UpgradeSucceeded("4.0.0", "4.1.0", ServiceStarted: true, HealthOk: true,
+            BackupDir: @"C:\ProgramData\IndyPOS\v4\backups\20260726-010203", BackupLocked: true,
+            PosUpdated: true);
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(0);
+        markers.Should().Contain("INDYPOS_MARKER RESULT=success");
+        markers.Should().Contain("INDYPOS_MARKER SERVICE_STARTED=true");
+        markers.Should().Contain("INDYPOS_MARKER HEALTH=ok");
+        markers.Should().Contain(@"INDYPOS_MARKER BACKUP_DIR=C:\ProgramData\IndyPOS\v4\backups\20260726-010203");
+        markers.Should().Contain("INDYPOS_MARKER BACKUP_LOCKED=true");
+        markers.Should().Contain("INDYPOS_MARKER POS_UPDATED=true");
+        markers.Should().Contain("INDYPOS_MARKER FROM_VERSION=4.0.0");
+        markers.Should().Contain("INDYPOS_MARKER TO_VERSION=4.1.0");
+    }
+
+    [Fact]
+    public void Map_WithUpgradeSucceeded_ShouldSuppressTheFreshPathAdminMarkers()
+    {
+        // ADMIN_SEEDED is necessarily false on an upgrade, and its else-branch would
+        // advise reissuing a bootstrap password for a store whose admin is fine.
+        var outcome = new UpgradeSucceeded("4.0.0", "4.1.0", true, true, @"C:\b", true, true);
+
+        var (_, markers) = SilentOutcomeMapper.Map(outcome);
+
+        markers.Should().NotContain(m => m.StartsWith("INDYPOS_MARKER ADMIN_SEEDED="));
+        markers.Should().NotContain(m => m.StartsWith("INDYPOS_MARKER RESET_HINT="));
+        markers.Should().NotContain(m => m.StartsWith("INDYPOS_MARKER CRED_FILE="));
+    }
+
+    [Fact]
+    public void Map_WithAPosOnlyFailure_ShouldStillReportTheServerAsServing()
+    {
+        // Spec section 5 row 8: no rollback -- the server is upgraded and serving. The 2026-07-26
+        // spike confirmed the POS step cannot disturb the service.
+        var outcome = new UpgradeFailed("Velopack exited 1", RolledBack: false,
+            ServiceStarted: true, HealthOk: true, BackupDir: @"C:\b");
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(2);
+        markers.Should().Contain("INDYPOS_MARKER RESULT=failed");
+        markers.Should().Contain("INDYPOS_MARKER SERVICE_STARTED=true");
+        markers.Should().Contain("INDYPOS_MARKER POS_UPDATED=false");
+        markers.Should().Contain("INDYPOS_MARKER ROLLED_BACK=false");
+    }
+
+    [Fact]
+    public void Map_WithARolledBackFailure_ShouldReportThePostRollbackHealth()
+    {
+        // Starting the service is not evidence it came back; without the probe a rollback
+        // can claim the store resumed while the store is dead.
+        var outcome = new UpgradeFailed("migrate failed", RolledBack: true,
+            ServiceStarted: true, HealthOk: false, BackupDir: @"C:\b\20260726-010203");
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(2);
+        markers.Should().Contain("INDYPOS_MARKER ROLLED_BACK=true");
+        markers.Should().Contain("INDYPOS_MARKER HEALTH=failed");
+        markers.Should().Contain(@"INDYPOS_MARKER BACKUP_DIR=C:\b\20260726-010203");
+    }
+
+    [Fact]
+    public void Map_WithAnUnusableInstall_ShouldReturnFiveAndCarryTheReason()
+    {
+        var (exit, markers) = SilentOutcomeMapper.Map(new UnusableInstall("Store:Type is missing"));
+
+        exit.Should().Be(5);
+        markers.Should().Contain("INDYPOS_MARKER RESULT=failed");
+        markers.Should().Contain("INDYPOS_MARKER REASON=Store:Type is missing");
+    }
+
+    [Fact]
+    public void Map_WithADowngrade_ShouldReturnSix()
+    {
+        var (exit, markers) = SilentOutcomeMapper.Map(new DowngradeRefused("4.1.0", "4.0.0"));
+
+        exit.Should().Be(6);
+        markers.Should().Contain("INDYPOS_MARKER RESULT=failed");
+        markers.Should().Contain(m => m.Contains("4.1.0") && m.Contains("4.0.0"));
+    }
+
+    [Theory]
+    [InlineData(InstallMode.Fresh, "INDYPOS_MARKER MODE=fresh")]
+    [InlineData(InstallMode.Upgrade, "INDYPOS_MARKER MODE=upgrade")]
+    [InlineData(InstallMode.Unusable, "INDYPOS_MARKER MODE=unusable")]
+    public void ModeMarker_ForEachMode_ShouldEmitTheLowercaseName(InstallMode mode, string expected)
+    {
+        // Months later, a store's own install-latest.log must answer "which path ran"
+        // without anyone reading C#.
+        SilentOutcomeMapper.ModeMarker(mode).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Map_ForEveryOutcomeType_ShouldHaveAnExplicitArm()
+    {
+        // Map ends in a throwing discard, so a new outcome silently crashes the run.
+        var outcomes = new SilentOutcome[]
+        {
+            new InstallSucceeded(true, @"C:\x", true, true, true),
+            new InstallFailed("x"),
+            new InstallTimedOut(),
+            new UsageErrorOutcome("x"),
+            new NotElevatedOutcome(),
+            new UpgradeSucceeded("4.0.0", "4.1.0", true, true, @"C:\b", true, true),
+            new UpgradeFailed("x", false, true, true, @"C:\b"),
+            new UnusableInstall("x"),
+            new DowngradeRefused("4.1.0", "4.0.0")
+        };
+
+        foreach (var outcome in outcomes)
+        {
+            var act = () => SilentOutcomeMapper.Map(outcome);
+            act.Should().NotThrow($"{outcome.GetType().Name} needs an explicit arm");
+        }
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~SilentOutcomeMapperTests`
+Expected: FAIL — the new outcome records do not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+In `installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs`, add `using IndyPOS.Bootstrapper.Upgrade;` and the new records beside the existing ones:
+
+```csharp
+/// <summary>
+/// An in-place upgrade completed. Sibling of <see cref="InstallSucceeded"/> rather than a
+/// widening of it: that record is a five-field positional type belonging to the frozen
+/// fresh path, and an upgrade reports a genuinely different set of facts.
+/// </summary>
+public sealed record UpgradeSucceeded(
+    string? FromVersion, string ToVersion, bool ServiceStarted, bool HealthOk,
+    string BackupDir, bool BackupLocked, bool PosUpdated) : SilentOutcome;
+
+/// <param name="ServiceStarted">Post-rollback when <paramref name="RolledBack"/> is true.</param>
+/// <param name="HealthOk">Post-rollback when <paramref name="RolledBack"/> is true.</param>
+public sealed record UpgradeFailed(
+    string Message, bool RolledBack, bool ServiceStarted, bool HealthOk,
+    string? BackupDir) : SilentOutcome;
+
+public sealed record UnusableInstall(string Reason) : SilentOutcome;
+
+public sealed record DowngradeRefused(string InstalledVersion, string InstallerVersion) : SilentOutcome;
+```
+
+Extend `Map` and add the two new marker builders plus `ModeMarker`:
+
+```csharp
+    public static (int ExitCode, IReadOnlyList<string> Markers) Map(SilentOutcome outcome) => outcome switch
+    {
+        InstallSucceeded s => (0, SuccessMarkers(s)),
+        InstallFailed => (2, [Prefix + "RESULT=failed"]),
+        InstallTimedOut => (4, [Prefix + "RESULT=timeout"]),
+        UsageErrorOutcome u => (1, [Prefix + "RESULT=failed", Prefix + $"REASON={u.Message}"]),
+        NotElevatedOutcome => (3, [Prefix + "RESULT=failed"]),
+        UpgradeSucceeded u => (0, UpgradeSuccessMarkers(u)),
+        UpgradeFailed u => (2, UpgradeFailureMarkers(u)),
+        UnusableInstall u => (5, [Prefix + "RESULT=failed", Prefix + $"REASON={u.Reason}"]),
+        DowngradeRefused d => (6, [
+            Prefix + "RESULT=failed",
+            Prefix + $"REASON=Installed version {d.InstalledVersion} is newer than this " +
+                     $"installer ({d.InstallerVersion}); downgrade refused."]),
+        _ => throw new ArgumentOutOfRangeException(nameof(outcome))
+    };
+
+    /// <summary>
+    /// Written to the log by the router before either orchestrator runs, so months later a
+    /// store's own install-latest.log answers "which path ran".
+    /// </summary>
+    public static string ModeMarker(InstallMode mode) =>
+        Prefix + "MODE=" + mode.ToString().ToLowerInvariant();
+
+    // No ADMIN_SEEDED / RESET_HINT / CRED_FILE here: those belong to the fresh path, and
+    // on an upgrade the reset hint actively misleads (spec section 7).
+    private static IReadOnlyList<string> UpgradeSuccessMarkers(UpgradeSucceeded u) =>
+    [
+        Prefix + "RESULT=success",
+        Prefix + $"FROM_VERSION={u.FromVersion ?? "unknown"}",
+        Prefix + $"TO_VERSION={u.ToVersion}",
+        Prefix + $"SERVICE_STARTED={Lower(u.ServiceStarted)}",
+        Prefix + $"HEALTH={(u.HealthOk ? "ok" : "failed")}",
+        Prefix + $"BACKUP_DIR={u.BackupDir}",
+        Prefix + $"BACKUP_LOCKED={Lower(u.BackupLocked)}",
+        Prefix + $"POS_UPDATED={Lower(u.PosUpdated)}"
+    ];
+
+    private static IReadOnlyList<string> UpgradeFailureMarkers(UpgradeFailed u)
+    {
+        var markers = new List<string>
+        {
+            Prefix + "RESULT=failed",
+            Prefix + $"ROLLED_BACK={Lower(u.RolledBack)}",
+            Prefix + $"SERVICE_STARTED={Lower(u.ServiceStarted)}",
+            Prefix + $"HEALTH={(u.HealthOk ? "ok" : "failed")}",
+            Prefix + "POS_UPDATED=false"
+        };
+
+        if (u.BackupDir is not null)
+        {
+            markers.Add(Prefix + $"BACKUP_DIR={u.BackupDir}");
+        }
+
+        return markers;
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~SilentOutcomeMapperTests`
+Expected: PASS — 8 new tests plus the 7 pre-existing ones, all 15.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs
+git commit -m "feat(installer): add upgrade outcomes, exit codes and markers"
+```
+
+---
+
+## Task 11: UpgradeOrchestrator
+
+Spec §4 and §5. The whole sequence, and the mutation line is the design's load-bearing idea: steps 0–3 touch nothing, so a failure there is a non-event; steps 4–7 roll back; step 8 does not.
+
+Step 5 is the heart of it. `DatabaseSetup` never runs, so there is no superuser password to need, no role to create and no connection string to generate — which is what makes the original Failure 2 *disappear* rather than be worked around.
+
+**Files:**
+- Create: `installer/IndyPOS.Bootstrapper/Upgrade/UpgradeOrchestrator.cs`, `installer/IndyPOS.Bootstrapper/Upgrade/SimulatedFailure.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeOrchestratorTests.cs`
+
+**Interfaces:**
+- Consumes: `DetectedInstall`, `UpgradeBackup`, `UpgradePreflight`, `PosAppVersion`, `ServiceControl`, `StoreHubPayload`, `MigrationRunner`, `HealthProbe`, `ConfigSnapshot`, `InstallManifestWriter`, and the upgrade outcome records
+- Produces:
+  - `enum UpgradeStage { Preflight, Stop, Backup, Deploy, RestoreConfig, Migrate, Start, PosApp }`
+  - `static class SimulatedFailure` with `static UpgradeStage? Parse(string? value)` and `const string ArgumentName = "--simulate-failure"`
+  - `interface IUpgradeSteps` — the seam the orchestrator drives, so the sequence and its rollback are unit-testable without a real machine
+  - `sealed class UpgradeOrchestrator(IUpgradeSteps steps, UpgradeStage? simulateFailure = null)` with
+    `Task<SilentOutcome> RunAsync(DetectedInstall detected, InstallationConfig config, IProgress<InstallationProgress> progress, CancellationToken ct)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeOrchestratorTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+using IndyPOS.Bootstrapper.Silent;
+using IndyPOS.Bootstrapper.Upgrade;
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class UpgradeOrchestratorTests
+{
+    private const string BackupDir = @"C:\ProgramData\IndyPOS\v4\backups\20260726-010203";
+
+    private static readonly DetectedInstall Detected = new(
+        InstallMode.Upgrade, "4.0.0", "Rungrat-001", StoreType.Minimart, "ok");
+
+    private static InstallationConfig Config() => new() { StoreId = "Rungrat-001", Interactive = false };
+
+    private sealed class FakeSteps : IUpgradeSteps
+    {
+        public List<string> Calls { get; } = [];
+
+        public bool PreflightOk { get; init; } = true;
+        public string PreflightReason { get; init; } = "preflight failed";
+        public bool IsDowngrade { get; init; }
+        public bool BackupOk { get; init; } = true;
+        public bool DeployOk { get; init; } = true;
+        public bool MigrateOk { get; init; } = true;
+        public bool StartOk { get; init; } = true;
+        public bool HealthOk { get; set; } = true;
+        public bool PostRollbackHealthOk { get; init; } = true;
+        public bool PosOk { get; init; } = true;
+        public string? PosVersionAfter { get; init; } = "4.1.0";
+        public bool RestoreThrows { get; init; }
+
+        public Task<PreflightResult> PreflightAsync(DetectedInstall d, InstallationConfig c, CancellationToken ct)
+        {
+            Calls.Add("preflight");
+            return Task.FromResult(new PreflightResult(
+                PreflightOk, @"C:\pg\bin\pg_dump.exe", "Host=127.0.0.1",
+                PreflightOk ? null : PreflightReason, IsDowngrade));
+        }
+
+        public Task<bool> StopServiceAsync(CancellationToken ct)
+        {
+            Calls.Add("stop");
+            return Task.FromResult(true);
+        }
+
+        public Task<BackupResult> BackupAsync(string pgDump, string conn, CancellationToken ct)
+        {
+            Calls.Add("backup");
+            return Task.FromResult(new BackupResult(BackupOk, BackupDir, true,
+                BackupOk ? null : "pg_dump failed"));
+        }
+
+        public ConfigSnapshotHandle CaptureConfig()
+        {
+            Calls.Add("capture");
+            return new ConfigSnapshotHandle(() => Calls.Add("restore-config"));
+        }
+
+        public Task<bool> DeployAsync(CancellationToken ct)
+        {
+            Calls.Add("deploy");
+            return Task.FromResult(DeployOk);
+        }
+
+        public Task<MigrationRunResult> MigrateAsync(CancellationToken ct)
+        {
+            Calls.Add("migrate");
+            return Task.FromResult(new MigrationRunResult(MigrateOk, false, MigrateOk ? null : "42703"));
+        }
+
+        public Task<bool> StartServiceAsync(CancellationToken ct)
+        {
+            Calls.Add("start");
+            return Task.FromResult(StartOk);
+        }
+
+        public Task<bool> HealthAsync(CancellationToken ct)
+        {
+            Calls.Add("health");
+            return Task.FromResult(Calls.Count(c => c == "health") > 1 ? PostRollbackHealthOk : HealthOk);
+        }
+
+        public string? ReadPosVersion()
+        {
+            Calls.Add("pos-version");
+            return Calls.Count(c => c == "pos-version") == 1 ? "4.0.0" : PosVersionAfter;
+        }
+
+        public Task<bool> InstallPosAppAsync(CancellationToken ct)
+        {
+            Calls.Add("pos-install");
+            return Task.FromResult(PosOk);
+        }
+
+        public void RestoreStoreHubTree(string stampDir)
+        {
+            Calls.Add("restore-tree");
+            if (RestoreThrows) throw new DirectoryNotFoundException("no backup");
+        }
+
+        public Task WriteManifestAsync(CancellationToken ct)
+        {
+            Calls.Add("manifest");
+            return Task.CompletedTask;
+        }
+    }
+
+    private static async Task<SilentOutcome> Run(FakeSteps steps, UpgradeStage? fault = null) =>
+        await new UpgradeOrchestrator(steps, fault).RunAsync(
+            Detected, Config(), new Progress<InstallationProgress>(_ => { }), CancellationToken.None);
+
+    [Fact]
+    public async Task RunAsync_OnTheHappyPath_ShouldSucceed()
+    {
+        var outcome = await Run(new FakeSteps());
+
+        outcome.Should().BeOfType<UpgradeSucceeded>()
+            .Which.BackupDir.Should().Be(BackupDir);
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldStopTheServiceBeforeDumping()
+    {
+        // A sale completed between the dump and the restart would exist only in the live
+        // database, and "restore the dump" is the documented recovery -- so that window
+        // would be silently discarded.
+        var steps = new FakeSteps();
+
+        await Run(steps);
+
+        steps.Calls.IndexOf("stop").Should().BeLessThan(steps.Calls.IndexOf("backup"));
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldRestoreConfigAfterDeploy()
+    {
+        // Extraction overwrites appsettings.json with the package template; step 5 is what
+        // puts the store's real config back, and it must land before migrate reads it.
+        var steps = new FakeSteps();
+
+        await Run(steps);
+
+        steps.Calls.IndexOf("deploy").Should().BeLessThan(steps.Calls.IndexOf("restore-config"));
+        steps.Calls.IndexOf("restore-config").Should().BeLessThan(steps.Calls.IndexOf("migrate"));
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldNeverCallDatabaseSetup()
+    {
+        // Enforced structurally: IUpgradeSteps exposes no such member. This test documents
+        // the invariant so a future widening of the seam is a deliberate act.
+        typeof(IUpgradeSteps).GetMethods().Select(m => m.Name)
+            .Should().NotContain(n => n.Contains("DatabaseSetup", StringComparison.OrdinalIgnoreCase));
+
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenPreflightFails_ShouldNotTouchAnything()
+    {
+        var steps = new FakeSteps { PreflightOk = false };
+
+        var outcome = await Run(steps);
+
+        outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeFalse();
+        steps.Calls.Should().NotContain("stop");
+        steps.Calls.Should().NotContain("deploy");
+    }
+
+    [Fact]
+    public async Task RunAsync_OnADowngrade_ShouldReturnDowngradeRefused()
+    {
+        var outcome = await Run(new FakeSteps { PreflightOk = false, IsDowngrade = true });
+
+        outcome.Should().BeOfType<DowngradeRefused>();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheBackupFails_ShouldStopBeforeTheMutationLine()
+    {
+        var steps = new FakeSteps { BackupOk = false };
+
+        var outcome = await Run(steps);
+
+        outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeFalse();
+        steps.Calls.Should().NotContain("deploy");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenDeployFails_ShouldRollBackAndProbeHealth()
+    {
+        var steps = new FakeSteps { DeployOk = false };
+
+        var outcome = await Run(steps);
+
+        var failure = outcome.Should().BeOfType<UpgradeFailed>().Subject;
+        failure.RolledBack.Should().BeTrue();
+        steps.Calls.Should().ContainInOrder("restore-tree", "restore-config", "start", "health");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenMigrateFails_ShouldRollBack()
+    {
+        var steps = new FakeSteps { MigrateOk = false };
+
+        var outcome = await Run(steps);
+
+        outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeTrue();
+        steps.Calls.Should().Contain("restore-tree");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenHealthFailsAfterStart_ShouldRollBack()
+    {
+        var steps = new FakeSteps { HealthOk = false };
+
+        var outcome = await Run(steps);
+
+        outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheRollbackItselfIsUnhealthy_ShouldReportItRatherThanClaimRecovery()
+    {
+        var steps = new FakeSteps { DeployOk = false, PostRollbackHealthOk = false };
+
+        var failure = (UpgradeFailed)await Run(steps);
+
+        failure.RolledBack.Should().BeTrue();
+        failure.HealthOk.Should().BeFalse();
+        failure.Message.Should().Contain(BackupDir);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheBackupTreeIsGone_ShouldReportTheRollbackDidNotHappen()
+    {
+        var steps = new FakeSteps { DeployOk = false, RestoreThrows = true };
+
+        var failure = (UpgradeFailed)await Run(steps);
+
+        failure.RolledBack.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenThePosStepFails_ShouldNotRollBackTheServer()
+    {
+        // Spec section 5 row 8, confirmed by the 2026-07-26 spike: the service survives a
+        // full POS package swap, so the two are genuinely independent.
+        var steps = new FakeSteps { PosOk = false };
+
+        var failure = (UpgradeFailed)await Run(steps);
+
+        failure.RolledBack.Should().BeFalse();
+        failure.ServiceStarted.Should().BeTrue();
+        steps.Calls.Should().NotContain("restore-tree");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenThePosVersionDidNotChange_ShouldReportPosUpdatedFalse()
+    {
+        // A same-version repair exits 0 too (spike, section 12), so the exit code cannot
+        // be trusted -- only sq.version before vs after can.
+        var steps = new FakeSteps { PosVersionAfter = "4.0.0" };
+
+        var success = (UpgradeSucceeded)await Run(steps);
+
+        success.PosUpdated.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenThePosVersionChanged_ShouldReportPosUpdatedTrue()
+    {
+        var success = (UpgradeSucceeded)await Run(new FakeSteps { PosVersionAfter = "4.1.0" });
+
+        success.PosUpdated.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RunAsync_WithASimulatedDeployFailure_ShouldRollBack()
+    {
+        // The fault hook is runtime-selected so ONE 190 MB installer build serves VM
+        // cases 1 and 2 in a single session.
+        var steps = new FakeSteps();
+
+        var outcome = await Run(steps, UpgradeStage.Deploy);
+
+        outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("deploy", UpgradeStage.Deploy)]
+    [InlineData("MIGRATE", UpgradeStage.Migrate)]
+    [InlineData("start", UpgradeStage.Start)]
+    [InlineData("nonsense", null)]
+    [InlineData(null, null)]
+    public void Parse_WithVariousValues_ShouldReturnExpected(string? value, UpgradeStage? expected)
+    {
+        SimulatedFailure.Parse(value).Should().Be(expected);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~UpgradeOrchestratorTests`
+Expected: FAIL — `UpgradeOrchestrator`, `IUpgradeSteps`, `UpgradeStage`, `SimulatedFailure`, `ConfigSnapshotHandle` do not exist.
+
+- [ ] **Step 3: Write the fault hook**
+
+Create `installer/IndyPOS.Bootstrapper/Upgrade/SimulatedFailure.cs`:
+
+```csharp
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+public enum UpgradeStage
+{
+    Preflight,
+    Stop,
+    Backup,
+    Deploy,
+    RestoreConfig,
+    Migrate,
+    Start,
+    PosApp
+}
+
+/// <summary>
+/// Runtime-selected fault injection for VM case 2 (forced mid-upgrade failure).
+/// <para>Runtime, not compile-time, deliberately: at roughly 10 minutes per cycle plus a
+/// 190 MB build, one binary serving both VM cases is the difference between one evening
+/// and two. Undocumented in help output — it is a test hook, not a feature.</para>
+/// </summary>
+public static class SimulatedFailure
+{
+    public const string ArgumentName = "--simulate-failure";
+
+    public static UpgradeStage? Parse(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var matched = Enum.GetNames<UpgradeStage>()
+            .FirstOrDefault(n => n.Equals(value, StringComparison.OrdinalIgnoreCase));
+
+        return matched is null ? null : Enum.Parse<UpgradeStage>(matched);
+    }
+}
+```
+
+- [ ] **Step 4: Write the step seam**
+
+Create the seam and its Windows implementation at the top of `installer/IndyPOS.Bootstrapper/Upgrade/UpgradeOrchestrator.cs`:
+
+```csharp
+using IndyPOS.Bootstrapper.Installers;
+using IndyPOS.Bootstrapper.Silent;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>A captured config, restorable once. Wraps ConfigSnapshot for testability.</summary>
+public sealed class ConfigSnapshotHandle(Action restore)
+{
+    public void Restore() => restore();
+}
+
+/// <summary>
+/// The individual step units the upgrade sequence drives. An interface so the ORDER and
+/// the rollback decisions — the parts that actually failed in production — are unit-testable
+/// without a service, a database or a 190 MB installer.
+/// <para>There is deliberately no DatabaseSetup member: it is fresh-install only.</para>
+/// </summary>
+public interface IUpgradeSteps
+{
+    Task<PreflightResult> PreflightAsync(DetectedInstall detected, InstallationConfig config, CancellationToken ct);
+    Task<bool> StopServiceAsync(CancellationToken ct);
+    Task<BackupResult> BackupAsync(string pgDumpPath, string connectionString, CancellationToken ct);
+    ConfigSnapshotHandle CaptureConfig();
+    Task<bool> DeployAsync(CancellationToken ct);
+    Task<MigrationRunResult> MigrateAsync(CancellationToken ct);
+    Task<bool> StartServiceAsync(CancellationToken ct);
+    Task<bool> HealthAsync(CancellationToken ct);
+    string? ReadPosVersion();
+    Task<bool> InstallPosAppAsync(CancellationToken ct);
+    void RestoreStoreHubTree(string stampDirectory);
+    Task WriteManifestAsync(CancellationToken ct);
+}
+```
+
+- [ ] **Step 5: Write the orchestrator**
+
+Append to the same file:
+
+```csharp
+/// <summary>
+/// The in-place upgrade sequence (upgrade design spec, sections 4 and 5).
+/// <para>Steps 0-3 mutate nothing: a failure there is a non-event. Steps 4-7 roll back.
+/// Step 8 does not — the server is upgraded and serving, and the 2026-07-26 spike confirmed
+/// the POS step cannot disturb it.</para>
+/// </summary>
+public sealed class UpgradeOrchestrator(IUpgradeSteps steps, UpgradeStage? simulateFailure = null)
+{
+    public async Task<SilentOutcome> RunAsync(
+        DetectedInstall detected,
+        InstallationConfig config,
+        IProgress<InstallationProgress> progress,
+        CancellationToken cancellationToken = default)
+    {
+        // --- Step 1: preflight ------------------------------------------------
+        progress.Report(InstallationProgress.Step("Upgrading", "Checking this machine...", 5));
+
+        var preflight = await steps.PreflightAsync(detected, config, cancellationToken);
+        Fault(UpgradeStage.Preflight);
+
+        if (!preflight.Ok)
+        {
+            return preflight.IsDowngrade
+                ? new DowngradeRefused(detected.InstalledVersion ?? "unknown", config.InstallVersion)
+                : new UpgradeFailed(preflight.FailureReason ?? "Preflight failed.",
+                    RolledBack: false, ServiceStarted: true, HealthOk: true, BackupDir: null);
+        }
+
+        var posVersionBefore = steps.ReadPosVersion();
+
+        // --- Step 2: stop the service ----------------------------------------
+        // Above the mutation line: stopping is reversible, and dumping a live database
+        // would silently discard any sale completed before the restart.
+        progress.Report(InstallationProgress.Step("Upgrading", "Stopping StoreHub...", 10));
+        await steps.StopServiceAsync(cancellationToken);
+        Fault(UpgradeStage.Stop);
+
+        // --- Step 3: back up --------------------------------------------------
+        progress.Report(InstallationProgress.Step("Upgrading", "Backing up database and binaries...", 20));
+
+        var backup = await steps.BackupAsync(preflight.PgDumpPath!, preflight.ConnectionString!, cancellationToken);
+        Fault(UpgradeStage.Backup);
+
+        if (!backup.Success)
+        {
+            // Nothing has been mutated, but the service is stopped — put it back.
+            await steps.StartServiceAsync(cancellationToken);
+            return new UpgradeFailed(backup.ErrorMessage ?? "Backup failed.",
+                RolledBack: false, ServiceStarted: true,
+                HealthOk: await steps.HealthAsync(cancellationToken), BackupDir: null);
+        }
+
+        // ============ EVERYTHING BELOW THIS LINE MUTATES THE INSTALL ============
+
+        var snapshot = steps.CaptureConfig();
+
+        try
+        {
+            // --- Step 4: deploy -----------------------------------------------
+            progress.Report(InstallationProgress.Step("Upgrading", "Deploying StoreHub...", 40));
+            Fault(UpgradeStage.Deploy);
+
+            if (!await steps.DeployAsync(cancellationToken))
+            {
+                return await RollBackAsync("Failed to deploy the StoreHub payload.",
+                    backup.StampDirectory!, snapshot, cancellationToken);
+            }
+
+            // --- Step 5: restore the store's real config ----------------------
+            // The heart of the design. Extraction just wrote the package template over
+            // appsettings.json, and DatabaseSetup — which would have rewritten the real
+            // values on a fresh install — never runs here.
+            progress.Report(InstallationProgress.Step("Upgrading", "Restoring store configuration...", 55));
+            snapshot.Restore();
+            Fault(UpgradeStage.RestoreConfig);
+
+            // --- Step 6: migrate ----------------------------------------------
+            progress.Report(InstallationProgress.Step("Upgrading", "Applying database migrations...", 65));
+            Fault(UpgradeStage.Migrate);
+
+            var migration = await steps.MigrateAsync(cancellationToken);
+            if (!migration.Success)
+            {
+                return await RollBackAsync(migration.ErrorMessage ?? "Migration failed.",
+                    backup.StampDirectory!, snapshot, cancellationToken);
+            }
+
+            // --- Step 7: start + verify ---------------------------------------
+            progress.Report(InstallationProgress.Step("Upgrading", "Starting StoreHub...", 80));
+            Fault(UpgradeStage.Start);
+
+            var started = await steps.StartServiceAsync(cancellationToken);
+            var healthy = started && await steps.HealthAsync(cancellationToken);
+
+            if (!healthy)
+            {
+                return await RollBackAsync("StoreHub did not become healthy after the upgrade.",
+                    backup.StampDirectory!, snapshot, cancellationToken);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return await RollBackAsync(ex.Message, backup.StampDirectory!, snapshot, cancellationToken);
+        }
+
+        // ==================== SERVER UPGRADE COMPLETE ====================
+
+        // --- Step 8: the POS app. No rollback past this point. ----------------
+        progress.Report(InstallationProgress.Step("Upgrading", "Updating the POS application...", 90));
+        Fault(UpgradeStage.PosApp);
+
+        var posOk = await steps.InstallPosAppAsync(cancellationToken);
+        if (!posOk)
+        {
+            return new UpgradeFailed(
+                "The StoreHub service upgraded and is serving, but the POS application " +
+                "update failed. Re-run the installer to retry it; the store can keep trading.",
+                RolledBack: false, ServiceStarted: true, HealthOk: true, backup.StampDirectory);
+        }
+
+        // POS_UPDATED cannot come from the exit code: the spike measured 0 for both a real
+        // upgrade and a same-version repair. sq.version is the only truthful record.
+        var posUpdated = steps.ReadPosVersion() is { } after &&
+                         !string.Equals(after, posVersionBefore, StringComparison.Ordinal);
+
+        // --- Steps 9-10: manifest + markers. Non-fatal; the next run repairs a stale one.
+        try
+        {
+            await steps.WriteManifestAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            progress.Report(InstallationProgress.Error($"Warning: could not write install manifest: {ex.Message}"));
+        }
+
+        progress.Report(InstallationProgress.Step("Upgrade Complete", "IndyPOS has been upgraded.", 100));
+
+        return new UpgradeSucceeded(
+            detected.InstalledVersion, config.InstallVersion,
+            ServiceStarted: true, HealthOk: true,
+            backup.StampDirectory!, backup.Locked, posUpdated);
+    }
+
+    /// <summary>
+    /// Delete-then-copy the binaries back, put the config back, restart, and PROVE it came
+    /// back. Without the probe a rollback can report "the store resumed on its previous
+    /// version" while the store is dead.
+    /// </summary>
+    private async Task<UpgradeFailed> RollBackAsync(
+        string reason, string stampDirectory, ConfigSnapshotHandle snapshot, CancellationToken cancellationToken)
+    {
+        try
+        {
+            steps.RestoreStoreHubTree(stampDirectory);
+        }
+        catch (Exception ex)
+        {
+            return new UpgradeFailed(
+                $"{reason} The rollback then failed as well ({ex.Message}). This store needs " +
+                $"manual recovery; the database dump is at {stampDirectory}.",
+                RolledBack: false, ServiceStarted: false, HealthOk: false, stampDirectory);
+        }
+
+        snapshot.Restore();
+
+        var started = await steps.StartServiceAsync(cancellationToken);
+        var healthy = started && await steps.HealthAsync(cancellationToken);
+
+        var message = healthy
+            ? $"{reason} The upgrade was rolled back and the store is serving its previous version."
+            : $"{reason} The upgrade was rolled back but StoreHub is not healthy. Restore the " +
+              $"database dump at {stampDirectory} — see docs\\operations\\upgrade-procedure.md.";
+
+        return new UpgradeFailed(message, RolledBack: true, started, healthy, stampDirectory);
+    }
+
+    private void Fault(UpgradeStage stage)
+    {
+        if (simulateFailure == stage)
+        {
+            throw new InvalidOperationException($"Simulated failure at stage '{stage}' (test hook).");
+        }
+    }
+}
+```
+
+Note the `Fault(UpgradeStage.Deploy)` call sits *before* `DeployAsync`, so the simulated failure is thrown inside the `try` and takes the rollback path — which is exactly what VM case 2 must exercise.
+
+- [ ] **Step 6: Write the Windows implementation of the seam**
+
+Create `installer/IndyPOS.Bootstrapper/Upgrade/WindowsUpgradeSteps.cs`:
+
+```csharp
+using IndyPOS.Bootstrapper.Installers;
+using IndyPOS.Vault;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>Binds <see cref="IUpgradeSteps"/> to the real machine.</summary>
+public sealed class WindowsUpgradeSteps(InstallationConfig config, IProgress<string> log) : IUpgradeSteps
+{
+    private const int PostgresMajor = 18;
+
+    private readonly ServiceControl _service = new(config.ServiceName);
+    private readonly UpgradeBackup _backup = new(
+        config.BackupsDirectory,
+        config.StoreHubInstallPath,
+        new ExternalProcessRunner(),
+        () => DateTime.Now.ToString("yyyyMMdd-HHmmss"));
+
+    private string ConfigPath => Path.Combine(config.StoreHubInstallPath, "appsettings.json");
+
+    public async Task<PreflightResult> PreflightAsync(
+        DetectedInstall detected, InstallationConfig cfg, CancellationToken ct)
+    {
+        var (ok, reason, isDowngrade) = UpgradePreflight.CheckVersions(
+            detected.InstalledVersion, cfg.InstallVersion);
+        if (!ok)
+        {
+            return new PreflightResult(false, null, null, reason, isDowngrade);
+        }
+
+        if (UpgradePreflight.IsPosAppRunning())
+        {
+            return new PreflightResult(false, null, null,
+                "The IndyPOS POS application is running. Close it on this machine and re-run.", false);
+        }
+
+        if (!UpgradePreflight.HasFreeSpace(cfg.BackupsDirectory))
+        {
+            return new PreflightResult(false, null, null,
+                "Not enough free disk space to back up the database and binaries.", false);
+        }
+
+        var pgDump = UpgradePreflight.LocatePgDump(cfg.PostgresBinPath, PostgresMajor);
+        if (pgDump is null)
+        {
+            return new PreflightResult(false, null, null,
+                $"pg_dump.exe for PostgreSQL {PostgresMajor} could not be located.", false);
+        }
+
+        var connectionString = ReadConnectionString();
+        if (connectionString is null)
+        {
+            return new PreflightResult(false, null, null,
+                "The StoreHub connection string could not be decrypted on this machine.", false);
+        }
+
+        // Idempotent check-then-install. Omitting these delivers a UI-polish release that
+        // renders in a fallback face, or binaries the machine cannot run.
+        log.Report("Ensuring prerequisites (fonts, .NET 10, VC++ redistributable)...");
+        new FontInstaller().Install(log);
+        await new DotNetInstaller().EnsureInstalledAsync(log, ct, cfg.Interactive);
+        await new VCRedistInstaller().EnsureInstalledAsync(null, ct);
+
+        return new PreflightResult(true, pgDump, connectionString, null, false);
+    }
+
+    private string? ReadConnectionString()
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(ConfigPath));
+            var raw = doc.RootElement.GetProperty("connectionStrings").GetProperty("storehub-db").GetString();
+            return raw is null ? null : SecretProtector.Unprotect(StoreHubConfigReader.ConnectionStringKey, raw);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public Task<bool> StopServiceAsync(CancellationToken ct) =>
+        _service.StopAsync(TimeSpan.FromSeconds(60), ct);
+
+    public Task<BackupResult> BackupAsync(string pgDumpPath, string connectionString, CancellationToken ct) =>
+        _backup.CreateAsync(pgDumpPath, connectionString, ct);
+
+    public ConfigSnapshotHandle CaptureConfig()
+    {
+        var snapshot = ConfigSnapshot.Capture(ConfigPath);
+        return new ConfigSnapshotHandle(snapshot.Restore);
+    }
+
+    public Task<bool> DeployAsync(CancellationToken ct) =>
+        StoreHubPayload.ExtractAsync(config.StoreHubInstallPath, log, ct);
+
+    public Task<MigrationRunResult> MigrateAsync(CancellationToken ct) =>
+        MigrationRunner.RunAsync(config.StoreHubInstallPath, log, ct);
+
+    public Task<bool> StartServiceAsync(CancellationToken ct) =>
+        _service.StartAsync(TimeSpan.FromSeconds(60), ct);
+
+    public Task<bool> HealthAsync(CancellationToken ct) =>
+        HealthProbe.IsReadyAsync(config.HealthCheckPort, cancellationToken: ct);
+
+    public string? ReadPosVersion() => PosAppVersion.Read(config.VelopackInstallPath);
+
+    public async Task<bool> InstallPosAppAsync(CancellationToken ct) =>
+        (await new VelopackLauncher().InstallAsync(config, null, ct)).Success;
+
+    public void RestoreStoreHubTree(string stampDirectory) => _backup.RestoreStoreHubTree(stampDirectory);
+
+    public Task WriteManifestAsync(CancellationToken ct) => InstallManifestWriter.WriteAsync(config, ct);
+}
+```
+
+`ConfigSnapshot` is `internal sealed`; `WindowsUpgradeSteps` is in the same assembly, so this compiles. If `FontInstaller.Install` / `DotNetInstaller.EnsureInstalledAsync` / `VCRedistInstaller.EnsureInstalledAsync` have different signatures than shown, match the real ones as used in `FreshInstallOrchestrator` steps 0–1b.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~UpgradeOrchestratorTests`
+Expected: PASS, 21 tests (16 facts + 5 theory cases).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Upgrade/SimulatedFailure.cs installer/IndyPOS.Bootstrapper/Upgrade/UpgradeOrchestrator.cs installer/IndyPOS.Bootstrapper/Upgrade/WindowsUpgradeSteps.cs tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeOrchestratorTests.cs
+git commit -m "feat(installer): add the in-place upgrade sequence with verified rollback"
+```
+
+---
+
+## Task 12: Entry points — one router, and a wizard that refuses
+
+Spec §9. Both entry points consume **one** detection result from a single router. If `Program.cs` and `SilentInstaller` each called the detector, the two forks would diverge.
+
+The wizard must not be left undetected: a double-clicked `Setup.exe` on a live store otherwise reproduces both original failures, and that is the likely path on a hands-on store visit. But it does not gain an upgrade UI — it collects StoreId and StoreType up front (both already fixed on an upgrade) and its finish screen is built around bootstrap credentials that do not exist on an upgrade.
+
+**Files:**
+- Modify: `installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs`, `installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs`, `installer/IndyPOS.Bootstrapper/Program.cs`, `installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs`
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs`
+
+**Interfaces:**
+- Consumes: `InstallModeDetector.Detect`, `WindowsInstallProbe`, `UpgradeOrchestrator`, `WindowsUpgradeSteps`, `SilentOutcomeMapper.ModeMarker`, `SimulatedFailure.Parse`
+- Produces:
+  - `SilentInstallOptions` gains `string? StoreId` (was `string`), `UpgradeStage? SimulateFailure`
+  - `static string InstallationWizard.BuildExistingInstallMessage(DetectedInstall detected)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs` (add `using IndyPOS.Bootstrapper.Upgrade;`):
+
+```csharp
+    [Fact]
+    public void Parse_WithSilentAndNoStoreId_ShouldSucceedWithANullStoreId()
+    {
+        // On an upgrade the store id is adopted from the detected config. Requiring it
+        // would force a comparison on every upgrade with no correct behaviour when the
+        // detected value is null.
+        var result = SilentArgs.Parse(["--silent"]);
+
+        result.Status.Should().Be(ParseStatus.Silent);
+        result.Options!.StoreId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_WithSilentAndAStoreId_ShouldStillCarryIt()
+    {
+        var result = SilentArgs.Parse(["--silent", "--store-id", "Rungrat-001"]);
+
+        result.Options!.StoreId.Should().Be("Rungrat-001");
+    }
+
+    [Fact]
+    public void Parse_WithAnEmptyStoreIdValue_ShouldStillBeAUsageError()
+    {
+        SilentArgs.Parse(["--silent", "--store-id", "   "]).Status.Should().Be(ParseStatus.UsageError);
+    }
+
+    [Fact]
+    public void Parse_WithSimulateFailure_ShouldCarryTheStage()
+    {
+        var result = SilentArgs.Parse(["--silent", "--simulate-failure=deploy"]);
+
+        result.Options!.SimulateFailure.Should().Be(UpgradeStage.Deploy);
+    }
+
+    [Fact]
+    public void Parse_WithAnUnknownSimulateFailureStage_ShouldBeAUsageError()
+    {
+        SilentArgs.Parse(["--silent", "--simulate-failure=nonsense"]).Status
+            .Should().Be(ParseStatus.UsageError);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~SilentArgsTests`
+Expected: FAIL — `--silent` without `--store-id` currently returns a usage error, and `SimulateFailure` does not exist.
+
+- [ ] **Step 3: Update SilentArgs**
+
+In `installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs`:
+
+Change the options record and add the new flag:
+
+```csharp
+using IndyPOS.Bootstrapper.Upgrade;
+
+/// <param name="StoreId">
+/// Null is legal: an upgrade adopts the detected store id. The router rejects a supplied
+/// value that conflicts with the detected one — silently rewriting store identity would
+/// orphan the store's sales history.
+/// </param>
+public sealed record SilentInstallOptions(
+    string? StoreId,
+    int TimeoutMinutes,
+    StoreType StoreType = StoreType.GeneralHardware,
+    UpgradeStage? SimulateFailure = null);
+```
+
+Inside `Parse`, add a local `UpgradeStage? simulateFailure = null;` and a new case:
+
+```csharp
+                case "--simulate-failure":
+                    if (!TryReadValue(args, ref i, inlineValue, out var stageRaw)
+                        || (simulateFailure = SimulatedFailure.Parse(stageRaw)) is null)
+                        return ParseResult.Usage(
+                            "--simulate-failure must name a stage (test hook).");
+                    break;
+```
+
+Replace the trailing validation so an absent `--store-id` is allowed but a blank *value* is not. Track whether the flag appeared:
+
+```csharp
+        // A supplied-but-blank value is still a usage error; an absent flag is not.
+        if (storeId is not null && string.IsNullOrWhiteSpace(storeId))
+            return ParseResult.Usage("--store-id requires a non-empty value.");
+
+        return ParseResult.Silent(
+            new SilentInstallOptions(storeId?.Trim(), timeoutMinutes, storeType, simulateFailure));
+```
+
+Delete the old `storeId = storeId?.Trim();` / `IsNullOrWhiteSpace` rejection block at lines 69-71.
+
+- [ ] **Step 4: Turn SilentInstaller into the router**
+
+In `installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs`, add `using IndyPOS.Bootstrapper.Upgrade;` and replace `Run`'s body from the config construction onwards:
+
+```csharp
+        var options = parse.Options!;
+
+        // Detected first, with a placeholder store id: only computed paths are needed to
+        // probe the machine, and StoreId is required on the record.
+        var probeConfig = new InstallationConfig
+        {
+            StoreId = options.StoreId ?? "pending",
+            StoreType = options.StoreType,
+            Interactive = false
+        };
+
+        var detected = InstallModeDetector.Detect(
+            new WindowsInstallProbe(probeConfig), probeConfig.StoreHubInstallPath);
+
+        string logPath;
+        TextWriter writer;
+        try
+        {
+            (logPath, writer) = OpenLog(probeConfig);
+        }
+        catch (Exception ex)
+        {
+            return Emit(new InstallFailed(SecretScrubber.Scrub(ex.Message)), logger: null);
+        }
+
+        var logger = new SilentInstallLogger(writer);
+        logger.WriteMarker(SilentOutcomeMapper.ModeMarker(detected.Mode));
+
+        var outcome = detected.Mode switch
+        {
+            InstallMode.Unusable => new UnusableInstall(detected.Reason),
+            InstallMode.Upgrade => RunUpgrade(detected, options, logger),
+            _ => RunFreshInstall(BuildFreshConfig(options), options, logger)
+        };
+
+        var exit = Emit(outcome, logger);
+
+        logger.Dispose();
+        CopyLatest(probeConfig, logPath);
+        return exit;
+```
+
+Add the three helpers. `RunInstall` keeps its current body, renamed `RunFreshInstall`:
+
+```csharp
+    private static SilentOutcome BuildFreshConfig(SilentInstallOptions options) =>
+        throw new InvalidOperationException("placeholder — see below");
+```
+
+Replace that placeholder with the real pair:
+
+```csharp
+    // A fresh install still requires an explicit store id: there is nothing to adopt.
+    private static InstallationConfig? BuildFreshConfig(SilentInstallOptions options) =>
+        options.StoreId is null
+            ? null
+            : new InstallationConfig
+            {
+                StoreId = options.StoreId,
+                StoreType = options.StoreType,
+                Interactive = false
+            };
+
+    private static SilentOutcome RunUpgrade(
+        DetectedInstall detected, SilentInstallOptions options, SilentInstallLogger logger)
+    {
+        // Rewriting store identity would orphan every sale recorded under the old id.
+        if (options.StoreId is not null &&
+            !string.Equals(options.StoreId, detected.StoreId, StringComparison.Ordinal))
+        {
+            return new UnusableInstall(
+                $"--store-id '{options.StoreId}' does not match the installed store " +
+                $"'{detected.StoreId}'. Re-run without --store-id to upgrade this store.");
+        }
+
+        var config = new InstallationConfig
+        {
+            StoreId = detected.StoreId!,
+            StoreType = detected.StoreType!.Value,
+            Interactive = false
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(options.TimeoutMinutes));
+
+        try
+        {
+            var steps = new WindowsUpgradeSteps(config, logger);
+            return new UpgradeOrchestrator(steps, options.SimulateFailure)
+                .RunAsync(detected, config, logger, cts.Token)
+                .GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            logger.WriteLine("ERROR: upgrade timed out.");
+            return new InstallTimedOut();
+        }
+        catch (Exception ex)
+        {
+            var message = SecretScrubber.Scrub(ex.Message);
+            logger.WriteLine("ERROR: " + message);
+            return new UpgradeFailed(message, false, false, false, null);
+        }
+    }
+```
+
+Change the `_ =>` arm to handle a missing store id on the fresh path:
+
+```csharp
+            _ => BuildFreshConfig(options) is { } fresh
+                ? RunFreshInstall(fresh, options, logger)
+                : new UsageErrorOutcome("--silent requires --store-id <ID> for a fresh install.")
+```
+
+`SilentInstallLogger` must satisfy both `IProgress<InstallationProgress>` (for the orchestrators) and `IProgress<string>` (for `WindowsUpgradeSteps`). Check its current declaration; if it only implements the former, add `IProgress<string>` with `void Report(string value) => WriteLine(value);`.
+
+- [ ] **Step 5: Make the wizard detect and refuse**
+
+In `installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs`, add `using IndyPOS.Bootstrapper.Upgrade;` and a static message builder:
+
+```csharp
+    /// <summary>
+    /// The wizard deliberately gains no upgrade UI: it collects StoreId and StoreType up
+    /// front (both already fixed on an upgrade) and its finish screen is built around
+    /// bootstrap credentials that do not exist on one. But it must not silently proceed —
+    /// a double-clicked Setup.exe on a live store reproduces both original failures.
+    /// </summary>
+    internal static string BuildExistingInstallMessage(DetectedInstall detected) =>
+        $"IndyPOS {detected.InstalledVersion ?? "(unknown version)"} is already installed on " +
+        $"this machine (store {detected.StoreId ?? "unknown"}).\n\n" +
+        "The wizard only performs new installations. To upgrade in place, open an " +
+        "administrator command prompt and run:\n\n" +
+        "    IndyPOS-Setup.exe --silent\n\n" +
+        "See docs\\operations\\upgrade-procedure.md.";
+```
+
+In `installer/IndyPOS.Bootstrapper/Program.cs`, run the same detector before showing the wizard:
+
+```csharp
+        ApplicationConfiguration.Initialize();
+
+        if (!Elevation.IsElevated())
+        {
+            MessageBox.Show(
+                "IndyPOS Setup requires administrator privileges.\n\n" +
+                "Please right-click and select 'Run as administrator'.",
+                "Administrator Required",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning);
+            return 0;
+        }
+
+        // One detection result, one router. If the wizard and the silent path each called
+        // the detector, the two forks would drift.
+        var probeConfig = new InstallationConfig { StoreId = "pending", Interactive = true };
+        var detected = InstallModeDetector.Detect(
+            new WindowsInstallProbe(probeConfig), probeConfig.StoreHubInstallPath);
+
+        if (detected.Mode != InstallMode.Fresh)
+        {
+            MessageBox.Show(
+                detected.Mode == InstallMode.Upgrade
+                    ? InstallationWizard.BuildExistingInstallMessage(detected)
+                    : detected.Reason,
+                "Existing Installation Detected",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
+            return 0;
+        }
+
+        Application.Run(new InstallationWizard());
+        return 0;
+```
+
+Add `using IndyPOS.Bootstrapper.Installers;` and `using IndyPOS.Bootstrapper.Upgrade;` to `Program.cs`.
+
+- [ ] **Step 6: Run the full bootstrapper suite and build**
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests`
+Expected: PASS — every prior task's tests plus the 5 new `SilentArgsTests`.
+
+Run: `dotnet build IndyPOS.sln -c Release`
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add installer/IndyPOS.Bootstrapper/Silent/ installer/IndyPOS.Bootstrapper/Program.cs installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs
+git commit -m "feat(installer): route fresh, upgrade and unusable from one detection result"
+```
+
+---
+
+## Task 13: VM harness — snapshot choice, expect-rollback, database assertions
+
+Spec §10. The harness cannot run VM case 2 at all today: it hardcodes the snapshot name and **throws** whenever `RESULT != success` (`Reset-AndInstall.ps1:153`, `:269-272`), so a deliberate-rollback run fails by construction.
+
+Case 2 must also assert against the **fresh timestamped log**, not `install-latest.log`, which can still hold a previous run's `RESULT=success`.
+
+**Files:**
+- Modify: `scripts/vm-testing/Reset-AndInstall.ps1`, `scripts/vm-testing/Test-IndyPOSInstallation.ps1`, `scripts/vm-testing/VMTestConfig.psd1`
+
+**Interfaces:**
+- Consumes: the markers from Task 10
+- Produces: `Reset-AndInstall.ps1` parameters `-SnapshotName <string>`, `-ExpectRollback`, `-InstallerArgs <string[]>`; `Test-IndyPOSInstallation.ps1` parameter `-AssertDatabase`
+
+**Everything written to the guest must be ASCII** — PowerShell 5.1 with a Windows-1252 codepage.
+
+- [ ] **Step 1: Add the parameters**
+
+In `scripts/vm-testing/Reset-AndInstall.ps1`, extend the `param()` block:
+
+```powershell
+    [string]$SnapshotName,
+    [switch]$ExpectRollback,
+    [string[]]$InstallerArgs,
+```
+
+Below `$Config = Import-PowerShellDataFile ...`, resolve the snapshot:
+
+```powershell
+# Case 1/2 run from a real store image; case 3 from the clean baseline.
+if (-not $SnapshotName) { $SnapshotName = $Config.CleanSnapshotName }
+```
+
+Replace every `$Config.CleanSnapshotName` in `Test-Prerequisites` and `Restore-CleanVM` with `$SnapshotName`.
+
+- [ ] **Step 2: Make the installer arguments configurable**
+
+In `Invoke-SilentInstall`, replace the hardcoded argument list:
+
+```powershell
+    $arguments = if ($InstallerArgs) { $InstallerArgs } else { @('--silent', '--store-id', $Config.TestStoreId) }
+    Write-Info "Running (in guest): $guestInstaller $($arguments -join ' ')"
+
+    $job = Invoke-Command -VMName $Config.VMName -Credential $Credential -AsJob -ScriptBlock {
+        param($exe, $argList)
+        $p = Start-Process -FilePath $exe -ArgumentList $argList -Wait -PassThru
+        [pscustomobject]@{ ExitCode = $p.ExitCode }
+    } -ArgumentList $guestInstaller, $arguments
+```
+
+- [ ] **Step 3: Read the fresh log, not install-latest.log**
+
+Still in `Invoke-SilentInstall`, replace the marker read. `install-latest.log` can hold a previous run's `RESULT=success`, which would make a deliberate-rollback run look like a pass:
+
+```powershell
+    # Newest install-<stamp>-<pid>.log, NOT install-latest.log: on a re-run the latter can
+    # still carry the previous run's RESULT=success.
+    $markers = Invoke-Command -VMName $Config.VMName -Credential $Credential -ScriptBlock {
+        param($dir)
+        $log = Get-ChildItem -Path $dir -Filter 'install-2*.log' -ErrorAction SilentlyContinue |
+               Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if ($log) { Get-Content $log.FullName | Where-Object { $_ -like 'INDYPOS_MARKER *' } } else { @() }
+    } -ArgumentList $logDir
+```
+
+- [ ] **Step 4: Add the expect-rollback gate**
+
+Replace the gating block at the end of `Invoke-SilentInstall`:
+
+```powershell
+    if ($ExpectRollback) {
+        # A deliberate mid-upgrade failure. Success here means the store came BACK, which
+        # is the only claim the rollback design actually makes.
+        $ok = ($marker['RESULT'] -eq 'failed') -and
+              ($marker['ROLLED_BACK'] -eq 'true') -and
+              ($marker['SERVICE_STARTED'] -eq 'true') -and
+              ($marker['HEALTH'] -eq 'ok')
+        if (-not $ok) {
+            throw ("Expected a verified rollback but got RESULT=$($marker['RESULT']), " +
+                   "ROLLED_BACK=$($marker['ROLLED_BACK']), SERVICE_STARTED=$($marker['SERVICE_STARTED']), " +
+                   "HEALTH=$($marker['HEALTH']). See $latestLog in the guest.")
+        }
+        Write-OK 'Rollback verified: store is serving its previous version.'
+        return
+    }
+
+    # Authoritative gating rule: exit code + RESULT + service.
+    $failed = ($run.ExitCode -ne 0) -or ($marker['RESULT'] -ne 'success') -or ($marker['SERVICE_STARTED'] -eq 'false')
+    if ($failed) {
+        throw "Silent install failed (exit=$($run.ExitCode), RESULT=$($marker['RESULT']), SERVICE_STARTED=$($marker['SERVICE_STARTED'])). See $latestLog in the guest."
+    }
+    if ($marker['CRED_LOCKED'] -eq 'false') {
+        Write-Warn2 "Credential file could not be ACL-locked (CRED_LOCKED=false)."
+    }
+    Write-OK "Silent install completed (RESULT=$($marker['RESULT']), MODE=$($marker['MODE']))."
+```
+
+Also skip the verifier on an expect-rollback run — it audits a *completed* install. In the `try` block of Main:
+
+```powershell
+    Invoke-SilentInstall -Credential $cred
+    if ($ExpectRollback) {
+        Write-OK 'Expect-rollback run complete; skipping the install verifier.'
+        exit 0
+    }
+    $result = Invoke-Verifier -Credential $cred
+```
+
+- [ ] **Step 5: Script the database assertions**
+
+Add to `scripts/vm-testing/Test-IndyPOSInstallation.ps1` a `-AssertDatabase` switch and this check block. Done interactively on 2026-07-25; this is the scripting of it:
+
+```powershell
+# Decrypt the DPAPI-sealed connection string in-guest, then drive psql. Machine scope,
+# entropy = SHA256("IndyPOS:ConnectionStrings:storehub-db"). PowerShell 5.1 has no static
+# SHA256.HashData, so use an instance.
+function Get-StoreHubConnectionString {
+    param([string]$AppSettingsPath)
+
+    $raw = (Get-Content $AppSettingsPath -Raw | ConvertFrom-Json).connectionStrings.'storehub-db'
+    if (-not $raw.StartsWith('DPAPI:')) { return $raw }
+
+    Add-Type -AssemblyName System.Security
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    $entropy = $sha.ComputeHash([Text.Encoding]::UTF8.GetBytes('IndyPOS:ConnectionStrings:storehub-db'))
+    $cipher = [Convert]::FromBase64String($raw.Substring(6))
+    $plain = [System.Security.Cryptography.ProtectedData]::Unprotect(
+        $cipher, $entropy, [System.Security.Cryptography.DataProtectionScope]::LocalMachine)
+
+    return [Text.Encoding]::UTF8.GetString($plain)
+}
+
+function Invoke-StoreHubQuery {
+    param([string]$ConnectionString, [string]$Sql, [string]$PsqlPath)
+
+    $parts = @{}
+    foreach ($kv in $ConnectionString.Split(';')) {
+        if ($kv -match '^\s*([^=]+)=(.*)$') { $parts[$Matches[1].Trim()] = $Matches[2].Trim() }
+    }
+
+    $env:PGPASSWORD = $parts['Password']
+    try {
+        # SQL via stdin: native-argument quoting strips the double quotes psql needs.
+        return $Sql | & $PsqlPath -h $parts['Host'] -p $parts['Port'] -U $parts['Username'] `
+                                  -d $parts['Database'] -w -t -A -F '|'
+    }
+    finally { Remove-Item Env:PGPASSWORD -ErrorAction SilentlyContinue }
+}
+```
+
+Add the checks themselves, guarded by `-AssertDatabase`, asserting the spec §10 case-1 expectations against snapshot `Pre-Upgrade-2026-07-25`:
+
+```powershell
+if ($AssertDatabase) {
+    $conn = Get-StoreHubConnectionString -AppSettingsPath 'C:\ProgramData\IndyPOS\v4\StoreHub\appsettings.json'
+    $psql = 'C:\Program Files\PostgreSQL\18\bin\psql.exe'
+
+    $rows = Invoke-StoreHubQuery -ConnectionString $conn -PsqlPath $psql `
+        -Sql 'SELECT code, kind, is_enabled FROM payment_method ORDER BY code;'
+
+    # The snapshot is a genuine PRE-reclassification store: PayLater kind=1, WelfareCard kind=1.
+    Add-Check -Category 'Database' -Name 'PayLater reclassified to Special (kind=3)' `
+              -Pass ([bool]($rows | Where-Object { $_ -like 'PayLater|3|*' }))
+
+    Add-Check -Category 'Database' -Name 'WelfareCard is GovernmentCampaign (kind=2) and still enabled' `
+              -Pass ([bool]($rows | Where-Object { $_ -eq 'WelfareCard|2|t' }))
+
+    Add-Check -Category 'Database' -Name 'Cash and MoneyTransfer are Standard (kind=1)' `
+              -Pass (@($rows | Where-Object { $_ -like 'Cash|1|*' -or $_ -like 'MoneyTransfer|1|*' }).Count -eq 2)
+
+    $storeIds = Invoke-StoreHubQuery -ConnectionString $conn -PsqlPath $psql `
+        -Sql 'SELECT DISTINCT store_id FROM payment_method;'
+
+    # A second catalogue under STORE-<MachineName> is the exact orphaning that detection
+    # rule 2's non-empty Store:Id check exists to prevent.
+    Add-Check -Category 'Database' -Name 'Exactly one store id in payment_method' `
+              -Pass (@($storeIds | Where-Object { $_ }).Count -eq 1) `
+              -Detail ($storeIds -join ', ')
+}
+```
+
+Match `Add-Check`'s real parameter names to the ones already used in the file.
+
+- [ ] **Step 6: Verify the scripts parse and are ASCII**
+
+```bash
+pwsh -NoProfile -Command "\$null = [System.Management.Automation.Language.Parser]::ParseFile('scripts/vm-testing/Reset-AndInstall.ps1', [ref]\$null, [ref]\$e); if (\$e) { \$e; exit 1 }"
+pwsh -NoProfile -Command "\$null = [System.Management.Automation.Language.Parser]::ParseFile('scripts/vm-testing/Test-IndyPOSInstallation.ps1', [ref]\$null, [ref]\$e); if (\$e) { \$e; exit 1 }"
+```
+
+Expected: no parse errors.
+
+```bash
+pwsh -NoProfile -Command "Get-ChildItem scripts/vm-testing/*.ps1 | ForEach-Object { \$b = [IO.File]::ReadAllBytes(\$_.FullName); if (\$b | Where-Object { \$_ -gt 127 }) { \$_.Name } }"
+```
+
+Expected: no output. Any listed file contains non-ASCII bytes and will not parse under the guest's Windows-1252 codepage — replace the offending characters.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/vm-testing/
+git commit -m "test(vm): support upgrade snapshots, expected rollbacks and database assertions"
+```
+
+---
+
+## Task 14: Operator documentation
+
+Spec §3 (`Unusable` recovery must be documented per rule), §4 (the `pg_restore` command), §5 (forward-only migrations as a release gate) and §6.
+
+**Files:**
+- Create: `docs/operations/upgrade-procedure.md`
+- Modify: `docs/operations/update-procedure.md` (cross-link), `docs/operations/RUNBOOK.md` (index entry), `CLAUDE.md` (the forward-only migration rule)
+
+- [ ] **Step 1: Write the upgrade procedure**
+
+Create `docs/operations/upgrade-procedure.md` covering, in this order:
+
+1. **When to use this** — an in-place upgrade of a store already running IndyPOS v4. Fresh installs use `docs/operations/store-installation-guide.md`.
+2. **The command** — `IndyPOS-Setup.exe --silent` from an elevated prompt. `--store-id` is *not* needed and, if supplied, must match the installed store exactly. `--store-type` is needed only when the store predates 2026-07-18 and has no `Store:Type` key.
+3. **Exit codes** — `0` success · `1` usage · `2` failed (read `ROLLED_BACK`) · `3` not elevated · `4` timeout · `5` unusable (read `REASON`) · `6` downgrade refused.
+4. **Reading the result** — the markers in `C:\ProgramData\IndyPOS\v4\logs\install-latest.log`, with a table: `MODE`, `RESULT`, `FROM_VERSION`, `TO_VERSION`, `SERVICE_STARTED`, `HEALTH`, `BACKUP_DIR`, `BACKUP_LOCKED`, `POS_UPDATED`, `ROLLED_BACK`. Note explicitly that `POS_UPDATED=false` with `RESULT=success` means the POS app was already current — not a failure.
+5. **`Unusable` recovery, one section per detection rule:**
+   - *Rule 1 — a database from another major.* **Do not remove PostgreSQL; it holds the sales history.** Run the installer for the major that owns the existing install root (`C:\ProgramData\IndyPOS\v<N>`).
+   - *Rule 2, connection string.* Restore `appsettings.json` from the newest `backups\<stamp>\StoreHub\`. A `DPAPI:` value sealed on another machine can never be decrypted here.
+   - *Rule 2, `Store:Id`.* Set it to the store's real id — the one in `store_user.store_id` — before upgrading.
+   - *Rule 2, `Store:Type`.* Re-run with `--store-type GeneralHardware|Minimart`.
+   - *Rule 2, service ImagePath.* Re-register the service against `C:\ProgramData\IndyPOS\v4\StoreHub\IndyPOS.StoreHub.exe`.
+   - *Rule 4.* A config with no manifest — inspect the install root before proceeding.
+
+   **None of these sections may mention `cleanup-v4.ps1`.** That script drops `indypos_storehub` unconditionally unless `-SkipDatabase`.
+6. **Restoring the database dump** — a human decision, never automatic:
+
+```powershell
+# Stop the service first, then restore into the existing database.
+Stop-Service IndyPOS.StoreHub.v4
+$env:PGPASSWORD = '<indypos_app password from the connection string>'
+& 'C:\Program Files\PostgreSQL\18\bin\pg_restore.exe' `
+    --host=127.0.0.1 --port=5432 --username=indypos_app `
+    --dbname=indypos_storehub --clean --if-exists --no-owner --no-password `
+    'C:\ProgramData\IndyPOS\v4\backups\<stamp>\storehub.dump'
+Start-Service IndyPOS.StoreHub.v4
+```
+
+7. **Backups** — the last 2 stamps are kept under `C:\ProgramData\IndyPOS\v4\backups\`; each is roughly 130 MB. They are ACL-locked to Administrators + LocalSystem because the dump contains the full sales history and BCrypt admin hashes. `BACKUP_LOCKED=false` in the log means that failed — fix the ACL before leaving the store.
+8. **Known limitations** — copy spec §11 items 1, 2, 5 and 8 in operator language: Velopack is per-user so a cashier's profile may lag; the POS app self-updates independently; one machine per run; a store missing `StoreConfiguration.json` will not have one created by an upgrade.
+
+- [ ] **Step 2: Cross-link the existing docs**
+
+Add to `docs/operations/update-procedure.md`, near the top: a line pointing at `upgrade-procedure.md` as the authoritative in-place upgrade path. Add `upgrade-procedure.md` to the document index in `docs/operations/RUNBOOK.md`.
+
+- [ ] **Step 3: Record the forward-only migration release gate**
+
+Add to `CLAUDE.md` under **Coding Standards**, a new subsection. This is a standing rule with teeth, not documentation of this epic:
+
+```markdown
+### Database Migrations — Forward-Only (release gate)
+
+An upgrade rolls back binaries and config, **not schema**. Every migration in a release
+must therefore be runnable against the *previous* release's binaries:
+
+- Additive only. New columns nullable or with a default.
+- No renames, no drops, no type narrowing.
+- No new `NOT NULL` column without a default — the restored binaries' INSERT would fail
+  and the till could not complete a sale.
+
+A migration that breaks this makes the installer's rollback claim false.
+```
+
+- [ ] **Step 4: Verify the docs are ASCII-safe and links resolve**
+
+```bash
+pwsh -NoProfile -Command "\$b = [IO.File]::ReadAllBytes('docs/operations/upgrade-procedure.md'); if (\$b | Where-Object { \$_ -gt 127 }) { 'non-ascii present' } else { 'ascii clean' }"
+```
+
+Non-ASCII is acceptable in a Markdown doc (unlike guest scripts), but the embedded PowerShell block must be ASCII so it can be pasted into the guest.
+
+Confirm every relative link resolves: `docs/operations/store-installation-guide.md`, `docs/operations/update-procedure.md`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/operations/upgrade-procedure.md docs/operations/update-procedure.md docs/operations/RUNBOOK.md CLAUDE.md
+git commit -m "docs(operations): document the upgrade procedure and unusable-install recovery"
+```
+
+---
+
+## Final verification (after Task 14)
+
+Not a task — the gate before the branch is offered for review.
+
+- [ ] **Full build and test sweep**
+
+```bash
+dotnet build IndyPOS.sln -c Release
+dotnet test tests/IndyPOS.Bootstrapper.Tests
+dotnet test tests/IndyPOS.Domain.Tests
+dotnet test tests/IndyPOS.Application.Tests
+```
+
+Expected: Release build 0 errors. Bootstrapper ~160 pass / 8 skip. Domain 8/8. Application 274/274. StoreHub integration (76/76) needs Docker and is unaffected by this branch — run it if Docker is up.
+
+- [ ] **Confirm the refactor gate one last time**
+
+```bash
+git diff development -- installer/IndyPOS.Bootstrapper/Installers/FreshInstallOrchestrator.cs
+```
+
+The only changes may be the rename, the doc comment, and the delegations to `ServiceControl` / `StoreHubPayload` / `MigrationRunner` / `HealthProbe`. No reordering. No new conditionals.
+
+- [ ] **Rebuild the installer**
+
+```bash
+pwsh -NoProfile -File scripts/publish.ps1
+pwsh -NoProfile -File installer/build-installer.ps1
+```
+
+Note `scripts/publish.ps1` **deletes the whole `publish/` directory** on start — that is expected, but it means the current 190 MB `IndyPOS-Setup.exe` is gone until `build-installer.ps1` finishes.
+
+- [ ] **VM case 1 — happy upgrade**
+
+```bash
+pwsh -File scripts/vm-testing/Reset-AndInstall.ps1 -SnapshotName 'Pre-Upgrade-2026-07-25' -InstallerArgs '--silent' -KeepRunning
+```
+
+Assert: `MODE=upgrade`; `RESULT=success`; `Store:Id` **and `Store:Type`** preserved; config still `DPAPI:`-protected; service Running; health 200; dump present, non-trivial and ACL-locked; and the payment-method reclassification (`PayLater kind=3`, `WelfareCard kind=2` **still enabled**, `Cash`/`MoneyTransfer kind=1`) via `-AssertDatabase`.
+
+- [ ] **VM case 2 — forced mid-upgrade failure**
+
+```bash
+pwsh -File scripts/vm-testing/Reset-AndInstall.ps1 -SnapshotName 'Pre-Upgrade-2026-07-25' -InstallerArgs '--silent','--simulate-failure=deploy' -ExpectRollback
+```
+
+Assert: `ROLLED_BACK=true`, old version restored, real config back, service Running **and health ok**. Both of the original 2026-07-25 failures would have flunked this, so it is not optional.
+
+- [ ] **VM case 3 — fresh-install regression**
+
+```bash
+pwsh -File scripts/vm-testing/Reset-AndInstall.ps1 -SnapshotName 'Clean-Windows-Ready'
+```
+
+Assert: 18/18, `MODE=fresh`. **This gates distribution, not merge** — the branch may land before it, but no installer goes to a store until this passes.
+
+- [ ] **Park the VM**
+
+```bash
+pwsh -NoProfile -Command "Stop-VM -Name IndyPOS-Test -Force -TurnOff; Restore-VMSnapshot -VMName IndyPOS-Test -Name 'Pre-Upgrade-2026-07-25' -Confirm:\$false"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** §1 goals → Tasks 3, 8, 11. §2 architecture → Tasks 4, 5, 6 (+ the frozen-path gate at 6 step 6 and again in final verification). §3 detection → Tasks 1, 3; `--store-id` optional → Task 12; `Unusable` recovery docs → Task 14. §4 sequence → Task 11, with preflight in 9 and backup in 8. §5 failure handling → Task 11 (`RollBackAsync`); forward-only migrations → Task 14 step 3. §6 backup artifacts → Task 8. §7 markers → Task 10; `MODE` emitted by the router in Task 12. §8 data-loss path → Task 2 **and** detection rule 1 in Task 3. §9 entry points → Task 12. §10 testing → per-task unit tests plus Task 13 and the final verification. §11 limitations → documented in Task 14 step 1 item 8. §12 → Task 7 (`sq.version`) and Task 11 (`POS_UPDATED` derivation).
+
+**Two spec items deliberately deferred, and why:**
+- §11 item 9, raising the `migrate` command timeout past Npgsql's 30 s. The spec says "consider"; no migration today comes close, and changing it touches StoreHub's runtime rather than the installer. It belongs with the first long DDL migration, and Task 14's release-gate section is where that decision will be reached for.
+- §4's `--store-type`-writes-a-single-key option for a store missing `Store:Type`. Task 3 implements the other permitted branch — refuse as `Unusable` — which the spec explicitly allows ("Options when absent: require `--store-type` … or refuse"). Refusing is the smaller change and keeps the upgrade path from writing config, and Task 14 documents the `--store-type` re-run.
+
+**Type consistency check.** `StoreHubConfigFacts` is constructed positionally as `(Exists, ConnectionStringUsable, StoreId, StoreType)` in Tasks 1 and 3 — same order both times. `MigrationRunResult(Success, AdminSeeded, ErrorMessage)` in Tasks 5 and 11 match. `BackupResult(Success, StampDirectory, Locked, ErrorMessage)` in Tasks 8 and 11 match. `PreflightResult(Ok, PgDumpPath, ConnectionString, FailureReason, IsDowngrade)` in Tasks 9 and 11 match. `UpgradeSucceeded` / `UpgradeFailed` field order in Task 10 matches every construction in Task 11. `SimulatedFailure.Parse` is defined in Task 11 and consumed in Task 12.
+
+**One thing an implementer must verify rather than assume:** `DatabaseSetup.TryRestrictFilePermissions` takes a *file* path and uses `FileInfo.GetAccessControl`. Task 8 calls it on the stamp *directory*. If that throws at runtime, add the `DirectoryInfo`/`DirectorySecurity` sibling described in Task 8 step 4 — the ACL on the stamp directory is a real requirement, not a nicety, because `BackupsDirectory` inherits ProgramData's DACL granting `BUILTIN\Users` read.

--- a/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
+++ b/docs/superpowers/plans/2026-07-26-installer-upgrade-support.md
@@ -427,20 +427,20 @@ Append to `tests/IndyPOS.Bootstrapper.Tests/Installers/DatabaseSetupTests.cs` (k
 
 ```csharp
     [Fact]
-    public void BuildSuperuserGuardMessage_WhenAStoreDatabaseExists_ShouldNeverRecommendTheCleanupScript()
+    public void BuildSuperuserGuardMessage_WhenAnIndyPOSInstallExists_ShouldNeverRecommendTheCleanupScript()
     {
         // cleanup-v4.ps1 drops indypos_storehub unconditionally unless -SkipDatabase.
         // Recommending it to a live store destroys every sale ever recorded.
-        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: true);
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeInstallExists: true);
 
         message.Should().NotContain("cleanup-v4");
         message.Should().NotContain("-RemovePostgres");
     }
 
     [Fact]
-    public void BuildSuperuserGuardMessage_WhenAStoreDatabaseExists_ShouldPointAtTheUpgradeCommand()
+    public void BuildSuperuserGuardMessage_WhenAnIndyPOSInstallExists_ShouldPointAtTheUpgradeCommand()
     {
-        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: true);
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeInstallExists: true);
 
         message.Should().Contain("--silent");
         message.Should().Contain("existing IndyPOS database");
@@ -450,7 +450,7 @@ Append to `tests/IndyPOS.Bootstrapper.Tests/Installers/DatabaseSetupTests.cs` (k
     public void BuildSuperuserGuardMessage_OnABareMachine_ShouldStillOfferTheCleanupScript()
     {
         // No store data to lose here, so the fast path stays available.
-        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: false);
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeInstallExists: false);
 
         message.Should().Contain("cleanup-v4.ps1");
     }
@@ -482,14 +482,19 @@ Replace the guard block at lines 38-50 with:
 ```csharp
         if (string.IsNullOrEmpty(postgresPassword))
         {
-            var storeDatabaseExists = StoreHubConfigReader
+            // .Exists, NOT .ConnectionStringUsable. The latter is false for a store whose
+            // DPAPI value was sealed on another machine (a swapped POS terminal) or whose
+            // JSON is malformed — both real installs with real sales history. Branching on
+            // it would route exactly those stores to the destructive recommendation. This
+            // fails safe: the worst case is a manual PostgreSQL removal on a dead machine.
+            var storeInstallExists = StoreHubConfigReader
                 .Read(Path.Combine(config.StoreHubInstallPath, "appsettings.json"))
-                .ConnectionStringUsable;
+                .Exists;
 
             return new DatabaseSetupResult
             {
                 Success = false,
-                ErrorMessage = BuildSuperuserGuardMessage(storeDatabaseExists)
+                ErrorMessage = BuildSuperuserGuardMessage(storeInstallExists)
             };
         }
 ```
@@ -500,10 +505,11 @@ Add the message builder next to `GenerateJwtSecret`:
     /// <summary>
     /// The superuser password is deliberately not persisted (spec section 1), so an existing
     /// PostgreSQL cannot be provisioned into. What the operator should do next depends
-    /// entirely on whether there is a store database to protect.
+    /// entirely on whether IndyPOS was ever installed here — if it was, there is sales
+    /// history to protect and the cleanup script must not be named.
     /// </summary>
-    internal static string BuildSuperuserGuardMessage(bool storeDatabaseExists) =>
-        storeDatabaseExists
+    internal static string BuildSuperuserGuardMessage(bool storeInstallExists) =>
+        storeInstallExists
             ? "PostgreSQL 18 is already installed and this machine has an existing IndyPOS database.\n" +
               "Do NOT remove PostgreSQL — that would destroy the store's sales history.\n" +
               "Upgrade in place instead:\n" +

--- a/docs/superpowers/plans/2026-07-29-product-categories-and-store-types.md
+++ b/docs/superpowers/plans/2026-07-29-product-categories-and-store-types.md
@@ -1,0 +1,1781 @@
+# Data-driven product categories + store types — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the two-value `ProductCategory` enum with a store-scoped `product_category` catalogue so each of the three stores carries its own real category set, and add `MimyShop` as a store type.
+
+**Architecture:** Mirror Epic M's `payment_method` catalogue exactly — same composite key, same repository shape, same idempotent seeder, same endpoint shape. A `Kind` column (`GeneralGoods`/`Hardware`/`Service`) carries the product-type gate that is currently a string comparison against an enum name.
+
+**Tech Stack:** .NET 10, EF Core (Npgsql), Nokpirab mediator (handlers registered individually via `AddTransient`), xUnit + FluentAssertions, Testcontainers PostgreSQL for integration tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-product-categories-and-store-types-design.md`
+
+## Global Constraints
+
+- **Composite primary key `(StoreId, Code)`** — no `Guid Id`. This deliberately follows `PaymentMethod` (`PaymentMethodConfiguration` line 11: `builder.HasKey(e => new { e.StoreId, e.Code })`) rather than CLAUDE.md's general "all new entities use `Guid Id`" rule. Catalogue tables are keyed by their natural key in this codebase. **This corrects §3 of the spec**, which listed a `Guid Id`.
+- **Table and column names are snake_case** (`product_category`, `display_name`) — see `PaymentMethodConfiguration`.
+- **Enum backing values are persisted** via `HasConversion<int>()`. Never reuse or renumber a value.
+- **`StoreType` value `3` is retired, not reused.** `CoffeeShop = 3` is deleted; `MimyShop = 4`.
+- **Every repository method filters by `IStoreIdentityService.StoreId`** and `AddAsync` overwrites the caller's `StoreId`. Never trust a caller's store id.
+- **Seeders are idempotent and non-fatal**: insert only an absent `Code`, log, never throw into startup.
+- Thai display names are UTF-8 string literals in C# source. C# source files are UTF-8; this is safe (`PaymentMethodSeeder` already does it).
+- Migration tool changes are **out of scope** — that is Epic 2. This plan only unblocks it.
+
+---
+
+## File Structure
+
+**Domain**
+- Create `src/IndyPOS.Domain/Enums/ProductCategoryKind.cs` — the kind enum.
+- Create `src/IndyPOS.Domain/Entities/Core/ProductCategory.cs` — the catalogue entity.
+- Create `src/IndyPOS.Domain/ValueObjects/ProductCategoryPolicy.cs` — which kinds a store type may use. Pure.
+- Delete `src/IndyPOS.Domain/Entities/ProductCategory.cs` — dead code, verified zero references.
+- Modify `src/IndyPOS.Domain/Enums/StoreType.cs`, `src/IndyPOS.Domain/ValueObjects/StoreTypeFeatures.cs`.
+
+**Application**
+- Create `src/IndyPOS.Application/Common/Constants/ProductCategoryCodes.cs` — the stable codes.
+- Create `src/IndyPOS.Application/Abstractions/StoreHub/Repositories/IProductCategoryRepository.cs`.
+- Create `src/IndyPOS.Application/Common/Exceptions/UnknownProductCategoryException.cs` — maps to 400.
+- Create `src/IndyPOS.Application/UseCases/StoreHub/ProductCategories/ProductCategoryDto.cs`, `GetProductCategoriesQuery.cs`, `GetProductCategoriesQueryHandler.cs`.
+- Delete `src/IndyPOS.Application/Common/Enums/ProductCategories.cs`.
+- Modify the two product handlers.
+
+**Infrastructure**
+- Create `.../Persistence/StoreHub/Configurations/ProductCategoryConfiguration.cs`.
+- Create `.../Persistence/StoreHub/Repositories/ProductCategoryRepository.cs`.
+- Create `.../Persistence/StoreHub/Seeders/ProductCategorySeeder.cs` + its seed tables.
+- Modify `StoreHubDbContext.cs`, `StoreHubDbContextExtensions.cs`, `ConfigureServices.cs`, `HardcodedStoreConstants.cs`, `StoreHubInventoryProductService.cs`, `GetLegacySalesSummaryQueryHandler.cs`, `StoreHubHttpClient.cs`.
+- EF migration `AddProductCategoryTable`.
+
+**StoreHub** — modify `Program.cs` (DI + endpoint + seeding call).
+
+**WinForms** — modify the three inventory forms.
+
+**Installer** — modify `SilentArgs.cs` usage text; the wizard picker.
+
+---
+
+## Task 1: ProductCategoryKind + the store-type policy
+
+Pure Domain, no infrastructure. Establishes the vocabulary every later task uses.
+
+**Files:**
+- Create: `src/IndyPOS.Domain/Enums/ProductCategoryKind.cs`
+- Create: `src/IndyPOS.Domain/ValueObjects/ProductCategoryPolicy.cs`
+- Test: `tests/IndyPOS.Domain.Tests/ValueObjects/ProductCategoryPolicyTests.cs`
+
+**Interfaces:**
+- Consumes: `StoreTypeFeatures` (`IndyPOS.Domain.ValueObjects`), `StoreType` (`IndyPOS.Domain.Enums`).
+- Produces:
+  - `enum ProductCategoryKind { GeneralGoods = 1, Hardware = 2, Service = 3 }`
+  - `static class ProductCategoryPolicy` with `static bool IsUsable(ProductCategoryKind kind, StoreTypeFeatures features)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/IndyPOS.Domain.Tests/ValueObjects/ProductCategoryPolicyTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Domain.Enums;
+using IndyPOS.Domain.ValueObjects;
+
+namespace IndyPOS.Domain.Tests.ValueObjects;
+
+public class ProductCategoryPolicyTests
+{
+    [Fact]
+    public void IsUsable_WithGeneralGoods_ShouldAlwaysBeTrue()
+    {
+        // Every store sells general goods; this is the one kind with no gate.
+        foreach (var storeType in Enum.GetValues<StoreType>())
+        {
+            ProductCategoryPolicy
+                .IsUsable(ProductCategoryKind.GeneralGoods, StoreTypeFeatures.For(storeType))
+                .Should().BeTrue($"{storeType} must be able to sell general goods");
+        }
+    }
+
+    [Fact]
+    public void IsUsable_WithHardwareOnAGeneralOnlyStore_ShouldBeFalse()
+    {
+        var features = StoreTypeFeatures.For(StoreType.Minimart);
+
+        ProductCategoryPolicy.IsUsable(ProductCategoryKind.Hardware, features).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsUsable_WithHardwareOnAMultiTypeStore_ShouldBeTrue()
+    {
+        var features = StoreTypeFeatures.For(StoreType.GeneralHardware);
+
+        ProductCategoryPolicy.IsUsable(ProductCategoryKind.Hardware, features).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsUsable_WithServiceOnAGeneralOnlyStore_ShouldBeFalse()
+    {
+        // Services are a non-general kind, so the same gate applies. MimyShop seeds a
+        // Services category but cannot use it until the feature exists - see the spec's
+        // "Known gap" section. Failing closed is the safe direction.
+        var features = StoreTypeFeatures.For(StoreType.Minimart);
+
+        ProductCategoryPolicy.IsUsable(ProductCategoryKind.Service, features).Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Domain.Tests --filter FullyQualifiedName~ProductCategoryPolicyTests`
+Expected: FAIL — `ProductCategoryKind` and `ProductCategoryPolicy` do not exist (CS0246).
+
+- [ ] **Step 3: Write the enum**
+
+Create `src/IndyPOS.Domain/Enums/ProductCategoryKind.cs`:
+
+```csharp
+namespace IndyPOS.Domain.Enums;
+
+/// <summary>
+/// Classifies a catalogue product category. Carries the product-type gate that used to be a
+/// string comparison against an enum name.
+/// <para>Backing values are persisted (see ProductCategoryConfiguration), so never reuse one.</para>
+/// </summary>
+public enum ProductCategoryKind
+{
+    /// <summary>Everyday retail goods. Every store type may sell these.</summary>
+    GeneralGoods = 1,
+
+    /// <summary>Building materials and tools. GeneralHardware only.</summary>
+    Hardware = 2,
+
+    /// <summary>
+    /// A service rather than stock (e.g. MimyShop's บริการ). Recorded so the category has a
+    /// home; non-stock BEHAVIOUR is not implemented and needs Product.IsTrackable.
+    /// </summary>
+    Service = 3
+}
+```
+
+- [ ] **Step 4: Write the policy**
+
+Create `src/IndyPOS.Domain/ValueObjects/ProductCategoryPolicy.cs`:
+
+```csharp
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Domain.ValueObjects;
+
+/// <summary>
+/// Whether a store may use a category of a given kind. The single place this rule lives, so the
+/// create handler, the update handler and the UI cannot drift apart.
+/// </summary>
+public static class ProductCategoryPolicy
+{
+    public static bool IsUsable(ProductCategoryKind kind, StoreTypeFeatures features) =>
+        kind == ProductCategoryKind.GeneralGoods || features.MultipleProductTypesEnabled;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.Domain.Tests --filter FullyQualifiedName~ProductCategoryPolicyTests`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/IndyPOS.Domain/Enums/ProductCategoryKind.cs src/IndyPOS.Domain/ValueObjects/ProductCategoryPolicy.cs tests/IndyPOS.Domain.Tests/ValueObjects/ProductCategoryPolicyTests.cs
+git commit -m "feat(domain): add ProductCategoryKind and the store-type usability policy"
+```
+
+---
+
+## Task 2: Add MimyShop, remove CoffeeShop
+
+`CoffeeShop` has 9 code references. Removing it and adding `MimyShop` together keeps the enum compiling in one step.
+
+**Files:**
+- Modify: `src/IndyPOS.Domain/Enums/StoreType.cs`
+- Modify: `src/IndyPOS.Domain/ValueObjects/StoreTypeFeatures.cs`
+- Modify: `tests/IndyPOS.Domain.Tests/ValueObjects/StoreTypeFeaturesTests.cs:20`
+- Modify: `tests/IndyPOS.Domain.Tests/ValueObjects/PaymentMethodPolicyTests.cs:29`
+- Modify: `tests/IndyPOS.Mock/MockStoreIdentityService.cs:41-45`
+- Modify: `installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs:71`
+- Modify: `tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs:40`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `StoreType.MimyShop = 4`; `MockStoreIdentityService.MimyShop()` replacing `.CoffeeShop()`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/IndyPOS.Domain.Tests/ValueObjects/StoreTypeFeaturesTests.cs`, replace the `[InlineData(StoreType.CoffeeShop)]` line (line 20) with `[InlineData(StoreType.MimyShop)]`, then append this test to the class:
+
+```csharp
+    [Fact]
+    public void For_WithMimyShop_ShouldMatchMinimart()
+    {
+        // MimyShop differs from a minimart only in its seeded category set today. Modelling it
+        // as a real store type is deliberate (services and reporting will diverge), so this
+        // test pins that the flags are intentionally identical rather than accidentally copied.
+        StoreTypeFeatures.For(StoreType.MimyShop)
+            .Should().BeEquivalentTo(StoreTypeFeatures.For(StoreType.Minimart));
+    }
+
+    [Fact]
+    public void StoreType_ShouldNotDefineCoffeeShop()
+    {
+        // Removed 2026-07-29: coffee shops need a dedicated app. Value 3 stays reserved so a
+        // future type cannot silently inherit persisted CoffeeShop rows.
+        Enum.GetNames<StoreType>().Should().NotContain("CoffeeShop");
+        Enum.IsDefined(typeof(StoreType), 3).Should().BeFalse();
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Domain.Tests --filter FullyQualifiedName~StoreTypeFeaturesTests`
+Expected: FAIL to compile — `StoreType.MimyShop` does not exist.
+
+- [ ] **Step 3: Update the enum**
+
+Replace the body of `src/IndyPOS.Domain/Enums/StoreType.cs`:
+
+```csharp
+namespace IndyPOS.Domain.Enums;
+
+/// <summary>
+/// Type of store, determines available features.
+/// Immutable after installation.
+/// </summary>
+public enum StoreType
+{
+    /// <summary>
+    /// Full features: PayLater, multiple product types, all payment methods.
+    /// </summary>
+    GeneralHardware = 1,
+
+    /// <summary>
+    /// Limited features: No PayLater, general products only.
+    /// </summary>
+    Minimart = 2,
+
+    // 3 was CoffeeShop, removed 2026-07-29 - its products and services differ enough to
+    // deserve a dedicated app. Do NOT reuse the value: any store row still carrying 3 must
+    // fail to bind rather than silently become a different type.
+
+    /// <summary>
+    /// Gift/lifestyle shop. Same feature flags as <see cref="Minimart"/> today; it exists as its
+    /// own type because its product categories differ, and services plus reporting are expected
+    /// to diverge. Payment methods are expected to CONVERGE with Minimart, so do not add a
+    /// payment flag here.
+    /// </summary>
+    MimyShop = 4
+}
+```
+
+- [ ] **Step 4: Update the feature map**
+
+In `src/IndyPOS.Domain/ValueObjects/StoreTypeFeatures.cs`, replace the `StoreType.CoffeeShop => ...` arm with:
+
+```csharp
+        StoreType.MimyShop => new StoreTypeFeatures
+        {
+            PayLaterEnabled = false,
+            MultipleProductTypesEnabled = false
+        },
+```
+
+- [ ] **Step 5: Update the remaining CoffeeShop references**
+
+- `tests/IndyPOS.Domain.Tests/ValueObjects/PaymentMethodPolicyTests.cs:29` — change `[InlineData(StoreType.CoffeeShop)]` to `[InlineData(StoreType.MimyShop)]`.
+- `tests/IndyPOS.Mock/MockStoreIdentityService.cs` — rename the factory:
+
+```csharp
+    /// <summary>
+    /// Creates a mock configured for a MimyShop store (PayLater disabled).
+    /// </summary>
+    public static MockStoreIdentityService MimyShop() => new()
+    {
+        StoreType = StoreType.MimyShop
+    };
+```
+
+- `installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs:71` — change the usage message to:
+
+```csharp
+                        return ParseResult.Usage(
+                            "--store-type must be one of: GeneralHardware, Minimart, MimyShop.");
+```
+
+- `tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs:40` — change `[InlineData("CoffeeShop", StoreType.CoffeeShop)]` to `[InlineData("MimyShop", StoreType.MimyShop)]`.
+
+- [ ] **Step 6: Confirm no persisted CoffeeShop value exists**
+
+The spec requires checking before deletion. Run:
+
+```bash
+grep -rn "CoffeeShop" --include=*.json --include=*.ps1 --include=*.psd1 . | grep -v node_modules
+```
+
+Expected: no hits in `appsettings*.json`, installer scripts, or VM test config. Documentation hits are fine and are updated in Task 11. If a real config hit appears, STOP and report it — a live store carrying `Type=CoffeeShop` would fail to bind after this change.
+
+- [ ] **Step 7: Run the affected suites**
+
+Run:
+```bash
+dotnet test tests/IndyPOS.Domain.Tests
+dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~SilentArgsTests
+dotnet build IndyPOS.sln -c Debug
+```
+Expected: Domain tests pass, SilentArgs tests pass, solution builds (the mock rename may surface call sites — fix any `MockStoreIdentityService.CoffeeShop()` callers to `.MimyShop()`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/IndyPOS.Domain tests/IndyPOS.Domain.Tests tests/IndyPOS.Mock installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs
+git commit -m "feat(domain): add MimyShop store type and remove CoffeeShop"
+```
+
+---
+
+## Task 3: The ProductCategory entity, EF mapping and migration
+
+**Files:**
+- Create: `src/IndyPOS.Domain/Entities/Core/ProductCategory.cs`
+- Delete: `src/IndyPOS.Domain/Entities/ProductCategory.cs`
+- Create: `src/IndyPOS.Infrastructure/Persistence/StoreHub/Configurations/ProductCategoryConfiguration.cs`
+- Modify: `src/IndyPOS.Infrastructure/Persistence/StoreHub/StoreHubDbContext.cs:25` (add the DbSet after `PaymentMethods`)
+- Test: `tests/IndyPOS.StoreHub.IntegrationTests/ProductCategoryPersistenceTests.cs`
+
+**Interfaces:**
+- Consumes: `ProductCategoryKind` (Task 1).
+- Produces:
+  - `IndyPOS.Domain.Entities.Core.ProductCategory` with `string StoreId, string Code, string DisplayName, ProductCategoryKind Kind, bool IsEnabled, int DisplayOrder, DateTime CreatedUtc, DateTime LastModifiedUtc`
+  - `StoreHubDbContext.ProductCategories`
+
+- [ ] **Step 1: Confirm the legacy entity is dead before deleting it**
+
+Run:
+
+```bash
+grep -rn "Entities\.ProductCategory\|new ProductCategory(" --include=*.cs src/ tests/ | grep -v "Entities/Core" | grep -v Designer
+```
+
+Expected: only `src/IndyPOS.Domain/Entities/ProductCategory.cs` itself. If anything else appears, STOP: it must be migrated to the new entity or the file kept and renamed `LegacyProductCategory` instead of deleted.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/IndyPOS.StoreHub.IntegrationTests/ProductCategoryPersistenceTests.cs`. Follow the fixture pattern used by the existing payment-method integration tests in this project (`IntegrationTestBase` provisions the schema via `EnsureCreatedAsync`):
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Domain.Entities.Core;
+using IndyPOS.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace IndyPOS.StoreHub.IntegrationTests;
+
+public class ProductCategoryPersistenceTests : IntegrationTestBase
+{
+    [Fact]
+    public async Task ProductCategory_ShouldRoundTripThroughPostgres()
+    {
+        var now = DateTime.UtcNow;
+
+        DbContext.ProductCategories.Add(new ProductCategory
+        {
+            StoreId = "STORE-A",
+            Code = "PlumbingMaterials",
+            DisplayName = "วัสดุและอุปกรณ์ระบบประปา",
+            Kind = ProductCategoryKind.Hardware,
+            IsEnabled = true,
+            DisplayOrder = 14,
+            CreatedUtc = now,
+            LastModifiedUtc = now
+        });
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var loaded = await DbContext.ProductCategories.AsNoTracking()
+            .SingleAsync(c => c.StoreId == "STORE-A" && c.Code == "PlumbingMaterials");
+
+        loaded.Kind.Should().Be(ProductCategoryKind.Hardware);
+        loaded.DisplayName.Should().Be("วัสดุและอุปกรณ์ระบบประปา", "Thai labels must survive the round trip");
+        loaded.DisplayOrder.Should().Be(14);
+    }
+
+    [Fact]
+    public async Task ProductCategory_ShouldAllowTheSameCodeInDifferentStores()
+    {
+        // The whole point of store scoping: MimyShop's Toys and GeneralHardware's Toys are
+        // different rows, and a global unique constraint would reject the second store.
+        var now = DateTime.UtcNow;
+
+        foreach (var storeId in new[] { "STORE-B", "STORE-C" })
+        {
+            DbContext.ProductCategories.Add(new ProductCategory
+            {
+                StoreId = storeId, Code = "Toys", DisplayName = "ของเล่น",
+                Kind = ProductCategoryKind.GeneralGoods, IsEnabled = true, DisplayOrder = 1,
+                CreatedUtc = now, LastModifiedUtc = now
+            });
+        }
+
+        var act = async () => await DbContext.SaveChangesAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.StoreHub.IntegrationTests --filter FullyQualifiedName~ProductCategoryPersistenceTests`
+Expected: FAIL to compile — `ProductCategories` is not a member of `StoreHubDbContext`. (Docker must be running.)
+
+- [ ] **Step 4: Create the entity and delete the dead one**
+
+Create `src/IndyPOS.Domain/Entities/Core/ProductCategory.cs`:
+
+```csharp
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Domain.Entities.Core;
+
+/// <summary>
+/// A product category available in this store. Rows are data (not a hardcoded enum) because the
+/// three store types carry genuinely different category sets, and legacy category ids collide
+/// across them — id 10 is เบ็ดเตล็ด (misc) in GeneralHardware and ของขวัญ (gifts) in MimyShop.
+/// <para>Code is the stable key stored on <see cref="Product.Category"/> and used in reports.
+/// Codes are shared across stores where the meaning genuinely matches, which is what makes
+/// cross-store reporting a plain GROUP BY.</para>
+/// </summary>
+public class ProductCategory
+{
+    public string StoreId { get; set; } = default!;
+    public string Code { get; set; } = default!;
+    public string DisplayName { get; set; } = default!;
+    public ProductCategoryKind Kind { get; set; }
+    public bool IsEnabled { get; set; }
+    public int DisplayOrder { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime LastModifiedUtc { get; set; }
+}
+```
+
+Delete `src/IndyPOS.Domain/Entities/ProductCategory.cs` (confirmed dead in Step 1).
+
+- [ ] **Step 5: Add the EF configuration and DbSet**
+
+Create `src/IndyPOS.Infrastructure/Persistence/StoreHub/Configurations/ProductCategoryConfiguration.cs`:
+
+```csharp
+using IndyPOS.Domain.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace IndyPOS.Infrastructure.Persistence.StoreHub.Configurations;
+
+public class ProductCategoryConfiguration : IEntityTypeConfiguration<ProductCategory>
+{
+    public void Configure(EntityTypeBuilder<ProductCategory> builder)
+    {
+        builder.ToTable("product_category");
+        builder.HasKey(e => new { e.StoreId, e.Code });
+
+        builder.Property(e => e.StoreId).HasColumnName("store_id").HasMaxLength(50).IsRequired();
+        builder.Property(e => e.Code).HasColumnName("code").HasMaxLength(50).IsRequired();
+        builder.Property(e => e.DisplayName).HasColumnName("display_name").HasMaxLength(100).IsRequired();
+        builder.Property(e => e.Kind).HasColumnName("kind").HasConversion<int>().IsRequired();
+        builder.Property(e => e.IsEnabled).HasColumnName("is_enabled").IsRequired();
+        builder.Property(e => e.DisplayOrder).HasColumnName("display_order").IsRequired();
+        builder.Property(e => e.CreatedUtc).HasColumnName("created_utc").IsRequired();
+        builder.Property(e => e.LastModifiedUtc).HasColumnName("last_modified_utc").IsRequired();
+    }
+}
+```
+
+In `src/IndyPOS.Infrastructure/Persistence/StoreHub/StoreHubDbContext.cs`, add after the `PaymentMethods` line:
+
+```csharp
+    public DbSet<ProductCategory> ProductCategories => Set<ProductCategory>();
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.StoreHub.IntegrationTests --filter FullyQualifiedName~ProductCategoryPersistenceTests`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 7: Create the EF migration**
+
+Run:
+
+```bash
+dotnet ef migrations add AddProductCategoryTable \
+  --project src/IndyPOS.Infrastructure \
+  --startup-project src/IndyPOS.StoreHub \
+  --context StoreHubDbContext
+```
+
+Open the generated migration and confirm it contains **only** `CreateTable("product_category", ...)` with the composite primary key. There must be **no** data migration — no store runs v4, so there is no `Product.Category` data to reclassify (spec §6). If the migration contains anything else, something drifted; STOP and report.
+
+- [ ] **Step 8: Verify the migration applies to a fresh database**
+
+Run: `dotnet test tests/IndyPOS.StoreHub.IntegrationTests`
+Expected: the whole suite passes (76 pre-existing + 2 new = 78).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/IndyPOS.Domain/Entities src/IndyPOS.Infrastructure/Persistence/StoreHub tests/IndyPOS.StoreHub.IntegrationTests/ProductCategoryPersistenceTests.cs
+git commit -m "feat(storehub): add the store-scoped product_category table"
+```
+
+---
+
+## Task 4: The repository
+
+**Files:**
+- Create: `src/IndyPOS.Application/Abstractions/StoreHub/Repositories/IProductCategoryRepository.cs`
+- Create: `src/IndyPOS.Infrastructure/Persistence/StoreHub/Repositories/ProductCategoryRepository.cs`
+- Modify: `src/IndyPOS.Infrastructure/ConfigureServices.cs:72` (register beside `IPaymentMethodRepository`)
+- Test: `tests/IndyPOS.StoreHub.IntegrationTests/ProductCategoryRepositoryTests.cs`
+
+**Interfaces:**
+- Consumes: `ProductCategory` (Task 3), `IStoreIdentityService`.
+- Produces: `IProductCategoryRepository` with
+  `Task<IReadOnlyList<ProductCategory>> GetAllAsync(CancellationToken)`,
+  `Task<ProductCategory?> GetByCodeAsync(string code, CancellationToken)`,
+  `Task AddAsync(ProductCategory category, CancellationToken)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/IndyPOS.StoreHub.IntegrationTests/ProductCategoryRepositoryTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Domain.Entities.Core;
+using IndyPOS.Domain.Enums;
+using IndyPOS.Infrastructure.Persistence.StoreHub.Repositories;
+
+namespace IndyPOS.StoreHub.IntegrationTests;
+
+public class ProductCategoryRepositoryTests : IntegrationTestBase
+{
+    private ProductCategoryRepository CreateRepository(string storeId) =>
+        new(DbContext, new MockStoreIdentityService { StoreId = storeId });
+
+    private static ProductCategory Category(string code, int order, ProductCategoryKind kind) => new()
+    {
+        Code = code,
+        DisplayName = code,
+        Kind = kind,
+        IsEnabled = true,
+        DisplayOrder = order,
+        CreatedUtc = DateTime.UtcNow,
+        LastModifiedUtc = DateTime.UtcNow
+    };
+
+    [Fact]
+    public async Task GetAllAsync_ShouldReturnOnlyThisStoreOrderedByDisplayOrder()
+    {
+        var mine = CreateRepository("STORE-MINE");
+        await mine.AddAsync(Category("Toys", 2, ProductCategoryKind.GeneralGoods));
+        await mine.AddAsync(Category("Gifts", 1, ProductCategoryKind.GeneralGoods));
+
+        var theirs = CreateRepository("STORE-THEIRS");
+        await theirs.AddAsync(Category("PlumbingMaterials", 1, ProductCategoryKind.Hardware));
+
+        var result = await mine.GetAllAsync();
+
+        result.Select(c => c.Code).Should().Equal("Gifts", "Toys");
+    }
+
+    [Fact]
+    public async Task AddAsync_ShouldOverwriteACallerSuppliedStoreId()
+    {
+        // Never trust the caller's store id - the same guard PaymentMethodRepository applies.
+        var repository = CreateRepository("STORE-REAL");
+        var category = Category("Toys", 1, ProductCategoryKind.GeneralGoods);
+        category.StoreId = "STORE-SOMEONE-ELSE";
+
+        await repository.AddAsync(category);
+
+        (await repository.GetByCodeAsync("Toys")).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetByCodeAsync_ForAnotherStoresCode_ShouldReturnNull()
+    {
+        await CreateRepository("STORE-A").AddAsync(Category("Gifts", 1, ProductCategoryKind.GeneralGoods));
+
+        (await CreateRepository("STORE-B").GetByCodeAsync("Gifts")).Should().BeNull();
+    }
+}
+```
+
+If `MockStoreIdentityService` is not already referenced by this test project, add a project reference to `tests/IndyPOS.Mock` — the payment-method integration tests use the same mock, so follow whatever they do.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.StoreHub.IntegrationTests --filter FullyQualifiedName~ProductCategoryRepositoryTests`
+Expected: FAIL to compile — `ProductCategoryRepository` does not exist.
+
+- [ ] **Step 3: Write the interface**
+
+Create `src/IndyPOS.Application/Abstractions/StoreHub/Repositories/IProductCategoryRepository.cs`:
+
+```csharp
+using IndyPOS.Domain.Entities.Core;
+
+namespace IndyPOS.Application.Abstractions.StoreHub.Repositories;
+
+public interface IProductCategoryRepository
+{
+    Task<IReadOnlyList<ProductCategory>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<ProductCategory?> GetByCodeAsync(string code, CancellationToken cancellationToken = default);
+    Task AddAsync(ProductCategory category, CancellationToken cancellationToken = default);
+}
+```
+
+There is deliberately no `UpdateAsync`: the spec rules out an admin editing screen (categories are stable, unlike churning government campaigns). Add it when there is a reason.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/IndyPOS.Infrastructure/Persistence/StoreHub/Repositories/ProductCategoryRepository.cs`:
+
+```csharp
+using IndyPOS.Application.Abstractions.StoreHub.Repositories;
+using IndyPOS.Application.Common.Interfaces;
+using IndyPOS.Domain.Entities.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace IndyPOS.Infrastructure.Persistence.StoreHub.Repositories;
+
+public class ProductCategoryRepository : IProductCategoryRepository
+{
+    private readonly StoreHubDbContext _dbContext;
+    private readonly IStoreIdentityService _storeIdentity;
+
+    public ProductCategoryRepository(StoreHubDbContext dbContext, IStoreIdentityService storeIdentity)
+    {
+        _dbContext = dbContext;
+        _storeIdentity = storeIdentity;
+    }
+
+    public async Task<IReadOnlyList<ProductCategory>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var storeId = _storeIdentity.StoreId;
+        return await _dbContext.ProductCategories.AsNoTracking()
+            .Where(c => c.StoreId == storeId)
+            .OrderBy(c => c.DisplayOrder)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<ProductCategory?> GetByCodeAsync(string code, CancellationToken cancellationToken = default)
+    {
+        var storeId = _storeIdentity.StoreId;
+        return await _dbContext.ProductCategories.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.StoreId == storeId && c.Code == code, cancellationToken);
+    }
+
+    public async Task AddAsync(ProductCategory category, CancellationToken cancellationToken = default)
+    {
+        // Force the current store's identity — never trust the caller's StoreId.
+        category.StoreId = _storeIdentity.StoreId;
+
+        _dbContext.ProductCategories.Add(category);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}
+```
+
+- [ ] **Step 5: Register it**
+
+In `src/IndyPOS.Infrastructure/ConfigureServices.cs`, beside the `IPaymentMethodRepository` registration (line 72), add:
+
+```csharp
+		        .AddScoped<IProductCategoryRepository, ProductCategoryRepository>()
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.StoreHub.IntegrationTests --filter FullyQualifiedName~ProductCategoryRepositoryTests`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/IndyPOS.Application/Abstractions src/IndyPOS.Infrastructure tests/IndyPOS.StoreHub.IntegrationTests/ProductCategoryRepositoryTests.cs
+git commit -m "feat(storehub): add the product category repository"
+```
+
+---
+
+## Task 5: The category codes and per-store-type seed tables
+
+Data only, so it is worth its own task and its own review: these codes are the contract Epic 2's migration maps into.
+
+**Files:**
+- Create: `src/IndyPOS.Application/Common/Constants/ProductCategoryCodes.cs`
+- Test: `tests/IndyPOS.Application.Tests/Common/Constants/ProductCategoryCodesTests.cs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `static class ProductCategoryCodes` with one `const string` per code (names equal values).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/IndyPOS.Application.Tests/Common/Constants/ProductCategoryCodesTests.cs`:
+
+```csharp
+using System.Reflection;
+using FluentAssertions;
+using IndyPOS.Application.Common.Constants;
+
+namespace IndyPOS.Application.Tests.Common.Constants;
+
+public class ProductCategoryCodesTests
+{
+    private static IReadOnlyList<FieldInfo> Constants() =>
+        typeof(ProductCategoryCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => f is { IsLiteral: true, IsInitOnly: false })
+            .ToList();
+
+    [Fact]
+    public void EveryConstant_ShouldHaveAValueEqualToItsName()
+    {
+        // The code IS the identifier. A mismatch means a rename silently changed stored data.
+        foreach (var field in Constants())
+        {
+            field.GetValue(null).Should().Be(field.Name);
+        }
+    }
+
+    [Fact]
+    public void Codes_ShouldBeUnique()
+    {
+        var values = Constants().Select(f => (string)f.GetValue(null)!).ToList();
+
+        values.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void Codes_ShouldCoverEveryCategoryTheThreeStoresUse()
+    {
+        // 16 GeneralHardware + 17 MimyShop, minus the 4 codes shared between them
+        // (Toys, Stationery, Household, Miscellaneous). MimyMart's 10 are a subset of
+        // GeneralHardware's. See the spec's section 4 tables.
+        Constants().Should().HaveCount(29);
+    }
+
+    [Fact]
+    public void Codes_ShouldIncludeTheServicesCategory()
+    {
+        ProductCategoryCodes.Services.Should().Be("Services");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Application.Tests --filter FullyQualifiedName~ProductCategoryCodesTests`
+Expected: FAIL — `ProductCategoryCodes` does not exist.
+
+- [ ] **Step 3: Write the constants**
+
+Create `src/IndyPOS.Application/Common/Constants/ProductCategoryCodes.cs`:
+
+```csharp
+namespace IndyPOS.Application.Common.Constants;
+
+/// <summary>
+/// Stable product-category codes. Stored on <c>Product.Category</c> and mapped to by the
+/// SQLite migration, so a value here is a data contract — rename nothing without a migration.
+/// <para>Codes are shared across stores where the meaning genuinely matches (Toys, Stationery,
+/// Household, Miscellaneous), which is what makes cross-store reporting a plain GROUP BY.</para>
+/// </summary>
+public static class ProductCategoryCodes
+{
+    // --- General goods, present in GeneralHardware and MimyMart ---
+    public const string Miscellaneous = "Miscellaneous";              // เบ็ดเตล็ด
+    public const string Beverages = "Beverages";                      // เครื่องดื่ม
+    public const string Snacks = "Snacks";                            // ขนม
+    public const string AlcoholicBeverages = "AlcoholicBeverages";    // เครื่องดื่มแอลกอฮอล์
+    public const string Food = "Food";                                // อาหาร
+    public const string Stationery = "Stationery";                    // เครื่องเขียน
+    public const string Household = "Household";                      // ของใช้ในบ้าน
+    public const string ElectricalAppliances = "ElectricalAppliances";// เครื่องใช้ไฟฟ้า
+    public const string Toys = "Toys";                                // ของเล่น
+    public const string Medicine = "Medicine";                        // ยา
+
+    // --- GeneralHardware only ---
+    public const string Agriculture = "Agriculture";                          // การเกษตร
+    public const string GeneralMaterials = "GeneralMaterials";                // วัสดุและอุปกรณ์ทั่วไป
+    public const string MaterialsAndEquipment = "MaterialsAndEquipment";      // วัสดุและอุปกรณ์
+    public const string PlumbingMaterials = "PlumbingMaterials";              // วัสดุและอุปกรณ์ระบบประปา
+    public const string ElectricalMaterials = "ElectricalMaterials";          // วัสดุและอุปกรณ์ระบบไฟฟ้า
+    public const string ConstructionMaterials = "ConstructionMaterials";      // วัสดุก่อสร้างและอุปกรณ์การช่าง
+
+    // --- MimyShop only ---
+    public const string Gifts = "Gifts";                              // ของขวัญ
+    public const string BooksAndNotebooks = "BooksAndNotebooks";      // หนังสือและสมุด
+    public const string Cosmetics = "Cosmetics";                      // เครื่องสำอาง
+    public const string Jewellery = "Jewellery";                      // เครื่องประดับ
+    public const string Bags = "Bags";                                // กระเป๋า
+    public const string Fashion = "Fashion";                          // แฟชั่น
+    public const string Kitchenware = "Kitchenware";                  // เครื่องครัว
+    public const string SnacksAndBeverages = "SnacksAndBeverages";    // ขนมและเครื่องดื่ม
+    public const string MobileAccessories = "MobileAccessories";      // อุปกรณ์มือถือ
+    public const string Electronics = "Electronics";                  // อุปกรณ์อิเล็กทรอนิกส์
+    public const string PartySupplies = "PartySupplies";              // อุปกรณ์งานปาร์ตี้
+    public const string SeasonalGoods = "SeasonalGoods";              // สินค้าตามเทศกาล
+    public const string Services = "Services";                        // บริการ
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.Application.Tests --filter FullyQualifiedName~ProductCategoryCodesTests`
+Expected: PASS, 4 tests. If the count assertion fails, recount against the spec's §4 tables rather than editing the number to match.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/IndyPOS.Application/Common/Constants/ProductCategoryCodes.cs tests/IndyPOS.Application.Tests/Common/Constants/ProductCategoryCodesTests.cs
+git commit -m "feat(application): add stable product category codes"
+```
+
+---
+
+## Task 6: The per-store-type seeder
+
+The task that catches an id or name mix-up between MimyMart and MimyShop.
+
+**Files:**
+- Create: `src/IndyPOS.Infrastructure/Persistence/StoreHub/Seeders/ProductCategorySeeder.cs`
+- Modify: `src/IndyPOS.Infrastructure/ConfigureServices.cs:165` (register beside `PaymentMethodSeeder`)
+- Modify: `src/IndyPOS.Infrastructure/Persistence/StoreHub/StoreHubDbContextExtensions.cs` (add `SeedProductCategoriesAsync`)
+- Modify: `src/IndyPOS.StoreHub/Program.cs` (call it wherever `SeedPaymentMethodsAsync` is called)
+- Test: `tests/IndyPOS.StoreHub.IntegrationTests/ProductCategorySeederTests.cs`
+
+**Interfaces:**
+- Consumes: `IProductCategoryRepository` (Task 4), `ProductCategoryCodes` (Task 5), `ProductCategoryKind` (Task 1), `IStoreIdentityService`.
+- Produces: `ProductCategorySeeder` with `Task SeedAsync(CancellationToken)`; `IHost.SeedProductCategoriesAsync()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/IndyPOS.StoreHub.IntegrationTests/ProductCategorySeederTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Application.Common.Constants;
+using IndyPOS.Domain.Enums;
+using IndyPOS.Infrastructure.Persistence.StoreHub.Repositories;
+using IndyPOS.Infrastructure.Persistence.StoreHub.Seeders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace IndyPOS.StoreHub.IntegrationTests;
+
+public class ProductCategorySeederTests : IntegrationTestBase
+{
+    private async Task<IReadOnlyList<string>> SeedAndReadCodesAsync(string storeId, StoreType storeType)
+    {
+        var identity = new MockStoreIdentityService { StoreId = storeId, StoreType = storeType };
+        var repository = new ProductCategoryRepository(DbContext, identity);
+
+        await new ProductCategorySeeder(repository, identity,
+            NullLogger<ProductCategorySeeder>.Instance).SeedAsync();
+
+        DbContext.ChangeTracker.Clear();
+        return (await repository.GetAllAsync()).Select(c => c.Code).ToList();
+    }
+
+    [Fact]
+    public async Task SeedAsync_ForGeneralHardware_ShouldSeedSixteenIncludingFiveHardware()
+    {
+        var identity = new MockStoreIdentityService
+        {
+            StoreId = "STORE-GH", StoreType = StoreType.GeneralHardware
+        };
+        var repository = new ProductCategoryRepository(DbContext, identity);
+
+        await new ProductCategorySeeder(repository, identity,
+            NullLogger<ProductCategorySeeder>.Instance).SeedAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var seeded = await repository.GetAllAsync();
+
+        seeded.Should().HaveCount(16);
+        seeded.Count(c => c.Kind == ProductCategoryKind.Hardware).Should().Be(5);
+        seeded.Should().Contain(c => c.Code == ProductCategoryCodes.PlumbingMaterials);
+    }
+
+    [Fact]
+    public async Task SeedAsync_ForMinimart_ShouldSeedTenAndNoHardware()
+    {
+        var codes = await SeedAndReadCodesAsync("STORE-MM", StoreType.Minimart);
+
+        codes.Should().HaveCount(10);
+        codes.Should().NotContain(ProductCategoryCodes.PlumbingMaterials);
+    }
+
+    [Fact]
+    public async Task SeedAsync_ForMinimart_ShouldNotSeedTheLeftoverAgricultureCategory()
+    {
+        // MimyMart's category table was copied from GeneralHardware and การเกษตร came along as a
+        // leftover: 0 products and 0 invoice lines in the real database. Seeding it would put a
+        // category a minimart never sells in its picker.
+        var codes = await SeedAndReadCodesAsync("STORE-MM2", StoreType.Minimart);
+
+        codes.Should().NotContain(ProductCategoryCodes.Agriculture);
+    }
+
+    [Fact]
+    public async Task SeedAsync_ForMimyShop_ShouldSeedSeventeenIncludingServices()
+    {
+        // All 17 are seeded even though 12 have no products yet: MimyShop is a new store still
+        // adding inventory, so its unused categories are a plan, not detritus.
+        var codes = await SeedAndReadCodesAsync("STORE-MS", StoreType.MimyShop);
+
+        codes.Should().HaveCount(17);
+        codes.Should().Contain(ProductCategoryCodes.Services);
+        codes.Should().Contain(ProductCategoryCodes.Gifts);
+    }
+
+    [Fact]
+    public async Task SeedAsync_ForMimyShop_ShouldNotSeedMinimartOnlyGroceryCategories()
+    {
+        // The mix-up this test exists to catch: MimyShop and MimyMart share id ranges with
+        // completely different meanings, so a copy-paste between their seed tables is easy.
+        var codes = await SeedAndReadCodesAsync("STORE-MS2", StoreType.MimyShop);
+
+        codes.Should().NotContain(ProductCategoryCodes.Beverages);
+        codes.Should().NotContain(ProductCategoryCodes.AlcoholicBeverages);
+        codes.Should().NotContain(ProductCategoryCodes.Medicine);
+    }
+
+    [Fact]
+    public async Task SeedAsync_RunTwice_ShouldNotDuplicate()
+    {
+        var identity = new MockStoreIdentityService
+        {
+            StoreId = "STORE-TWICE", StoreType = StoreType.MimyShop
+        };
+        var repository = new ProductCategoryRepository(DbContext, identity);
+        var seeder = new ProductCategorySeeder(repository, identity,
+            NullLogger<ProductCategorySeeder>.Instance);
+
+        await seeder.SeedAsync();
+        DbContext.ChangeTracker.Clear();
+        await seeder.SeedAsync();
+        DbContext.ChangeTracker.Clear();
+
+        (await repository.GetAllAsync()).Should().HaveCount(17);
+    }
+
+    [Fact]
+    public async Task SeedAsync_ShouldGiveEachStoreItsOwnRows()
+    {
+        await SeedAndReadCodesAsync("STORE-A", StoreType.MimyShop);
+        var second = await SeedAndReadCodesAsync("STORE-B", StoreType.Minimart);
+
+        second.Should().HaveCount(10, "STORE-B must not see STORE-A's rows");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.StoreHub.IntegrationTests --filter FullyQualifiedName~ProductCategorySeederTests`
+Expected: FAIL to compile — `ProductCategorySeeder` does not exist.
+
+- [ ] **Step 3: Write the seeder**
+
+Create `src/IndyPOS.Infrastructure/Persistence/StoreHub/Seeders/ProductCategorySeeder.cs`:
+
+```csharp
+using IndyPOS.Application.Abstractions.StoreHub.Repositories;
+using IndyPOS.Application.Common.Constants;
+using IndyPOS.Application.Common.Interfaces;
+using IndyPOS.Domain.Entities.Core;
+using IndyPOS.Domain.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace IndyPOS.Infrastructure.Persistence.StoreHub.Seeders;
+
+/// <summary>
+/// Seeds this store's product categories. Idempotent — only inserts a Code that is absent.
+/// <para>Unlike <see cref="PaymentMethodSeeder"/>, the set depends on the STORE TYPE: the three
+/// stores carry genuinely different catalogues, and legacy category ids collide across them
+/// (id 10 is เบ็ดเตล็ด in GeneralHardware and ของขวัญ in MimyShop), so there is no shared default.</para>
+/// </summary>
+public class ProductCategorySeeder
+{
+    private readonly IProductCategoryRepository _repository;
+    private readonly IStoreIdentityService _storeIdentity;
+    private readonly ILogger<ProductCategorySeeder> _logger;
+
+    public ProductCategorySeeder(IProductCategoryRepository repository, IStoreIdentityService storeIdentity,
+        ILogger<ProductCategorySeeder> logger)
+    {
+        _repository = repository;
+        _storeIdentity = storeIdentity;
+        _logger = logger;
+    }
+
+    private sealed record Seed(string Code, string DisplayName, ProductCategoryKind Kind, int Order);
+
+    // Shared by GeneralHardware and Minimart, in legacy id order 10-19.
+    private static readonly Seed[] GroceryCommon =
+    [
+        new(ProductCategoryCodes.Miscellaneous, "เบ็ดเตล็ด", ProductCategoryKind.GeneralGoods, 1),
+        new(ProductCategoryCodes.Beverages, "เครื่องดื่ม", ProductCategoryKind.GeneralGoods, 2),
+        new(ProductCategoryCodes.Snacks, "ขนม", ProductCategoryKind.GeneralGoods, 3),
+        new(ProductCategoryCodes.AlcoholicBeverages, "เครื่องดื่มแอลกอฮอล์", ProductCategoryKind.GeneralGoods, 4),
+        new(ProductCategoryCodes.Food, "อาหาร", ProductCategoryKind.GeneralGoods, 5),
+        new(ProductCategoryCodes.Stationery, "เครื่องเขียน", ProductCategoryKind.GeneralGoods, 6),
+        new(ProductCategoryCodes.Household, "ของใช้ในบ้าน", ProductCategoryKind.GeneralGoods, 7),
+        new(ProductCategoryCodes.ElectricalAppliances, "เครื่องใช้ไฟฟ้า", ProductCategoryKind.GeneralGoods, 8),
+        new(ProductCategoryCodes.Toys, "ของเล่น", ProductCategoryKind.GeneralGoods, 9),
+        new(ProductCategoryCodes.Medicine, "ยา", ProductCategoryKind.GeneralGoods, 10)
+    ];
+
+    // GeneralHardware = the grocery set, plus การเกษตร (legacy 20) and the five วัสดุ* ranges (50-54).
+    private static readonly Seed[] GeneralHardwareSeeds =
+    [
+        .. GroceryCommon,
+        new(ProductCategoryCodes.Agriculture, "การเกษตร", ProductCategoryKind.GeneralGoods, 11),
+        new(ProductCategoryCodes.GeneralMaterials, "วัสดุและอุปกรณ์ทั่วไป", ProductCategoryKind.Hardware, 12),
+        new(ProductCategoryCodes.MaterialsAndEquipment, "วัสดุและอุปกรณ์", ProductCategoryKind.Hardware, 13),
+        new(ProductCategoryCodes.PlumbingMaterials, "วัสดุและอุปกรณ์ระบบประปา", ProductCategoryKind.Hardware, 14),
+        new(ProductCategoryCodes.ElectricalMaterials, "วัสดุและอุปกรณ์ระบบไฟฟ้า", ProductCategoryKind.Hardware, 15),
+        new(ProductCategoryCodes.ConstructionMaterials, "วัสดุก่อสร้างและอุปกรณ์การช่าง", ProductCategoryKind.Hardware, 16)
+    ];
+
+    // Minimart = the grocery set only. การเกษตร is deliberately absent: it was copied from
+    // GeneralHardware and has 0 products and 0 invoice lines in the real MimyMart database.
+    private static readonly Seed[] MinimartSeeds = [.. GroceryCommon];
+
+    // MimyShop reuses legacy ids 10-26 with entirely different meanings. All 17 are seeded even
+    // though 12 currently have no products: it is a new store still adding inventory.
+    private static readonly Seed[] MimyShopSeeds =
+    [
+        new(ProductCategoryCodes.Gifts, "ของขวัญ", ProductCategoryKind.GeneralGoods, 1),
+        new(ProductCategoryCodes.Toys, "ของเล่น", ProductCategoryKind.GeneralGoods, 2),
+        new(ProductCategoryCodes.Stationery, "เครื่องเขียน", ProductCategoryKind.GeneralGoods, 3),
+        new(ProductCategoryCodes.BooksAndNotebooks, "หนังสือและสมุด", ProductCategoryKind.GeneralGoods, 4),
+        new(ProductCategoryCodes.Cosmetics, "เครื่องสำอาง", ProductCategoryKind.GeneralGoods, 5),
+        new(ProductCategoryCodes.Jewellery, "เครื่องประดับ", ProductCategoryKind.GeneralGoods, 6),
+        new(ProductCategoryCodes.Bags, "กระเป๋า", ProductCategoryKind.GeneralGoods, 7),
+        new(ProductCategoryCodes.Fashion, "แฟชั่น", ProductCategoryKind.GeneralGoods, 8),
+        new(ProductCategoryCodes.Household, "ของใช้ในบ้าน", ProductCategoryKind.GeneralGoods, 9),
+        new(ProductCategoryCodes.Kitchenware, "เครื่องครัว", ProductCategoryKind.GeneralGoods, 10),
+        new(ProductCategoryCodes.SnacksAndBeverages, "ขนมและเครื่องดื่ม", ProductCategoryKind.GeneralGoods, 11),
+        new(ProductCategoryCodes.MobileAccessories, "อุปกรณ์มือถือ", ProductCategoryKind.GeneralGoods, 12),
+        new(ProductCategoryCodes.Electronics, "อุปกรณ์อิเล็กทรอนิกส์", ProductCategoryKind.GeneralGoods, 13),
+        new(ProductCategoryCodes.PartySupplies, "อุปกรณ์งานปาร์ตี้", ProductCategoryKind.GeneralGoods, 14),
+        new(ProductCategoryCodes.SeasonalGoods, "สินค้าตามเทศกาล", ProductCategoryKind.GeneralGoods, 15),
+        new(ProductCategoryCodes.Services, "บริการ", ProductCategoryKind.Service, 16),
+        new(ProductCategoryCodes.Miscellaneous, "เบ็ดเตล็ด", ProductCategoryKind.GeneralGoods, 17)
+    ];
+
+    public async Task SeedAsync(CancellationToken cancellationToken = default)
+    {
+        var storeType = _storeIdentity.StoreType;
+        var seeds = SeedsFor(storeType);
+        var now = DateTime.UtcNow;
+        var seededCount = 0;
+
+        foreach (var seed in seeds)
+        {
+            if (await _repository.GetByCodeAsync(seed.Code, cancellationToken) is not null) continue;
+
+            await _repository.AddAsync(new ProductCategory
+            {
+                Code = seed.Code,
+                DisplayName = seed.DisplayName,
+                Kind = seed.Kind,
+                IsEnabled = true,
+                DisplayOrder = seed.Order,
+                StoreId = _storeIdentity.StoreId,
+                CreatedUtc = now,
+                LastModifiedUtc = now
+            }, cancellationToken);
+            seededCount++;
+        }
+
+        _logger.LogInformation(
+            "Product category seeding complete for {StoreType}: {SeededCount} of {TotalCount} inserted",
+            storeType, seededCount, seeds.Length);
+    }
+
+    private static Seed[] SeedsFor(StoreType storeType) => storeType switch
+    {
+        StoreType.GeneralHardware => GeneralHardwareSeeds,
+        StoreType.Minimart => MinimartSeeds,
+        StoreType.MimyShop => MimyShopSeeds,
+        // A new store type with no seed table must be a loud failure, not an empty catalogue:
+        // an empty catalogue means no product can be created at all.
+        _ => throw new ArgumentOutOfRangeException(nameof(storeType), storeType,
+            "No product-category seed set is defined for this store type.")
+    };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.StoreHub.IntegrationTests --filter FullyQualifiedName~ProductCategorySeederTests`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Register and wire the seeder**
+
+In `src/IndyPOS.Infrastructure/ConfigureServices.cs`, beside `services.AddScoped<PaymentMethodSeeder>();` (line 165):
+
+```csharp
+		services.AddScoped<ProductCategorySeeder>();
+```
+
+In `src/IndyPOS.Infrastructure/Persistence/StoreHub/StoreHubDbContextExtensions.cs`, after `SeedPaymentMethodsAsync`:
+
+```csharp
+    /// <summary>
+    /// Seeds this store's product categories, chosen by store type.
+    /// Idempotent — safe to run on every start.
+    /// </summary>
+    public static async Task SeedProductCategoriesAsync(this IHost app)
+    {
+        using var scope = app.Services.CreateScope();
+        var seeder = scope.ServiceProvider.GetRequiredService<ProductCategorySeeder>();
+        await seeder.SeedAsync();
+    }
+```
+
+In `src/IndyPOS.StoreHub/Program.cs`, find every call to `SeedPaymentMethodsAsync()` and add immediately after each:
+
+```csharp
+await app.SeedProductCategoriesAsync();
+```
+
+Both the `migrate` CLI path and normal startup must seed, exactly as payment methods do.
+
+- [ ] **Step 6: Verify the wiring compiles and nothing regressed**
+
+Run:
+```bash
+dotnet build IndyPOS.sln -c Debug
+dotnet test tests/IndyPOS.StoreHub.IntegrationTests
+```
+Expected: builds clean; suite passes (78 from Task 3 + 3 from Task 4 + 7 = 88).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/IndyPOS.Infrastructure src/IndyPOS.StoreHub/Program.cs tests/IndyPOS.StoreHub.IntegrationTests/ProductCategorySeederTests.cs
+git commit -m "feat(storehub): seed product categories per store type"
+```
+
+---
+
+## Task 7: GET /product-categories
+
+**Files:**
+- Create: `src/IndyPOS.Application/UseCases/StoreHub/ProductCategories/ProductCategoryDto.cs`
+- Create: `src/IndyPOS.Application/UseCases/StoreHub/ProductCategories/GetProductCategoriesQuery.cs`
+- Create: `src/IndyPOS.Application/UseCases/StoreHub/ProductCategories/GetProductCategoriesQueryHandler.cs`
+- Modify: `src/IndyPOS.StoreHub/Program.cs` (register the handler near line 103; map the endpoint near line 332)
+- Test: `tests/IndyPOS.Application.Tests/UseCases/StoreHub/ProductCategories/GetProductCategoriesQueryHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `IProductCategoryRepository` (Task 4), `ProductCategoryKind` (Task 1).
+- Produces:
+  - `record ProductCategoryDto(string Code, string DisplayName, ProductCategoryKind Kind, bool IsEnabled, int DisplayOrder)`
+  - `record GetProductCategoriesQuery()`
+  - `GetProductCategoriesQueryHandler : IQueryHandler<GetProductCategoriesQuery, IReadOnlyList<ProductCategoryDto>>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/IndyPOS.Application.Tests/UseCases/StoreHub/ProductCategories/GetProductCategoriesQueryHandlerTests.cs`:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Application.Abstractions.StoreHub.Repositories;
+using IndyPOS.Application.UseCases.StoreHub.ProductCategories;
+using IndyPOS.Domain.Entities.Core;
+using IndyPOS.Domain.Enums;
+using Moq;
+
+namespace IndyPOS.Application.Tests.UseCases.StoreHub.ProductCategories;
+
+public class GetProductCategoriesQueryHandlerTests
+{
+    private static ProductCategory Row(string code, int order, bool enabled = true) => new()
+    {
+        StoreId = "STORE-A",
+        Code = code,
+        DisplayName = code,
+        Kind = ProductCategoryKind.GeneralGoods,
+        IsEnabled = enabled,
+        DisplayOrder = order,
+        CreatedUtc = DateTime.UtcNow,
+        LastModifiedUtc = DateTime.UtcNow
+    };
+
+    [Fact]
+    public async Task HandleAsync_ShouldReturnDisabledCategoriesToo()
+    {
+        // The POS filters for pickers; existing products referencing a disabled category must
+        // still render their label, so the endpoint returns everything with its IsEnabled flag.
+        var repository = new Mock<IProductCategoryRepository>();
+        repository.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+                  .ReturnsAsync([Row("Gifts", 1), Row("Retired", 2, enabled: false)]);
+
+        var result = await new GetProductCategoriesQueryHandler(repository.Object)
+            .HandleAsync(new GetProductCategoriesQuery(), CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result.Single(c => c.Code == "Retired").IsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ShouldPreserveTheRepositoryOrdering()
+    {
+        var repository = new Mock<IProductCategoryRepository>();
+        repository.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+                  .ReturnsAsync([Row("First", 1), Row("Second", 2)]);
+
+        var result = await new GetProductCategoriesQueryHandler(repository.Object)
+            .HandleAsync(new GetProductCategoriesQuery(), CancellationToken.None);
+
+        result.Select(c => c.Code).Should().Equal("First", "Second");
+    }
+}
+```
+
+If this test project does not already use Moq, mirror whatever mocking approach the existing payment-method handler tests use instead.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Application.Tests --filter FullyQualifiedName~GetProductCategoriesQueryHandlerTests`
+Expected: FAIL to compile — the query, DTO and handler do not exist.
+
+- [ ] **Step 3: Write the DTO, query and handler**
+
+Create `src/IndyPOS.Application/UseCases/StoreHub/ProductCategories/ProductCategoryDto.cs`:
+
+```csharp
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Application.UseCases.StoreHub.ProductCategories;
+
+public record ProductCategoryDto(
+    string Code, string DisplayName, ProductCategoryKind Kind, bool IsEnabled, int DisplayOrder);
+```
+
+Create `src/IndyPOS.Application/UseCases/StoreHub/ProductCategories/GetProductCategoriesQuery.cs`:
+
+```csharp
+namespace IndyPOS.Application.UseCases.StoreHub.ProductCategories;
+
+/// <summary>Every category for this store, enabled or not, in display order.</summary>
+public record GetProductCategoriesQuery();
+```
+
+Create `src/IndyPOS.Application/UseCases/StoreHub/ProductCategories/GetProductCategoriesQueryHandler.cs`:
+
+```csharp
+using IndyPOS.Application.Abstractions.StoreHub.Repositories;
+using IndyPOS.Application.Common.Interfaces;
+
+namespace IndyPOS.Application.UseCases.StoreHub.ProductCategories;
+
+public class GetProductCategoriesQueryHandler
+    : IQueryHandler<GetProductCategoriesQuery, IReadOnlyList<ProductCategoryDto>>
+{
+    private readonly IProductCategoryRepository _repository;
+
+    public GetProductCategoriesQueryHandler(IProductCategoryRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IReadOnlyList<ProductCategoryDto>> HandleAsync(
+        GetProductCategoriesQuery query, CancellationToken cancellationToken = default)
+    {
+        var categories = await _repository.GetAllAsync(cancellationToken);
+
+        return categories
+            .Select(c => new ProductCategoryDto(c.Code, c.DisplayName, c.Kind, c.IsEnabled, c.DisplayOrder))
+            .ToList();
+    }
+}
+```
+
+Match `IQueryHandler`'s exact signature as used by `GetOfferablePaymentMethodsQueryHandler` — if the interface names the method differently or omits the default token, follow that file.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/IndyPOS.Application.Tests --filter FullyQualifiedName~GetProductCategoriesQueryHandlerTests`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Register the handler and map the endpoint**
+
+In `src/IndyPOS.StoreHub/Program.cs`, after the payment-method handler registrations (line 107):
+
+```csharp
+builder.Services.AddTransient<IQueryHandler<GetProductCategoriesQuery, IReadOnlyList<ProductCategoryDto>>, GetProductCategoriesQueryHandler>();
+```
+
+After the `/payment-methods` endpoint (line ~339):
+
+```csharp
+// Product categories for this store (the POS renders pickers from this)
+app.MapGet("/product-categories", async (
+    IQueryHandler<GetProductCategoriesQuery, IReadOnlyList<ProductCategoryDto>> handler,
+    CancellationToken cancellationToken) =>
+{
+    var categories = await handler.HandleAsync(new GetProductCategoriesQuery(), cancellationToken);
+    return Results.Ok(categories);
+}).RequireAuthorization("CanReadProducts");
+```
+
+Add `using IndyPOS.Application.UseCases.StoreHub.ProductCategories;` to `Program.cs` if the usings are explicit rather than global.
+
+- [ ] **Step 6: Verify the endpoint end to end**
+
+Run: `dotnet build IndyPOS.sln -c Debug && dotnet test tests/IndyPOS.StoreHub.IntegrationTests`
+Expected: builds clean, suite still passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/IndyPOS.Application/UseCases/StoreHub/ProductCategories src/IndyPOS.StoreHub/Program.cs tests/IndyPOS.Application.Tests/UseCases/StoreHub/ProductCategories
+git commit -m "feat(storehub): expose GET /product-categories"
+```
+
+---
+
+## Task 8: Gate product create/update on the category's Kind
+
+Replaces the string comparison in both handlers. This is the behavioural heart of the epic.
+
+**Files:**
+- Create: `src/IndyPOS.Application/Common/Exceptions/UnknownProductCategoryException.cs`
+- Modify: `src/IndyPOS.Application/UseCases/StoreHub/Products/Create/CreateProductCommandHandler.cs:45-52`
+- Modify: `src/IndyPOS.Application/UseCases/StoreHub/Products/Update/UpdateProductCommandHandler.cs:52-59`
+- Modify: `src/IndyPOS.StoreHub/Program.cs:405-419` (POST /products) and the PUT arm at ~422-445
+- Test: `tests/IndyPOS.Application.Tests/UseCases/StoreHub/Products/CreateProductCategoryGateTests.cs`
+
+**Interfaces:**
+- Consumes: `IProductCategoryRepository` (Task 4), `ProductCategoryPolicy` (Task 1).
+- Produces: `UnknownProductCategoryException`; both handlers gain an `IProductCategoryRepository` constructor parameter.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/IndyPOS.Application.Tests/UseCases/StoreHub/Products/CreateProductCategoryGateTests.cs`. Copy the arrangement style (mocked `IProductRepository`, `MockStoreIdentityService`) from the existing product-type-restriction tests in this project so the constructor arguments match:
+
+```csharp
+using FluentAssertions;
+using IndyPOS.Application.Common.Constants;
+using IndyPOS.Application.Common.Exceptions;
+using IndyPOS.Domain.Entities.Core;
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Application.Tests.UseCases.StoreHub.Products;
+
+public class CreateProductCategoryGateTests
+{
+    private static ProductCategory Category(string code, ProductCategoryKind kind) => new()
+    {
+        StoreId = "STORE-A", Code = code, DisplayName = code, Kind = kind,
+        IsEnabled = true, DisplayOrder = 1,
+        CreatedUtc = DateTime.UtcNow, LastModifiedUtc = DateTime.UtcNow
+    };
+
+    [Fact]
+    public async Task HandleAsync_WithAnUnknownCategoryCode_ShouldThrowUnknownProductCategory()
+    {
+        // A code the catalogue does not define is a malformed request (400), not a conflict.
+        // Accepting it would put a product in a category nothing can resolve - the failure mode
+        // that made 'Other' payments unreportable.
+        var handler = BuildHandler(StoreType.GeneralHardware, category: null);
+
+        var act = async () => await handler.HandleAsync(
+            CommandWithCategory("NoSuchCategory"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnknownProductCategoryException>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithAHardwareCategoryOnAGeneralOnlyStore_ShouldThrowInvalidOperation()
+    {
+        // Existing product-type restriction behaviour, now driven by Kind rather than by
+        // comparing the category string to an enum name. Maps to 409.
+        var handler = BuildHandler(StoreType.Minimart,
+            Category(ProductCategoryCodes.PlumbingMaterials, ProductCategoryKind.Hardware));
+
+        var act = async () => await handler.HandleAsync(
+            CommandWithCategory(ProductCategoryCodes.PlumbingMaterials), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+                 .WithMessage("*not available*");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithAHardwareCategoryOnAMultiTypeStore_ShouldSucceed()
+    {
+        var handler = BuildHandler(StoreType.GeneralHardware,
+            Category(ProductCategoryCodes.PlumbingMaterials, ProductCategoryKind.Hardware));
+
+        var act = async () => await handler.HandleAsync(
+            CommandWithCategory(ProductCategoryCodes.PlumbingMaterials), CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithAGeneralGoodsCategoryOnAGeneralOnlyStore_ShouldSucceed()
+    {
+        var handler = BuildHandler(StoreType.Minimart,
+            Category(ProductCategoryCodes.Beverages, ProductCategoryKind.GeneralGoods));
+
+        var act = async () => await handler.HandleAsync(
+            CommandWithCategory(ProductCategoryCodes.Beverages), CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+}
+```
+
+Write the `BuildHandler(StoreType, ProductCategory?)` and `CommandWithCategory(string)` helpers to match `CreateProductCommandHandler`'s real constructor and `CreateProductCommand`'s real shape — read both files first. `BuildHandler` must stub `IProductCategoryRepository.GetByCodeAsync` to return the supplied category (or null) and `IProductRepository.ExistsByBarcodeAsync` to return false.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/IndyPOS.Application.Tests --filter FullyQualifiedName~CreateProductCategoryGateTests`
+Expected: FAIL — `UnknownProductCategoryException` does not exist and the handler takes no category repository.
+
+- [ ] **Step 3: Add the exception**
+
+Create `src/IndyPOS.Application/Common/Exceptions/UnknownProductCategoryException.cs`:
+
+```csharp
+namespace IndyPOS.Application.Common.Exceptions;
+
+/// <summary>
+/// The requested category code is not in this store's catalogue. A malformed request (400), not a
+/// conflict: accepting it would file a product under a category nothing can resolve.
+/// </summary>
+public class UnknownProductCategoryException : Exception
+{
+    public UnknownProductCategoryException(string message) : base(message) { }
+}
+```
+
+- [ ] **Step 4: Replace the gate in CreateProductCommandHandler**
+
+Add `IProductCategoryRepository _categoryRepository` as a constructor-injected field, then replace lines 44-52 (the `isHardware` block) with:
+
+```csharp
+        // Store-type gating driven by the category's Kind. The category must exist: an unknown
+        // code would file the product under something no report or picker can resolve.
+        var category = await _categoryRepository.GetByCodeAsync(command.Category, cancellationToken)
+            ?? throw new UnknownProductCategoryException(
+                $"Product category '{command.Category}' is not in this store's catalogue.");
+
+        if (!ProductCategoryPolicy.IsUsable(category.Kind, _storeIdentityService.Features))
+        {
+            _logger.LogWarning(
+                "Product creation rejected: Kind={Kind}, StoreType={StoreType}, Barcode={Barcode}",
+                category.Kind, _storeIdentityService.StoreType, command.Barcode);
+            throw new InvalidOperationException(
+                $"{category.DisplayName} products are not available for {_storeIdentityService.StoreType} stores.");
+        }
+```
+
+Add the usings for `IndyPOS.Application.Common.Exceptions` and `IndyPOS.Domain.ValueObjects`, and remove the now-unused `IndyPOS.Application.Common.Enums` using if nothing else in the file needs it.
+
+- [ ] **Step 5: Apply the identical change to UpdateProductCommandHandler**
+
+Make the same substitution at `UpdateProductCommandHandler.cs:52`. The message and logging use `command.Barcode` if present on the update command; if not, use the product id. Do not paraphrase — keep the two handlers' logic identical so they cannot drift.
+
+- [ ] **Step 6: Map the exception to 400**
+
+In `src/IndyPOS.StoreHub/Program.cs`, in **both** the POST `/products` and PUT `/products/{id:guid}` handlers, add a catch arm **before** the existing `InvalidOperationException` arm (order matters — a more specific exception must be caught first):
+
+```csharp
+    catch (UnknownProductCategoryException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run:
+```bash
+dotnet test tests/IndyPOS.Application.Tests
+dotnet test tests/IndyPOS.StoreHub.IntegrationTests
+```
+Expected: both pass. Pre-existing product-type-restriction tests may need their arrangement updated to stub the new repository — update them rather than deleting them; they assert real behaviour.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/IndyPOS.Application src/IndyPOS.StoreHub/Program.cs tests/IndyPOS.Application.Tests
+git commit -m "feat(storehub): gate products on the category Kind instead of a string comparison"
+```
+
+---
+
+## Task 9: The client method and the WinForms pickers
+
+**Files:**
+- Modify: `src/IndyPOS.Infrastructure/Services/StoreHub/StoreHubHttpClient.cs` (after the payment-method catalog block, ~line 305)
+- Modify: the `IStoreHubClient` interface the client implements (find it via the existing `GetOfferablePaymentMethodsAsync` declaration)
+- Modify: `src/IndyPOS.Windows.Forms/UI/Inventory/AddNewInventoryProductForm.cs:118-134`
+- Modify: `src/IndyPOS.Windows.Forms/UI/Inventory/AddNewInventoryProductWithCustomBarcodeForm.cs:106-120`
+- Modify: `src/IndyPOS.Windows.Forms/UI/Inventory/UpdateInventoryProductForm.cs:94-108`
+
+**Interfaces:**
+- Consumes: `ProductCategoryDto` (Task 7).
+- Produces: `Task<IReadOnlyList<ProductCategoryDto>> GetProductCategoriesAsync(CancellationToken)` on the StoreHub client.
+
+- [ ] **Step 1: Add the client method**
+
+In `src/IndyPOS.Infrastructure/Services/StoreHub/StoreHubHttpClient.cs`, after the payment-method catalog methods:
+
+```csharp
+    // ========================
+    // Product category catalog
+    // ========================
+
+    public Task<IReadOnlyList<ProductCategoryDto>> GetProductCategoriesAsync(
+        CancellationToken cancellationToken = default) =>
+        SendAuthenticatedAsync<IReadOnlyList<ProductCategoryDto>>(
+            HttpMethod.Get, "/product-categories", content: null, cancellationToken);
+```
+
+Declare it on the same interface that declares `GetOfferablePaymentMethodsAsync`.
+
+- [ ] **Step 2: Replace the combo population in all three forms**
+
+In each of the three forms, replace the body of `PopulateProductCategoryComboBoxAsync` with:
+
+```csharp
+	private async Task PopulateProductCategoryComboBoxAsync()
+	{
+		CategoryComboBox.Items.Clear();
+
+		IReadOnlyList<ProductCategoryDto> categories;
+		bool multipleTypes = true;
+		try
+		{
+			categories = await _storeHubClient.GetProductCategoriesAsync();
+			multipleTypes = (await _storeHubClient.GetStoreFeaturesAsync()).MultipleProductTypesEnabled;
+		}
+		catch
+		{
+			// The server still guards creation, so a fetch failure must not block data entry.
+			// Leaving the list empty would do exactly that, so surface nothing and let the
+			// operator retry rather than silently offering a wrong set.
+			return;
+		}
+
+		foreach (var category in categories.Where(c => c.IsEnabled))
+		{
+			// Hide kinds this store may not use; the server rejects them anyway.
+			if (!multipleTypes && category.Kind != ProductCategoryKind.GeneralGoods)
+				continue;
+
+			CategoryComboBox.Items.Add(category.DisplayName);
+		}
+	}
+```
+
+Each form stores the selected **DisplayName** in the combo today. The value sent to the server must be the **Code**, so add a field mapping display name back to code, populated in the same loop:
+
+```csharp
+	private readonly Dictionary<string, string> _categoryCodeByDisplayName = new();
+```
+
+Add `_categoryCodeByDisplayName[category.DisplayName] = category.Code;` inside the loop, clear it alongside `CategoryComboBox.Items.Clear()`, and where the form currently derives a category value for the save call, look the code up from the selected text. **Read each form's save path before editing** — they differ, and sending a DisplayName where a Code is expected would make every product creation fail with `UnknownProductCategoryException`.
+
+- [ ] **Step 3: Remove the hardcoded dictionary and enum**
+
+- Delete `src/IndyPOS.Application/Common/Enums/ProductCategories.cs`.
+- In `src/IndyPOS.Infrastructure/Constants/HardcodedStoreConstants.cs`, delete the `ProductCategories` dictionary, its initialisation, and the `IReadOnlyDictionary<int, string> ProductCategories` property — plus the member on whatever interface declares it.
+- In `src/IndyPOS.Infrastructure/Services/StoreHub/StoreHubInventoryProductService.cs`, remove `MapCategoryName` (~line 250) and the two `(int)ProductCategory.GeneralGoods` fallbacks (~lines 256, 262). Read the surrounding methods and replace the category handling with the string `Code` carried straight through; this service predates the catalogue and should no longer translate ids.
+- In `src/IndyPOS.Infrastructure/QueryHandlers/Reports/GetLegacySalesSummaryQueryHandler.cs:135`, replace the `nameof(ProductCategory.Hardware)` comparison. This handler reports on **historical** rows, so it must classify by looking the category code up in the catalogue and testing `Kind == ProductCategoryKind.Hardware`. Inject `IProductCategoryRepository`, fetch once with `GetAllAsync`, and build a `HashSet<string>` of hardware codes rather than querying per row.
+
+- [ ] **Step 4: Build and run everything**
+
+Run:
+```bash
+dotnet build IndyPOS.sln -c Release
+dotnet test tests/IndyPOS.Domain.Tests
+dotnet test tests/IndyPOS.Application.Tests
+dotnet test tests/IndyPOS.StoreHub.IntegrationTests
+dotnet test tests/IndyPOS.Windows.Forms.Tests
+```
+Expected: Release build 0 errors; all suites pass. Compile errors are the main signal here — every remaining reference to the deleted enum surfaces now.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/IndyPOS.Infrastructure src/IndyPOS.Windows.Forms src/IndyPOS.Application
+git commit -m "feat(pos): render category pickers from the catalogue and drop the hardcoded enum"
+```
+
+---
+
+## Task 10: Installer store-type support and documentation
+
+**Files:**
+- Modify: `installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs` (the store-type picker)
+- Modify: `docs/operations/store-installation-guide.md`
+- Modify: `docs/operations/upgrade-procedure.md` (the `--store-type` recovery section lists valid values)
+- Modify: `CLAUDE.md` if it enumerates store types
+- Test: `tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs` (already updated in Task 2)
+
+**Interfaces:**
+- Consumes: `StoreType.MimyShop` (Task 2).
+- Produces: no new code interfaces.
+
+- [ ] **Step 1: Verify the parser already accepts MimyShop**
+
+`SilentArgs.TryParseStoreTypeName` matches against `Enum.GetNames<StoreType>()`, so `--store-type MimyShop` works the moment the enum value exists. Confirm:
+
+Run: `dotnet test tests/IndyPOS.Bootstrapper.Tests --filter FullyQualifiedName~SilentArgsTests`
+Expected: PASS, including the `[InlineData("MimyShop", StoreType.MimyShop)]` case added in Task 2.
+
+- [ ] **Step 2: Add MimyShop to the wizard picker**
+
+Find the store-type combo in `installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs` (search for `_storeTypeComboBox`). If it is populated from `Enum.GetNames<StoreType>()`, nothing is needed — verify and note it. If the values are hardcoded, add `MimyShop` and remove `CoffeeShop`.
+
+- [ ] **Step 3: Update the documentation**
+
+Replace every enumeration of supported store types with **GeneralHardware, Minimart, MimyShop**, and remove CoffeeShop:
+
+```bash
+grep -rn "CoffeeShop" docs/ CLAUDE.md .claude/STATUS.md
+```
+
+In `docs/operations/upgrade-procedure.md`, the `Store:Type is missing` recovery section names valid values — update it to `GeneralHardware`, `Minimart`, or `MimyShop`.
+
+- [ ] **Step 4: Verify**
+
+Run: `dotnet build IndyPOS.sln -c Release && dotnet test tests/IndyPOS.Bootstrapper.Tests`
+Expected: 0 errors; suite passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add installer docs CLAUDE.md .claude/STATUS.md
+git commit -m "feat(installer): support the MimyShop store type and drop CoffeeShop from docs"
+```
+
+---
+
+## Task 11: Full verification sweep
+
+Not a code task — the gate before this branch is offered for review.
+
+- [ ] **Step 1: Build and test everything**
+
+```bash
+dotnet build IndyPOS.sln -c Release
+dotnet test tests/IndyPOS.Domain.Tests
+dotnet test tests/IndyPOS.Application.Tests
+dotnet test tests/IndyPOS.StoreHub.IntegrationTests
+dotnet test tests/IndyPOS.Bootstrapper.Tests
+dotnet test tests/IndyPOS.Windows.Forms.Tests
+dotnet test tests/IndyPOS.Vault.Tests
+```
+
+Expected: Release 0 errors, and these counts:
+
+| Suite | Before | New | After |
+|---|---|---|---|
+| Domain | 8 | 6 (4 policy + 2 store type) | 14 |
+| Application | 274 | 10 (4 codes + 2 query + 4 gate) | 284 |
+| StoreHub integration | 76 | 12 (2 persistence + 3 repository + 7 seeder) | 88 |
+| Bootstrapper | 223 / 8 skip | 0 | 223 / 8 skip |
+
+No suite regresses. Pre-existing product-type-restriction tests may need their arrangement
+updated for the new constructor parameter — that is expected, not a regression.
+
+- [ ] **Step 2: Confirm the enum and dictionary are really gone**
+
+```bash
+grep -rn "ProductCategory\.GeneralGoods\|ProductCategory\.Hardware\|ProductCategories\[" --include=*.cs src/ tests/ | grep -v Designer
+```
+
+Expected: no hits. Any remaining hit means a call site still classifies by the old enum.
+
+- [ ] **Step 3: Confirm CoffeeShop is gone from code**
+
+```bash
+grep -rn "CoffeeShop" --include=*.cs --include=*.json --include=*.ps1 src/ tests/ installer/ scripts/
+```
+
+Expected: no hits. Historical mentions in `docs/superpowers/plans/` and `.superpowers/sdd/progress.md` are records of past decisions — leave them.
+
+- [ ] **Step 4: Verify a fresh install seeds the right catalogue for each store type**
+
+For each of `GeneralHardware`, `Minimart`, `MimyShop`, run StoreHub's `migrate` against a scratch database with `Store:Type` set accordingly, then:
+
+```sql
+SELECT code, kind, is_enabled, display_order FROM product_category ORDER BY display_order;
+```
+
+Expected row counts: 16, 10, 17. Confirm no `Hardware` kind appears for Minimart or MimyShop, and that MimyShop has exactly one `Service`.
+
+- [ ] **Step 5: Hand off to Epic 2**
+
+The migration hardening epic maps legacy category ids to these codes per store. Confirm `ProductCategoryCodes` covers every id in the three real databases:
+
+```bash
+python -c "
+import sqlite3, os
+base = r'.planning/indypos-overhaul/sqlite_database'
+for s in ['GeneralHardware','MimyMart','MimyShop']:
+    c = sqlite3.connect(os.path.join(base, s, 'Store.db'))
+    print(s, sorted(r[0] for r in c.execute('SELECT Id FROM ProductCategory')))
+"
+```
+
+Expected: GeneralHardware `[10..20, 50..54]`, MimyMart `[10..20]`, MimyShop `[10..26]`. Every id except MimyMart's 20 must have a code in Task 5's table. Record any mismatch in the Epic 2 spec rather than fixing it here.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| §3 data model (table, columns, `Kind`) | 1, 3 |
+| §3 remove enum + `HardcodedStoreConstants.ProductCategories` | 9 |
+| §3 legacy entity rename | 3 — **changed to deletion**: grep proved zero references, so deleting is simpler than renaming. Step 1 stops and reverts to a rename if that proves wrong |
+| §4 seed data, all three store types | 5, 6 |
+| §4 MimyMart drops `Agriculture`; MimyShop keeps empties | 6 (two dedicated tests) |
+| §4 no orphaned category ids | 11 step 5 |
+| §5 `MimyShop = 4`, `CoffeeShop` removed, 3 reserved | 2 |
+| §5 installer `--store-type` + wizard | 10 |
+| §6 seeder per store type, in `migrate` | 6 |
+| §6 `GET /product-categories` | 7 |
+| §6 no data migration needed | 3 step 7 asserts the migration is create-only |
+| §7 unknown code → 400 | 8 |
+| §7 wrong kind → 409 | 8 |
+| §7 disabled category hidden for new, rendered for existing | 7 (endpoint returns disabled), 9 (picker filters) |
+| §8 `IsTrackable` gap | Documented in Task 1's enum comment; deliberately not implemented |
+| §9 testing per layer | 1, 4, 6, 7, 8 |
+
+**Deviations from the spec, both deliberate:** composite key instead of `Guid Id` (stated in Global Constraints, matches `PaymentMethod`); legacy entity deleted rather than renamed (evidence-gated in Task 3 step 1).
+
+**Placeholder scan:** no TBD/TODO. Three places tell the implementer to read a file before editing rather than showing final code — the three WinForms save paths (Task 9 step 2), `GetLegacySalesSummaryQueryHandler` (Task 9 step 3), and the `BuildHandler` helper (Task 8 step 1). These are genuinely file-specific and the surrounding code was not read during planning; each states exactly what to look for and what breaks if it is got wrong.
+
+**Type consistency:** `ProductCategoryKind` (1) is used identically in 3, 5, 6, 7, 8, 9. `IProductCategoryRepository`'s three methods (4) are consumed as declared in 6, 7, 8, 9. `ProductCategoryDto`'s five fields (7) match the client and picker usage (9). `ProductCategoryPolicy.IsUsable(kind, features)` (1) is called with that argument order in 8. `ProductCategoryCodes` members (5) are referenced in 6 and 8 by the same names.

--- a/docs/superpowers/specs/2026-07-25-installer-upgrade-support-design.md
+++ b/docs/superpowers/specs/2026-07-25-installer-upgrade-support-design.md
@@ -1,8 +1,9 @@
 # In-Place Upgrade Support for the IndyPOS Installer — Design
 
-**Status:** 🟢 Ready for planning
+**Status:** 🟢 Ready for planning — no open questions
 **Created:** 2026-07-25
 **Revised:** 2026-07-25 after two independent spec reviews (correctness; scope/buildability)
+**Revised:** 2026-07-26 — §12 Velopack spike run on the VM; step 8 confirmed, no design change
 **Trigger:** VM upgrade smoke test on `IndyPOS-Test` (two failed runs, both diagnosed)
 
 ---
@@ -144,7 +145,8 @@ Rules are evaluated **in order**; the first match wins.
 6  Migrate       MigrationRunner: StoreHub.exe migrate
 7  Start service + HealthProbe
 --- server upgrade complete ---
-8  POS app       re-run embedded Velopack setup
+8  POS app       re-run embedded Velopack setup; read current\sq.version
+                 before and after to derive POS_UPDATED (verified, §12)
 9  Manifest      InstallManifestWriter.WriteAsync (new version, same paths)
 10 Markers       MODE, RESULT, SERVICE_STARTED, HEALTH, BACKUP_DIR,
                  BACKUP_LOCKED, POS_UPDATED, ROLLED_BACK
@@ -168,7 +170,7 @@ Connection-string parsing uses `NpgsqlConnectionStringBuilder`, not string split
 |---|---|
 | 0–3 | Nothing mutated. Report and exit. |
 | 4–7 | **Roll back:** delete `StoreHubInstallPath`, copy the backup tree back, `ConfigSnapshot.Restore()`, start the service, **run `HealthProbe`**, emit `ROLLED_BACK=true` with post-rollback `SERVICE_STARTED` / `HEALTH`, report the backup path. |
-| 8 | **No rollback.** The server is upgraded and serving. `RESULT=failed` with `SERVICE_STARTED=true, POS_UPDATED=false`. |
+| 8 | **No rollback.** The server is upgraded and serving. `RESULT=failed` with `SERVICE_STARTED=true, POS_UPDATED=false`. The spike confirms step 8 cannot disturb the service (§12), so the two are genuinely independent. |
 | 9–10 | Non-fatal. A stale manifest is cosmetic and the next run repairs it. |
 
 **Rollback is delete-then-copy, not copy-over.** Extraction is per-entry `ExtractToFile(overwrite: true)` with no clean step (`StoreHubInstaller.cs:227-235`), so after step 4 the tree is `old ∪ new`. Copying the backup over that would leave new-version files behind, violating goal 2.
@@ -259,15 +261,38 @@ Both entry points consume **one** detection result from a single router — if `
 4. **No PostgreSQL version management.**
 5. **Single machine per run.**
 6. **`LocalToken:SecretKey` is preserved**, so existing POS sessions survive an upgrade — a real benefit, but it also means the key is never rotated over the product's lifetime.
-7. **A release version bump is a precondition.** `Directory.Build.props` pins the version and requires a manual edit; without a bump, downgrade protection always takes the same-version repair branch, `InstalledVersion` is decorative, and step 8 has nothing newer to install so `POS_UPDATED=true` would be a lie. Define step 8's behaviour when Velopack has nothing newer.
+7. **A release version bump is a precondition.** `Directory.Build.props` pins the version and requires a manual edit; without a bump, downgrade protection always takes the same-version repair branch and `InstalledVersion` is decorative. Step 8 itself is safe without a bump — the spike measured a 2.5 s repair exiting 0 (§12) — and reports `POS_UPDATED=false` because it compares `sq.version` rather than trusting the exit code.
 8. **`StoreConfiguration.json` is create-if-absent on the fresh path**, so skipping `DatabaseSetup` loses nothing — but an upgrade of a store missing that file will not create it either.
 9. **`migrate` inherits Npgsql's 30s command timeout.** A future long DDL migration over a multi-year invoice table would time out and trigger a rollback for no real reason. Consider raising it on the migrate path.
 
 ---
 
-## 12. Open question for planning
+## 12. Step 8 — resolved by spike (2026-07-26)
 
-**Step 8's behaviour is unverified.** Nothing in the codebase establishes what the embedded Velopack `Setup.exe --silent` does on a machine where the app is already installed — `VelopackLauncher` just runs it and checks the exit code. This should be settled by a 30-minute spike on the existing VM *before* the orchestrator is written: if Velopack refuses or reinstalls destructively, step 8 and §5 row 8 both change.
+**Question:** what does the embedded Velopack `Setup.exe --silent` do on a machine where the POS app is already installed? Step 8 and §5 row 8 both depended on the answer.
+
+**Method.** Both cases were run against checkpoint `Pre-Upgrade-2026-07-25` (a real store image with `IndyPOS.POS.v4` 4.0.0 installed and the StoreHub service Running), restoring the snapshot between them. A 4.0.1 package was produced with `vpk pack` from the existing `publish\WinForms` output; the shipping 4.0.0 `Setup.exe` served the same-version case. Canary files were planted at the install root and inside `current\` to detect sweeping. This invoked the Velopack `Setup.exe` directly rather than through `VelopackLauncher`, which is the same executable with the same `--silent` argument.
+
+| | 4.0.1 over 4.0.0 | 4.0.0 over 4.0.0 |
+|---|---|---|
+| Exit code | 0 | 0 |
+| Elapsed | 7.5 s | 2.5 s |
+| `current\sq.version` | 4.0.0 → **4.0.1** | 4.0.0 → 4.0.0 |
+| `packages\` | old `.nupkg` pruned, 4.0.1 written | unchanged |
+| StoreHub service | untouched | **Running → Running** |
+| `C:\ProgramData\IndyPOS\v4` | untouched | untouched |
+| Shortcuts | preserved, same two paths | preserved, same two paths |
+| POS process after | none launched | none launched |
+
+**Conclusions:**
+
+1. **Step 8 stands as designed.** Velopack upgrades in place, prunes the superseded package, and reports 0. No refusal, no destructive reinstall — so §5 row 8 ("no rollback; the server is already serving") remains correct.
+2. **Nothing newer is a safe repair, not a failure.** The same-version run rebuilt `current\` from the existing package and exited 0 in 2.5 s. This closes the §11.7 open item: step 8 needs no special case, but `POS_UPDATED` must not be inferred from the exit code.
+3. **`POS_UPDATED` is derived by reading `current\sq.version` before and after** and comparing. The exit code cannot distinguish an upgrade from a repair, and the binaries keep their own build stamp — Velopack's `sq.version` (a nuspec document carrying `<version>`) is the only truthful record of what is installed.
+4. **Setup sweeps foreign files from the install root.** Both canaries were deleted, at the root as well as inside `current\`. IndyPOS keeps no state there — its data lives under `C:\ProgramData\IndyPOS\v4` — so nothing is at risk today, but the install root must never be used for store state.
+5. **The POS-app step cannot disturb the server.** The service stayed Running across a full package swap, confirming steps 7 and 8 are independent and that step 8's failure genuinely does not warrant rollback.
+
+Untested and still a limitation, not a blocker: running setup as a *different* admin than the one that installed (§11.1) — the spike ran as the installing user throughout.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-25-installer-upgrade-support-design.md
+++ b/docs/superpowers/specs/2026-07-25-installer-upgrade-support-design.md
@@ -1,0 +1,188 @@
+# In-Place Upgrade Support for the IndyPOS Installer — Design
+
+**Status:** 🟢 Ready for planning
+**Created:** 2026-07-25
+**Trigger:** VM upgrade smoke test on `IndyPOS-Test`, 2026-07-25 (two failed runs, both diagnosed)
+
+---
+
+## 1. Problem
+
+`IndyPOS-Setup.exe` is a **fresh-install-only** tool. Running it over an existing install fails, and fails destructively. Both failure modes were reproduced on a real store image (VM `IndyPOS-Test`, store `Rungrat-001`, StoreHub 4.0.0 running):
+
+**Failure 1 — locked binaries.** `StoreHubInstaller.InstallAsync` extracted the StoreHub payload *before* stopping the service, so the running service held its own DLLs open:
+
+```
+ERROR: StoreHub installation failed: The process cannot access the file
+'...\v4\StoreHub\Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.dll'
+because it is being used by another process.
+```
+
+**Failure 2 — no upgrade concept.** With the stop/extract order corrected, the run reached `DatabaseSetup` and stopped there:
+
+```
+ERROR: Database setup failed: PostgreSQL 18 is already installed, but its
+superuser password is unknown (the installer doesn't persist it across runs).
+```
+
+This is by design: `PostgresInstaller` returns `SuperuserPassword = ""` for an existing install (`PostgresInstaller.cs:58`), and `DatabaseSetup.SetupAsync` refuses to continue without it (`DatabaseSetup.cs:38-50`). The guard is correct — it exists to stop `psql` hanging on an interactive password prompt. The bug is that **the installer asks the database-provisioning question at all on an upgrade**, where the database, the `indypos_app` role, its password, and a working DPAPI-protected connection string already exist.
+
+**Collateral damage.** Both failures left the store worse than before. Extraction overwrites `appsettings.json` with the package template and `DatabaseSetup` only writes the real values afterwards, so a failure in between strands the store on a config it cannot start from — observed as a template config with an empty `Store:Id` and, after the stop/extract fix, a stopped service. The database and its data were never at risk in either run.
+
+**Why this was never caught.** Every validation to date has been a clean install from a wiped snapshot (the 18/18 verifier suite). No release has ever been upgrade-tested. Consequently **there is no supported upgrade path to the three live stores today.**
+
+### Goals
+
+1. Running the installer on a machine that already has IndyPOS upgrades it, rather than failing.
+2. A failed upgrade leaves the store running the version it started on.
+3. The store's identity, database, and secrets survive an upgrade untouched.
+4. The fresh-install path keeps its current behaviour exactly — it is the only path validated in production.
+
+### Non-goals
+
+- **PostgreSQL major-version upgrades.** Out of scope; requires data migration and is its own project.
+- **Config merging.** A preserved config does not gain new keys introduced by a newer template (see §7).
+- **Multi-terminal orchestration.** The installer upgrades the machine it runs on. A second POS terminal is its own run.
+- **Automatic database rollback.** A dump is taken and left as a recovery artifact; restoring it is a human decision (§5).
+- **Downgrade.** Refused (§4, step 1).
+
+---
+
+## 2. Architecture
+
+A dedicated upgrade sequence beside the existing install sequence, selected by a detector, with both composing shared step units.
+
+```
+                    InstallModeDetector
+                            |
+            Fresh  --------- + --------- Upgrade
+              |                             |
+   InstallationOrchestrator          UpgradeOrchestrator
+              |                             |
+              +----------- shared ----------+
+                  ServiceControl
+                  StoreHubPayload
+                  SchemaProvisioner
+                  ConfigSnapshot
+                  UpgradeBackup (upgrade only)
+```
+
+An upgrade is not a variation on a fresh install — it is a different algorithm with different safety requirements (back up first, roll back on failure, never touch database provisioning). Forcing both through one flow is what produced Failure 1: a step order that is correct for a fresh install and destructive for an upgrade. Keeping the validated path structurally frozen while the new path is built and tested separately is also the lower-risk way to reach three live stores.
+
+Rejected alternatives:
+
+- **Branch inside `InstallationOrchestrator`.** Cheapest to write, but threads new conditionals through the only path with production validation, and makes the upgrade sequence hard to read or test in isolation.
+- **Make every step idempotent and mode-agnostic.** `DatabaseSetup` would still have to distinguish "reuse existing" from "provision new" — mode detection in disguise — with maximum blast radius on the fresh path.
+
+---
+
+## 3. Mode detection
+
+```csharp
+enum InstallMode { Fresh, Upgrade, Unusable }
+
+record DetectedInstall(
+    InstallMode Mode,
+    string? InstalledVersion,   // from install-manifest.json
+    string? StoreId,            // from appsettings.json — see note
+    string  Reason);            // human-readable, surfaced on Unusable
+```
+
+Three outcomes, not two. A machine can be neither freshly installable nor upgradeable — the state observed after Failure 2 had a manifest and a registered service but a template config with no connection string. `Fresh` would fail on Postgres provisioning; `Upgrade` would fail on the missing connection string. Detecting that up front and refusing is strictly better than discovering it halfway through.
+
+| Manifest at `$SystemRoot\install-manifest.json` | Config has usable connection string | Mode |
+|---|---|---|
+| absent | absent | `Fresh` |
+| present | present | `Upgrade` |
+| present | absent or unreadable | `Unusable` |
+| absent | present | `Unusable` |
+
+"Usable connection string" means `ConnectionStrings:storehub-db` exists, is non-empty, and — when `DPAPI:`-marked — round-trips through `SecretProtector.Unprotect("ConnectionStrings:storehub-db", value)`. That is the same check the upgrade needs anyway to run `pg_dump`, so detection and preflight share one code path. A value that fails to decrypt means the config came from a different machine, which is exactly an `Unusable` store.
+
+**`StoreId` comes from `appsettings.json`, not the manifest.** `InstallManifest` records `InstallVersion`, paths, service identifiers, `DatabaseName`, `AppUser` and `PostgresBinPath`, but **not** the store id. Reading `Store:Id` from the StoreHub config works on stores already deployed today, which a manifest change could not. Adding `StoreId` to a future `ManifestVersion = 2` is optional convenience and deliberately not required here.
+
+**Store-id conflict.** If `--store-id` is passed and differs from the detected `Store:Id`, the run fails before mutating anything. Silently rewriting a store's identity would orphan its sales history from its reports.
+
+---
+
+## 4. The upgrade sequence
+
+```
+0  Detect        -> Upgrade (+ installed version, store id)
+1  Preflight     elevation; refuse downgrade (allow same-version repair);
+                 pg_dump present at manifest PostgresBinPath;
+                 read + DPAPI-unprotect the connection string
+2  Backup        pg_dump           -> <BackupsDirectory>\<stamp>\storehub.dump
+                 copy StoreHub dir -> <BackupsDirectory>\<stamp>\StoreHub\
+                 ConfigSnapshot.Capture(appsettings.json)
+--- nothing above this line mutates the install ---
+3  Stop service
+4  Deploy        StoreHubPayload.Extract   (overwrites config with template)
+5  Restore config  ConfigSnapshot.Restore()
+6  Migrate       StoreHub.exe migrate
+7  Start service + health probe
+--- server upgrade complete ---
+8  POS app       re-run embedded Velopack setup
+9  Manifest      InstallManifestWriter.WriteAsync (new version, same paths)
+10 Markers       MODE, RESULT, SERVICE_STARTED, HEALTH, BACKUP_DIR, POS_UPDATED
+```
+
+**Step 5 is the heart of the design.** `DatabaseSetup` never runs on an upgrade — no superuser password is needed, no role is created, no connection string is generated. The existing config is preserved verbatim. This is what makes Failure 2 disappear rather than be worked around.
+
+`BackupsDirectory` already exists in `InstallationConfig` and the manifest, and the directory is already present in a deployed install tree — no new path concept is introduced.
+
+`SchemaProvisioner` (step 6) is today's `StoreHubInstaller.ProvisionDatabaseAsync`, which runs `IndyPOS.StoreHub.exe migrate` as a one-shot console process before the service starts. On an upgrade it applies pending EF migrations; the payment-method seeder it also runs is idempotent (insert-if-absent), so re-running is safe.
+
+---
+
+## 5. Failure handling
+
+| Failing step | Action |
+|---|---|
+| 1–2 | Nothing mutated. Report and exit. |
+| 3–7 | **Roll back:** `ConfigSnapshot.Restore()`, restore the StoreHub dir from backup, start the service, report the backup path. Store resumes on its previous version. |
+| 8 | **No rollback.** The server is upgraded and serving; tearing that down to fix a POS copy would be worse. Report `RESULT=failed` with `SERVICE_STARTED=true, POS_UPDATED=false`. |
+| 9–10 | Non-fatal. The upgrade succeeded; a stale manifest is cosmetic and is repaired by the next run. |
+
+`RESULT` keeps its existing two values (`success`, `failed`) so the VM harness gating rule is unchanged. The additional markers say *what* succeeded.
+
+**Migrations are forward-only.** EF applies each migration in its own transaction on PostgreSQL, so a failed migration leaves a consistent but possibly partially-advanced schema. Rollback restores binaries and config, not schema. Old binaries against an additively-advanced schema is tolerable in practice — and the `pg_dump` from step 2 is the escape hatch when it is not. Automatic database restore is deliberately excluded: it is riskier than the failure it would fix.
+
+---
+
+## 6. Testing
+
+**Unit-testable — real seams, so these get real tests:**
+
+| Unit | Cases |
+|---|---|
+| `InstallModeDetector` | all four table rows of §3; store-id conflict; a `DPAPI:` value that fails to decrypt → `Unusable` |
+| `ConfigSnapshot` | ✅ built and tested 2026-07-25 (5 tests): byte-exact restore, absent-at-capture, template cleanup, idempotency |
+| `UpgradeBackup` | file copy + restore round-trip over temp dirs; restore when backup is absent |
+| Marker mapping | pure, mirroring `SilentOutcomeMapper`: `MODE`, `BACKUP_DIR`, `POS_UPDATED` permutations |
+
+**No seam — the VM's job:** `ServiceControl` (`ServiceController` is not injectable), `pg_dump`, Velopack.
+
+**VM validation** on `IndyPOS-Test` from checkpoint `Pre-Upgrade-2026-07-25` (a genuine pre-reclassification store: `PayLater kind=1`, `WelfareCard kind=1`, `Store:Id=Rungrat-001`, service running):
+
+1. **Happy upgrade** — `MODE=upgrade`; `PayLater kind=3`; `WelfareCard kind=2` **and still enabled**; `Cash`/`MoneyTransfer` `kind=1`; config still `DPAPI:`-protected with `Store:Id=Rungrat-001`; service Running; health 200; `storehub.dump` present in the backup dir.
+2. **Forced mid-upgrade failure** — induce a failure between steps 4 and 7 and assert the store came back on its old version with its real config and a running service. This is the case both of today's failures would have flunked, so it is not optional.
+3. **Fresh-install regression** — one clean install still reaching 18/18, proving the refactor into shared units changed nothing on the validated path.
+
+Case 3 needs a clean Windows snapshot. `Clean-Windows` and `Clean-Windows-Ready` were deleted in the 2026-07-25 disk cleanup, along with the Win11 ISO, so **rebuilding the clean snapshot is a prerequisite for case 3** and should be planned as its own task.
+
+---
+
+## 7. Known limitations
+
+1. **No config merge.** Step 5 restores the old `appsettings.json` wholesale, so keys introduced by a newer package template are absent after an upgrade. StoreHub must rely on code-side defaults (`IOptions<T>` defaults) for anything new. A merge is YAGNI until a release actually needs a new key.
+2. **Velopack is per-user.** Re-running setup under `--silent` updates the profile the installer runs as. A cashier's copy on another profile can be left on the old version until Velopack's own update path reaches it.
+3. **Forward-only migrations** (§5).
+4. **No PostgreSQL version management.** An upgrade assumes the installed major version is the one the release targets.
+5. **Single machine per run** (§1 non-goals).
+
+---
+
+## 8. Out-of-scope defect found alongside
+
+`StoreHubInstaller` stopped the service after extracting rather than before. The reorder plus a `ConfigSnapshot` guard was implemented on branch `fix/installer-upgrade-path` on 2026-07-25 (`ConfigSnapshot` + 5 tests; bootstrapper suite 101 pass / 8 skip). That fix is a strict improvement to the fresh path too — any extraction failure now leaves config intact — and this design assumes it as its starting point. Note its guard covers extraction failure only; the broader rollback in §5 supersedes it for the upgrade path.

--- a/docs/superpowers/specs/2026-07-25-installer-upgrade-support-design.md
+++ b/docs/superpowers/specs/2026-07-25-installer-upgrade-support-design.md
@@ -2,7 +2,8 @@
 
 **Status:** 🟢 Ready for planning
 **Created:** 2026-07-25
-**Trigger:** VM upgrade smoke test on `IndyPOS-Test`, 2026-07-25 (two failed runs, both diagnosed)
+**Revised:** 2026-07-25 after two independent spec reviews (correctness; scope/buildability)
+**Trigger:** VM upgrade smoke test on `IndyPOS-Test` (two failed runs, both diagnosed)
 
 ---
 
@@ -10,7 +11,7 @@
 
 `IndyPOS-Setup.exe` is a **fresh-install-only** tool. Running it over an existing install fails, and fails destructively. Both failure modes were reproduced on a real store image (VM `IndyPOS-Test`, store `Rungrat-001`, StoreHub 4.0.0 running):
 
-**Failure 1 — locked binaries.** `StoreHubInstaller.InstallAsync` extracted the StoreHub payload *before* stopping the service, so the running service held its own DLLs open:
+**Failure 1 — locked binaries.** `StoreHubInstaller.InstallAsync` extracted the payload *before* stopping the service, so the running service held its own DLLs open:
 
 ```
 ERROR: StoreHub installation failed: The process cannot access the file
@@ -18,61 +19,72 @@ ERROR: StoreHub installation failed: The process cannot access the file
 because it is being used by another process.
 ```
 
-**Failure 2 — no upgrade concept.** With the stop/extract order corrected, the run reached `DatabaseSetup` and stopped there:
+**Failure 2 — no upgrade concept.** With the order corrected, the run reached `DatabaseSetup` and stopped:
 
 ```
 ERROR: Database setup failed: PostgreSQL 18 is already installed, but its
 superuser password is unknown (the installer doesn't persist it across runs).
 ```
 
-This is by design: `PostgresInstaller` returns `SuperuserPassword = ""` for an existing install (`PostgresInstaller.cs:58`), and `DatabaseSetup.SetupAsync` refuses to continue without it (`DatabaseSetup.cs:38-50`). The guard is correct — it exists to stop `psql` hanging on an interactive password prompt. The bug is that **the installer asks the database-provisioning question at all on an upgrade**, where the database, the `indypos_app` role, its password, and a working DPAPI-protected connection string already exist.
+That guard is correct in itself — it exists to stop `psql` hanging on an interactive password prompt (`DatabaseSetup.cs:38-50`, `PostgresInstaller.cs:53-59`). The defect is that **the installer asks the database-provisioning question at all on an upgrade**, where the database, the `indypos_app` role, its password and a working DPAPI-protected connection string already exist.
 
-**Collateral damage.** Both failures left the store worse than before. Extraction overwrites `appsettings.json` with the package template and `DatabaseSetup` only writes the real values afterwards, so a failure in between strands the store on a config it cannot start from — observed as a template config with an empty `Store:Id` and, after the stop/extract fix, a stopped service. The database and its data were never at risk in either run.
+**Collateral damage.** Both failures left the store worse off. Extraction overwrites `appsettings.json` with the package template and `DatabaseSetup` only writes the real values afterwards, so a failure in between strands the store on a config it cannot start from — observed as a template config with an empty `Store:Id`, and after the stop/extract fix, a stopped service. The database was never at risk in either run.
 
-**Why this was never caught.** Every validation to date has been a clean install from a wiped snapshot (the 18/18 verifier suite). No release has ever been upgrade-tested. Consequently **there is no supported upgrade path to the three live stores today.**
+**Why it was never caught.** Every validation to date is a clean install from a wiped snapshot (the 18-check verifier). No release has ever been upgrade-tested.
+
+**Current deployment reality (confirmed 2026-07-25):** the three live stores are still on **v3.7.0**; v4 has never been distributed. So the fresh-install path ships first and is the higher-stakes path, and this upgrade support is for release two onward. Nothing in production is currently exposed to the bugs above.
 
 ### Goals
 
-1. Running the installer on a machine that already has IndyPOS upgrades it, rather than failing.
-2. A failed upgrade leaves the store running the version it started on.
-3. The store's identity, database, and secrets survive an upgrade untouched.
-4. The fresh-install path keeps its current behaviour exactly — it is the only path validated in production.
+1. Running the installer on a machine that already has IndyPOS upgrades it rather than failing.
+2. A failed upgrade leaves the store running the version it started on, and verifiably serving.
+3. The store's identity, type, database and secrets survive an upgrade untouched.
+4. The fresh-install path keeps its current behaviour exactly.
 
 ### Non-goals
 
-- **PostgreSQL major-version upgrades.** Out of scope; requires data migration and is its own project.
-- **Config merging.** A preserved config does not gain new keys introduced by a newer template (see §7).
-- **Multi-terminal orchestration.** The installer upgrades the machine it runs on. A second POS terminal is its own run.
-- **Automatic database rollback.** A dump is taken and left as a recovery artifact; restoring it is a human decision (§5).
-- **Downgrade.** Refused (§4, step 1).
+- **PostgreSQL major-version upgrades.**
+- **Multi-terminal orchestration.** The installer upgrades the machine it runs on.
+- **Automatic database rollback.** A dump is taken and left as a recovery artifact; restoring it is a human decision.
+- **Downgrade.** Refused.
+- **Upgrading through the interactive wizard.** The wizard detects and refuses (§9).
+- **Persisting the PostgreSQL superuser password.** Decided 2026-07-25: not persisted. Machine-scoped DPAPI with entropy from a public constant is not a defence against a local account, so storing a superuser credential on a store PC buys little. The consequences are handled by making the failure safe instead (§3, §8).
 
 ---
 
 ## 2. Architecture
 
-A dedicated upgrade sequence beside the existing install sequence, selected by a detector, with both composing shared step units.
+A dedicated upgrade sequence beside the existing install sequence, selected by a detector, both composing shared step units.
 
 ```
                     InstallModeDetector
                             |
             Fresh  --------- + --------- Upgrade
               |                             |
-   InstallationOrchestrator          UpgradeOrchestrator
+  FreshInstallOrchestrator          UpgradeOrchestrator
               |                             |
               +----------- shared ----------+
                   ServiceControl
                   StoreHubPayload
-                  SchemaProvisioner
+                  MigrationRunner
+                  HealthProbe
                   ConfigSnapshot
                   UpgradeBackup (upgrade only)
 ```
 
-An upgrade is not a variation on a fresh install — it is a different algorithm with different safety requirements (back up first, roll back on failure, never touch database provisioning). Forcing both through one flow is what produced Failure 1: a step order that is correct for a fresh install and destructive for an upgrade. Keeping the validated path structurally frozen while the new path is built and tested separately is also the lower-risk way to reach three live stores.
+An upgrade is not a variation on a fresh install — it is a different algorithm with different safety requirements. Forcing both through one flow is what produced Failure 1: a step order correct for one case and destructive for the other.
 
-Rejected alternatives:
+**`InstallationOrchestrator` is renamed `FreshInstallOrchestrator`** in its own mechanical commit. The unprefixed name reads as "the orchestrator" and the new one as a special case, which is precisely backwards. Its two call sites are `SilentInstaller.cs:61` and `InstallationWizard.cs:41`.
 
-- **Branch inside `InstallationOrchestrator`.** Cheapest to write, but threads new conditionals through the only path with production validation, and makes the upgrade sequence hard to read or test in isolation.
-- **Make every step idempotent and mode-agnostic.** `DatabaseSetup` would still have to distinguish "reuse existing" from "provision new" — mode detection in disguise — with maximum blast radius on the fresh path.
+**`SchemaProvisioner` is named `MigrationRunner`** — it runs `IndyPOS.StoreHub.exe migrate` and runs on **both** paths, whereas `DatabaseSetup` is fresh-only. Those two must never be confused; shared vocabulary invites exactly that.
+
+**`DatabaseSetup` gets a banner comment:** *"FRESH INSTALL ONLY. Never runs on an upgrade — the role, password and DPAPI connection string already exist."* Both of today's failures ultimately landed in this class.
+
+**Each shared unit gets a one-line note** that it is used by both paths, so a future change for the upgrade case cannot quietly alter what ships to a store.
+
+**Refactor safety gate.** The extraction of shared units must leave `FreshInstallOrchestrator` semantically unchanged. Enforced as a review gate: after the extraction tasks, `git diff` on that file shows **only the rename**, no logic changes. This matters because the fresh-only branches (`sc create`, first-time directory creation, `DatabaseSetup`, the Postgres install) **never execute on the only VM snapshot available**, so no amount of upgrade testing would catch a regression in them.
+
+Rejected: branching inside the existing orchestrator (threads conditionals through the only production-validated path); making every step mode-agnostic (`DatabaseSetup` would still need to distinguish reuse from provision — mode detection in disguise — with maximum blast radius on the fresh path).
 
 ---
 
@@ -83,55 +95,70 @@ enum InstallMode { Fresh, Upgrade, Unusable }
 
 record DetectedInstall(
     InstallMode Mode,
-    string? InstalledVersion,   // from install-manifest.json
-    string? StoreId,            // from appsettings.json — see note
-    string  Reason);            // human-readable, surfaced on Unusable
+    string? InstalledVersion,   // install-manifest.json
+    string? StoreId,            // appsettings.json — the manifest does not record it
+    string  Reason);            // surfaced on Unusable
 ```
 
-Three outcomes, not two. A machine can be neither freshly installable nor upgradeable — the state observed after Failure 2 had a manifest and a registered service but a template config with no connection string. `Fresh` would fail on Postgres provisioning; `Upgrade` would fail on the missing connection string. Detecting that up front and refusing is strictly better than discovering it halfway through.
+Three outcomes, not two. A machine can be neither freshly installable nor upgradeable — the state observed after Failure 2 had a manifest and a registered service but a template config. Collapsing `Unusable` into `Fresh` sends the run *past* the mutation line: extraction succeeds, then `DatabaseSetup` fails on the superuser guard, which is exactly the destructive state this design exists to prevent.
 
-| Manifest at `$SystemRoot\install-manifest.json` | Config has usable connection string | Mode |
+Rules are evaluated **in order**; the first match wins.
+
+| # | Condition | Mode |
 |---|---|---|
-| absent | absent | `Fresh` |
-| present | present | `Upgrade` |
-| present | absent or unreadable | `Unusable` |
-| absent | present | `Unusable` |
+| 1 | A PostgreSQL install with an `indypos_storehub` database exists, but no IndyPOS manifest for the target major | `Unusable` |
+| 2 | Manifest present, config has a usable connection string, non-empty `Store:Id`, present-and-parseable `Store:Type`, and the service's ImagePath resolves under `StoreHubInstallPath` | `Upgrade` |
+| 3 | No manifest and no prior StoreHub config | `Fresh` |
+| 4 | Anything else | `Unusable` |
 
-"Usable connection string" means `ConnectionStrings:storehub-db` exists, is non-empty, and — when `DPAPI:`-marked — round-trips through `SecretProtector.Unprotect("ConnectionStrings:storehub-db", value)`. That is the same check the upgrade needs anyway to run `pg_dump`, so detection and preflight share one code path. A value that fails to decrypt means the config came from a different machine, which is exactly an `Unusable` store.
+**Rule 1 exists to close a data-loss path (§8).** `SystemRoot` is `C:\ProgramData\IndyPOS\v{Major}` (`InstallationConfig.cs:80`), so a **v5 installer on a live v4 store** finds no manifest under `v5\` and would otherwise be classified `Fresh`. Because `DatabaseName` is **not** version-scoped (`indypos_storehub` for every major), that "side-by-side" install collides with the existing database. Note this differs from v3.7.0 ↔ v4 coexistence, which is genuinely safe: v3.7.0 lives outside every `v{N}` root and does not use PostgreSQL at all.
 
-**`StoreId` comes from `appsettings.json`, not the manifest.** `InstallManifest` records `InstallVersion`, paths, service identifiers, `DatabaseName`, `AppUser` and `PostgresBinPath`, but **not** the store id. Reading `Store:Id` from the StoreHub config works on stores already deployed today, which a manifest change could not. Adding `StoreId` to a future `ManifestVersion = 2` is optional convenience and deliberately not required here.
+**"Usable connection string"** means `ConnectionStrings:storehub-db` exists, is non-empty, and — when `DPAPI:`-marked — round-trips through `SecretProtector.Unprotect`. Catch broadly: `Unprotect` throws `CryptographicException` **or** `FormatException`. A value that fails to decrypt came from another machine, which is an `Unusable` store. Detection and the §7 preflight share this one code path.
 
-**Store-id conflict.** If `--store-id` is passed and differs from the detected `Store:Id`, the run fails before mutating anything. Silently rewriting a store's identity would orphan its sales history from its reports.
+**`Store:Id` must be non-empty** (rule 2). `StoreIdentityService` falls back to `STORE-{MachineName}` when it is absent, and `payment_method` is keyed on the composite `(StoreId, Code)` (`PaymentMethodConfiguration.cs:12`), so the seeder in step 6 would insert a **second full set of seven payment methods** under the fallback id — and every subsequent sale would be written against it (`Program.cs:495`), orphaning new sales from the store's history.
+
+**`Store:Type` must be present** (rule 2). It was only added on 2026-07-18 (`DatabaseSetup.cs:388-391`); a store installed before that build has no such key, and `StoreIdentityOptions.Type` defaults to `GeneralHardware` — the **most permissive** value, which re-enables PayLater and Hardware product types. Preserving config verbatim would therefore silently undo the product-type restriction for a Minimart. Options when absent: require `--store-type` and write that single key into the restored config, or refuse as `Unusable`. Accepting the default silently is not permitted.
+
+**`--store-id` becomes optional in upgrade mode**, adopted from the detected config. It is currently mandatory for `--silent` (`SilentArgs.cs:70-71`), which would force a comparison on every upgrade with no correct behaviour when the detected value is null. If it *is* supplied and differs from the detected value, the run fails before mutating anything — silently rewriting store identity would orphan sales history.
+
+**`Unusable` recovery** must be documented per rule, in `docs/operations/`. Since the superuser password is deliberately not persisted, recovery is manual: for rule 1, point the operator at the older major's install root; for rule 4, name the specific missing element. **The message must never recommend `cleanup-v4.ps1 -Force -RemovePostgres`** (§8).
 
 ---
 
 ## 4. The upgrade sequence
 
 ```
-0  Detect        -> Upgrade (+ installed version, store id)
+0  Detect        -> Upgrade (+ installed version, store id, store type)
 1  Preflight     elevation; refuse downgrade (allow same-version repair);
-                 pg_dump present at manifest PostgresBinPath;
-                 read + DPAPI-unprotect the connection string
-2  Backup        pg_dump           -> <BackupsDirectory>\<stamp>\storehub.dump
+                 pg_dump located; connection string decrypts; free space;
+                 no POS app running; ensure fonts / .NET 10 / VC++ redist
+2  Stop service
+3  Backup        pg_dump           -> <BackupsDirectory>\<stamp>\storehub.dump
                  copy StoreHub dir -> <BackupsDirectory>\<stamp>\StoreHub\
                  ConfigSnapshot.Capture(appsettings.json)
---- nothing above this line mutates the install ---
-3  Stop service
+                 ACL-lock the stamp dir and both artifacts; verify dump
+                 integrity; prune to last N stamps
+--- nothing above this line has mutated the install ---
 4  Deploy        StoreHubPayload.Extract   (overwrites config with template)
 5  Restore config  ConfigSnapshot.Restore()
-6  Migrate       StoreHub.exe migrate
-7  Start service + health probe
+6  Migrate       MigrationRunner: StoreHub.exe migrate
+7  Start service + HealthProbe
 --- server upgrade complete ---
 8  POS app       re-run embedded Velopack setup
 9  Manifest      InstallManifestWriter.WriteAsync (new version, same paths)
-10 Markers       MODE, RESULT, SERVICE_STARTED, HEALTH, BACKUP_DIR, POS_UPDATED
+10 Markers       MODE, RESULT, SERVICE_STARTED, HEALTH, BACKUP_DIR,
+                 BACKUP_LOCKED, POS_UPDATED, ROLLED_BACK
 ```
 
-**Step 5 is the heart of the design.** `DatabaseSetup` never runs on an upgrade — no superuser password is needed, no role is created, no connection string is generated. The existing config is preserved verbatim. This is what makes Failure 2 disappear rather than be worked around.
+**Step 5 is the heart of the design.** `DatabaseSetup` never runs on an upgrade — no superuser password needed, no role created, no connection string generated. This is what makes Failure 2 disappear rather than be worked around.
 
-`BackupsDirectory` already exists in `InstallationConfig` and the manifest, and the directory is already present in a deployed install tree — no new path concept is introduced.
+**The service stops *before* the dump** (step 2 before step 3). Dumping a live database yields an internally consistent snapshot, but any sale completed between the dump and step 7 would exist only in the live database — and "restore the dump" is the documented recovery, so that window would be silently discarded. Stopping the service is not an irreversible mutation (rollback restarts it), so it belongs above the mutation line.
 
-`SchemaProvisioner` (step 6) is today's `StoreHubInstaller.ProvisionDatabaseAsync`, which runs `IndyPOS.StoreHub.exe migrate` as a one-shot console process before the service starts. On an upgrade it applies pending EF migrations; the payment-method seeder it also runs is idempotent (insert-if-absent), so re-running is safe.
+**Prerequisite ensures are part of preflight** (step 1). The fresh path runs fonts, .NET 10 and VC++ redist first (`FreshInstallOrchestrator` steps 0–1b), all idempotent check-then-install. Omitting them on upgrade has a concrete consequence: the bundled **FC Subject fonts** were only added on 2026-07-14, so a store installed before that build would receive this UI-polish release and render it in a fallback face — a visible regression delivered *by* the upgrade. A future .NET major bump would otherwise deploy binaries the machine cannot run, surfacing as a dead service *after* the mutation line.
+
+`BackupsDirectory` already exists in `InstallationConfig` and the manifest, though only `DatabaseSetup.CreateDirectories` guarantees it — `UpgradeBackup` must create the stamp path itself.
+
+Connection-string parsing uses `NpgsqlConnectionStringBuilder`, not string splitting. The dump uses custom format (`-Fc`); the matching `pg_restore` command is documented in `docs/operations/`.
 
 ---
 
@@ -139,50 +166,113 @@ Three outcomes, not two. A machine can be neither freshly installable nor upgrad
 
 | Failing step | Action |
 |---|---|
-| 1–2 | Nothing mutated. Report and exit. |
-| 3–7 | **Roll back:** `ConfigSnapshot.Restore()`, restore the StoreHub dir from backup, start the service, report the backup path. Store resumes on its previous version. |
-| 8 | **No rollback.** The server is upgraded and serving; tearing that down to fix a POS copy would be worse. Report `RESULT=failed` with `SERVICE_STARTED=true, POS_UPDATED=false`. |
-| 9–10 | Non-fatal. The upgrade succeeded; a stale manifest is cosmetic and is repaired by the next run. |
+| 0–3 | Nothing mutated. Report and exit. |
+| 4–7 | **Roll back:** delete `StoreHubInstallPath`, copy the backup tree back, `ConfigSnapshot.Restore()`, start the service, **run `HealthProbe`**, emit `ROLLED_BACK=true` with post-rollback `SERVICE_STARTED` / `HEALTH`, report the backup path. |
+| 8 | **No rollback.** The server is upgraded and serving. `RESULT=failed` with `SERVICE_STARTED=true, POS_UPDATED=false`. |
+| 9–10 | Non-fatal. A stale manifest is cosmetic and the next run repairs it. |
 
-`RESULT` keeps its existing two values (`success`, `failed`) so the VM harness gating rule is unchanged. The additional markers say *what* succeeded.
+**Rollback is delete-then-copy, not copy-over.** Extraction is per-entry `ExtractToFile(overwrite: true)` with no clean step (`StoreHubInstaller.cs:227-235`), so after step 4 the tree is `old ∪ new`. Copying the backup over that would leave new-version files behind, violating goal 2.
 
-**Migrations are forward-only.** EF applies each migration in its own transaction on PostgreSQL, so a failed migration leaves a consistent but possibly partially-advanced schema. Rollback restores binaries and config, not schema. Old binaries against an additively-advanced schema is tolerable in practice — and the `pg_dump` from step 2 is the escape hatch when it is not. Automatic database restore is deliberately excluded: it is riskier than the failure it would fix.
+**Rollback must verify it worked.** Starting the service is not evidence it came back; without a probe, a rollback can report "store resumes on its previous version" while the store is dead. When the post-rollback probe fails, the outcome escalates to advising restoration of the dump.
+
+**Migrations are forward-only, and that is now a release gate rather than an assumption.** Rollback restores binaries and config, not schema, so every migration in a release must be old-binary-compatible: additive only, new columns nullable or defaulted, no renames or drops. Without that rule the rollback claim is false — a `NOT NULL`-without-default column makes the restored binaries' INSERT fail (the till cannot complete a sale), and a rename makes every SELECT throw `42703`. The migration set already contains column-adding shapes (`20260714085744_AddMustChangePassword`).
+
+For the record, `ReclassifyPaymentMethodKinds` is safe under old binaries, verified rather than assumed: the column is a plain `int` with no CHECK constraint, EF's int→enum conversion is an unchecked cast, `PaymentMethodPolicy` ignores `Kind` entirely, and the pre-reclassification grid rendered `Kind.ToString()`, so the cell simply reads `"3"`.
+
+`RESULT` keeps its two values (`success`, `failed`) so the harness gating rule is unchanged; the other markers say *what* succeeded.
 
 ---
 
-## 6. Testing
+## 6. Backup artifacts
 
-**Unit-testable — real seams, so these get real tests:**
+**They must be ACL-locked.** `appsettings.json` is deliberately restricted to Administrators + LocalSystem with inheritance disabled (`DatabaseSetup.TryRestrictFilePermissions`, applied at `:316`), but `BackupsDirectory` is created with a plain `Directory.CreateDirectory` and inherits ProgramData's default DACL, which grants `BUILTIN\Users` read. Copying the config into a backup would silently undo its protection, and the dump is worse: the entire sales history plus BCrypt admin hashes. `UpgradeBackup` applies `TryRestrictFilePermissions` to the stamp directory and both artifacts, and reports `BACKUP_LOCKED` the way `CRED_LOCKED` already works.
+
+**Dump integrity is verified, not assumed.** A disk-full `pg_dump` leaves a truncated file that still satisfies "present", so `BACKUP_DIR` would advertise an unrestorable artifact. Require a zero exit code **and** a non-trivial file size. A free-space preflight precedes the dump.
+
+**Retention: keep the last N stamps** (N = 2). Each stamp costs roughly 130 MB of self-contained binaries plus the dump, forever, on a small retail PC with nobody watching it.
+
+**`pg_dump` location falls back.** The manifest's `PostgresBinPath` can be stale; fall back to `PostgresInstaller.FindPostgresInstallation()`. That probes 18 → 17 → 16, so assert a major matching the server.
+
+---
+
+## 7. Markers and exit codes
+
+`SilentOutcomeMapper.Map` ends in `_ => throw new ArgumentOutOfRangeException`, so every new outcome needs an explicit arm and exit code. The harness gates on exit code **and** `RESULT` **and** `SERVICE_STARTED`.
+
+- Add sibling records — `UpgradeSucceeded`, `UpgradeFailed`, `Unusable`, `DowngradeRefused` — rather than widening `InstallSucceeded`, which is already a five-field positional record and belongs to the frozen fresh path.
+- **Suppress the fresh-path admin markers on upgrade.** `SuccessMarkers` always emits `ADMIN_SEEDED`, which on an upgrade is necessarily `false` (a fresh install stripped the `InitialAdmin` block, so `InitialAdminSeeder` skips), and the `else` branch then emits `RESET_HINT=run "IndyPOS.StoreHub.exe reset-admin"…` — advising a bootstrap-password reissue on a store whose admin is fine. The upgrade path ignores `AdminSeeded`, emits no `CRED_FILE`, and never writes `admin-credentials.txt`.
+- `MODE=upgrade|fresh` lands in `install-latest.log`, so months later a store's own log answers "which path ran" without reading any C#.
+
+---
+
+## 8. Closing the data-loss path
+
+Independent of everything above, one existing message must change. The superuser guard currently instructs the operator to run `scripts\cleanup-v4.ps1 -Force -RemovePostgres` (`DatabaseSetup.cs:46`). That script calls `DROP DATABASE IF EXISTS indypos_storehub` **unconditionally unless `-SkipDatabase`**, and *before* it touches PostgreSQL — while the flag name and its own help ("the Postgres data directory is left behind") both read as scoped to the PostgreSQL install. An operator following the installer's own guidance destroys every sale the store has recorded.
+
+**Requirement:** the guard must detect whether a populated `indypos_storehub` exists and, when it does, never recommend the cleanup script. Combined with detection rule 1, the v5-over-v4 case never reaches this guard at all.
+
+---
+
+## 9. Entry points
+
+Both entry points consume **one** detection result from a single router — if `Program.cs` and `SilentInstaller` each called the detector, the two forks would diverge.
+
+- **`--silent`** is the only path that performs an upgrade.
+- **The interactive wizard detects and refuses.** It must not be left undetected: a double-clicked `Setup.exe` on a live store otherwise reproduces both failures, and that is the likely path on a hands-on store visit. But it does not gain an upgrade UI — it collects StoreId and StoreType up front (both already fixed on an upgrade) and its finish screen is built around bootstrap credentials that do not exist on an upgrade. It shows the detected version and directs the operator to the `--silent` command.
+
+---
+
+## 10. Testing
+
+**Unit-testable — real seams:**
 
 | Unit | Cases |
 |---|---|
-| `InstallModeDetector` | all four table rows of §3; store-id conflict; a `DPAPI:` value that fails to decrypt → `Unusable` |
-| `ConfigSnapshot` | ✅ built and tested 2026-07-25 (5 tests): byte-exact restore, absent-at-capture, template cleanup, idempotency |
-| `UpgradeBackup` | file copy + restore round-trip over temp dirs; restore when backup is absent |
-| Marker mapping | pure, mirroring `SilentOutcomeMapper`: `MODE`, `BACKUP_DIR`, `POS_UPDATED` permutations |
+| `InstallModeDetector` | all four rules in order; rule 1 ahead of the manifest lookup; empty `Store:Id`; absent `Store:Type`; unresolvable service ImagePath; undecryptable `DPAPI:` value; store-id conflict incl. the null-detected case |
+| `ConfigSnapshot` | ✅ built and tested (5 tests) — byte-exact restore, absent-at-capture, template cleanup, idempotency |
+| `UpgradeBackup` | copy/restore round-trip; delete-then-copy semantics; retention prune; missing-backup restore; integrity rejection of a truncated dump |
+| Marker mapping | pure, mirroring `SilentOutcomeMapperTests`: every new outcome, suppression of `ADMIN_SEEDED`/`RESET_HINT`, `ROLLED_BACK` |
 
-**No seam — the VM's job:** `ServiceControl` (`ServiceController` is not injectable), `pg_dump`, Velopack.
+**No seam — the VM's job:** `ServiceControl`, `pg_dump`, Velopack.
 
-**VM validation** on `IndyPOS-Test` from checkpoint `Pre-Upgrade-2026-07-25` (a genuine pre-reclassification store: `PayLater kind=1`, `WelfareCard kind=1`, `Store:Id=Rungrat-001`, service running):
+**VM validation** from checkpoint `Pre-Upgrade-2026-07-25` (a genuine pre-reclassification store: `PayLater kind=1`, `WelfareCard kind=1`, `Store:Id=Rungrat-001`, service running):
 
-1. **Happy upgrade** — `MODE=upgrade`; `PayLater kind=3`; `WelfareCard kind=2` **and still enabled**; `Cash`/`MoneyTransfer` `kind=1`; config still `DPAPI:`-protected with `Store:Id=Rungrat-001`; service Running; health 200; `storehub.dump` present in the backup dir.
-2. **Forced mid-upgrade failure** — induce a failure between steps 4 and 7 and assert the store came back on its old version with its real config and a running service. This is the case both of today's failures would have flunked, so it is not optional.
-3. **Fresh-install regression** — one clean install still reaching 18/18, proving the refactor into shared units changed nothing on the validated path.
+1. **Happy upgrade** — `MODE=upgrade`; `PayLater kind=3`; `WelfareCard kind=2` **and still enabled**; `Cash`/`MoneyTransfer` `kind=1`; config still `DPAPI:`-protected; `Store:Id` **and `Store:Type`** preserved; service Running; health 200; dump present, non-trivial and ACL-locked.
+2. **Forced mid-upgrade failure** — old version restored, real config, service Running **and health 200**, `ROLLED_BACK=true`. Both of today's failures would have flunked this, so it is not optional.
+3. **Fresh-install regression** — one clean install reaching 18/18, proving the refactor changed nothing on the path that ships first.
 
-Case 3 needs a clean Windows snapshot. `Clean-Windows` and `Clean-Windows-Ready` were deleted in the 2026-07-25 disk cleanup, along with the Win11 ISO, so **rebuilding the clean snapshot is a prerequisite for case 3** and should be planned as its own task.
+**The fault hook must be runtime-selected** (an env var read once, or a hidden `--simulate-failure=deploy`), not compile-time, so one 190 MB installer build serves cases 1 and 2 in a single session. At ~10 minutes per cycle plus build, that is the difference between one evening and two.
+
+**The harness needs changes to run case 2 at all:** it hardcodes the snapshot name and *throws* whenever `RESULT ≠ success` (`Reset-AndInstall.ps1:153`, `:269-272`), so a deliberate-rollback run fails by construction. It needs a `-SnapshotName` parameter and an expect-rollback mode. Case 2 must assert against the fresh timestamped log, not `install-latest.log`, which can hold a previous run's `RESULT=success`.
+
+**Database assertions** are already proven feasible: decrypt the connection string in-guest using `SHA256("IndyPOS:ConnectionStrings:storehub-db")` as DPAPI entropy at LocalMachine scope, then drive `psql`. Done interactively on 2026-07-25 to capture the pre-upgrade state; it needs scripting into the verifier. Note the guest is **PowerShell 5.1 with a Windows-1252 codepage**, so any script sent to it must be ASCII or BOM-encoded.
+
+**Case 3 gates distribution, not merge.** The clean-Windows snapshot and the Win11 ISO were deleted on 2026-07-25; the baseline is being rebuilt by tearing down the existing VM. Because the fresh path is protected structurally (§2 refactor gate) and by the existing bootstrapper suite, the branch can land before case 3 — but no installer goes to a store until 18/18 passes on a clean baseline.
 
 ---
 
-## 7. Known limitations
+## 11. Known limitations
 
-1. **No config merge.** Step 5 restores the old `appsettings.json` wholesale, so keys introduced by a newer package template are absent after an upgrade. StoreHub must rely on code-side defaults (`IOptions<T>` defaults) for anything new. A merge is YAGNI until a release actually needs a new key.
-2. **Velopack is per-user.** Re-running setup under `--silent` updates the profile the installer runs as. A cashier's copy on another profile can be left on the old version until Velopack's own update path reaches it.
+1. **Velopack is per-user.** Re-running setup under `--silent` updates the profile the installer runs as, so a cashier's copy on another profile can stay on the old version until Velopack's own updater reaches it. The rewritten manifest's `VelopackInstallPath` also records the *installing* user's LocalAppData, so upgrading as a different admin repoints what cleanup and verify consume.
+2. **The POS app self-updates independently** (`UpdateService` against GitHub Releases), so it can already be *ahead* of StoreHub without the installer running. The upgrade path cannot fix that skew, only avoid adding to it — hence the running-app check in step 1, since two Velopack processes on one install root can leave the POS unlaunchable.
 3. **Forward-only migrations** (§5).
-4. **No PostgreSQL version management.** An upgrade assumes the installed major version is the one the release targets.
-5. **Single machine per run** (§1 non-goals).
+4. **No PostgreSQL version management.**
+5. **Single machine per run.**
+6. **`LocalToken:SecretKey` is preserved**, so existing POS sessions survive an upgrade — a real benefit, but it also means the key is never rotated over the product's lifetime.
+7. **A release version bump is a precondition.** `Directory.Build.props` pins the version and requires a manual edit; without a bump, downgrade protection always takes the same-version repair branch, `InstalledVersion` is decorative, and step 8 has nothing newer to install so `POS_UPDATED=true` would be a lie. Define step 8's behaviour when Velopack has nothing newer.
+8. **`StoreConfiguration.json` is create-if-absent on the fresh path**, so skipping `DatabaseSetup` loses nothing — but an upgrade of a store missing that file will not create it either.
+9. **`migrate` inherits Npgsql's 30s command timeout.** A future long DDL migration over a multi-year invoice table would time out and trigger a rollback for no real reason. Consider raising it on the migrate path.
 
 ---
 
-## 8. Out-of-scope defect found alongside
+## 12. Open question for planning
 
-`StoreHubInstaller` stopped the service after extracting rather than before. The reorder plus a `ConfigSnapshot` guard was implemented on branch `fix/installer-upgrade-path` on 2026-07-25 (`ConfigSnapshot` + 5 tests; bootstrapper suite 101 pass / 8 skip). That fix is a strict improvement to the fresh path too — any extraction failure now leaves config intact — and this design assumes it as its starting point. Note its guard covers extraction failure only; the broader rollback in §5 supersedes it for the upgrade path.
+**Step 8's behaviour is unverified.** Nothing in the codebase establishes what the embedded Velopack `Setup.exe --silent` does on a machine where the app is already installed — `VelopackLauncher` just runs it and checks the exit code. This should be settled by a 30-minute spike on the existing VM *before* the orchestrator is written: if Velopack refuses or reinstalls destructively, step 8 and §5 row 8 both change.
+
+---
+
+## 13. Prerequisite already landed
+
+The stop-before-extract reorder plus the `ConfigSnapshot` guard shipped as commit `d74cfda` on branch `fix/installer-upgrade-path` (5 tests; bootstrapper suite 101 pass / 8 skip). It is a strict improvement to the fresh path too — any extraction failure now leaves config intact — and this design builds on it. Its guard covers extraction failure only; §5's rollback supersedes it for the upgrade path.
+
+Two unrelated tooling bugs were found and fixed while rebuilding the VM baseline, both from the May move to a major-only install root being only half-applied: `cleanup-v4.ps1`'s `Assert-V4Path` still demanded `v<Major>.<Minor>.<Patch>` and so refused to clean the layout the installer produces, and three em-dashes made the script unparseable under the guest's Windows-1252 codepage.

--- a/docs/superpowers/specs/2026-07-25-installer-upgrade-support-design.md
+++ b/docs/superpowers/specs/2026-07-25-installer-upgrade-support-design.md
@@ -273,6 +273,8 @@ Both entry points consume **one** detection result from a single router — if `
 
 ## 13. Prerequisite already landed
 
-The stop-before-extract reorder plus the `ConfigSnapshot` guard shipped as commit `d74cfda` on branch `fix/installer-upgrade-path` (5 tests; bootstrapper suite 101 pass / 8 skip). It is a strict improvement to the fresh path too — any extraction failure now leaves config intact — and this design builds on it. Its guard covers extraction failure only; §5's rollback supersedes it for the upgrade path.
+The stop-before-extract reorder plus the `ConfigSnapshot` guard ship in **PR #53** (`fix/installer-upgrade-robustness`), with 5 tests and the bootstrapper suite at 101 pass / 8 skip, plus a fresh-install VM regression at 18/18. It is a strict improvement to the fresh path too — any extraction failure now leaves config intact — and this design builds on it. Its guard covers extraction failure only; §5's rollback supersedes it for the upgrade path.
 
-Two unrelated tooling bugs were found and fixed while rebuilding the VM baseline, both from the May move to a major-only install root being only half-applied: `cleanup-v4.ps1`'s `Assert-V4Path` still demanded `v<Major>.<Minor>.<Patch>` and so refused to clean the layout the installer produces, and three em-dashes made the script unparseable under the guest's Windows-1252 codepage.
+**This spec assumes PR #53 has merged.** If it has not, the upgrade path's first failure is still the locked-DLL error from §1.
+
+That PR also carries three `cleanup-v4.ps1` bugs found while rebuilding the VM baseline — two from the May move to a major-only install root being only half-applied (the safety guard still demanded `v<Major>.<Minor>.<Patch>`, and three em-dashes made the script unparseable under the guest's Windows-1252 codepage), plus one where the DPAPI-sealed connection string was fed to a connection-string builder, so the teardown silently skipped the database drop.

--- a/docs/superpowers/specs/2026-07-29-product-categories-and-store-types-design.md
+++ b/docs/superpowers/specs/2026-07-29-product-categories-and-store-types-design.md
@@ -35,7 +35,7 @@ across store types with different meanings** (from the real databases at
 | 12 | ขนม (snacks) | ขนม | **เครื่องเขียน (stationery)** |
 | 18 | ของเล่น (toys) | ของเล่น | **ของใช้ในบ้าน (household)** |
 | 50–54 | วัสดุ* (hardware) | — | — |
-| categories | 16 | 11 | 17 |
+| categories in the legacy table | 16 | 11 (one is a leftover — see §4) | 17 |
 
 Three consequences:
 
@@ -146,11 +146,17 @@ Codes below are the contract between this epic and the migration (Epic 2), which
 | 53 | วัสดุและอุปกรณ์ระบบไฟฟ้า | `ElectricalMaterials` | **Hardware** |
 | 54 | วัสดุก่อสร้างและอุปกรณ์การช่าง | `ConstructionMaterials` | **Hardware** |
 
-### Minimart / MimyMart (11)
+### Minimart / MimyMart (10)
 
-Legacy ids 10–20 with the same Thai labels and codes as GeneralHardware's 10–20, all `GeneralGoods`.
-Legacy id 20 (`การเกษตร`) has zero products in the real MimyMart database but is present in its
-`ProductCategory` table, so it is seeded.
+Legacy ids 10–19 with the same Thai labels and codes as GeneralHardware's 10–19, all `GeneralGoods`.
+
+**Legacy id 20 (`การเกษตร`) is deliberately NOT seeded.** MimyMart's category table was created by
+copying GeneralHardware's, and `การเกษตร` came along as a leftover (Pond, 2026-07-29). The data
+agrees: **0 products and 0 invoice lines**. Seeding it would propagate an accident into the clean
+model and put a category a minimart never sells in its picker.
+
+The migration therefore maps MimyMart legacy ids 10–19 only. Id 20 needs no mapping because nothing
+references it — verified, not assumed.
 
 ### MimyShop (17)
 
@@ -176,6 +182,20 @@ Legacy id 20 (`การเกษตร`) has zero products in the real MimyMart
 
 `Toys`, `Stationery`, `Household` and `Miscellaneous` deliberately repeat across store types — the
 key is `(StoreId, Code)`, and shared codes are what make cross-store reporting meaningful.
+
+**All 17 MimyShop categories are seeded, including the 12 with no products and no sales lines.**
+MimyShop is a new store (15 invoices, 100 products), so its unused categories are the catalogue the
+business intends to use, not detritus. Contrast MimyMart's `การเกษตร` above: identical evidence —
+zero products, zero lines — opposite meaning. "Unused" alone cannot distinguish a leftover from a
+plan, which is why this is recorded rather than derived by a rule. Do not "tidy up" MimyShop's empty
+categories later.
+
+### Category references in sales history — audited
+
+Every category id appearing in `InvoiceProduct` exists in that store's `ProductCategory` table, in
+all three databases. There are **no orphaned category references**, so the migration (Epic 2) cannot
+meet a historical line whose category it is unable to map. Verified 2026-07-29 against the real
+databases.
 
 ## 5. Store types
 
@@ -268,4 +288,5 @@ rather than silent. The §4 tables need Pond's review.
 | `MimyShop` as a real `StoreType` | Pond's call: services and reporting will diverge |
 | `CoffeeShop` removed, value 3 reserved | Deserves a dedicated app; reserving 3 avoids a future collision |
 | `Kind = Service` as data only | Non-stock behaviour needs `Product.IsTrackable`, which does not exist |
+| MimyMart's `การเกษตร` dropped, MimyShop's empty categories kept | Both are unused; one is a copy-paste leftover, the other a new shop's intended catalogue. Only Pond's context distinguishes them |
 | Rename legacy `ProductCategory` entity | Two entities with one name in sibling namespaces is a using-directive trap |

--- a/docs/superpowers/specs/2026-07-29-product-categories-and-store-types-design.md
+++ b/docs/superpowers/specs/2026-07-29-product-categories-and-store-types-design.md
@@ -1,0 +1,271 @@
+# Data-driven product categories + store types — design
+
+**Date:** 2026-07-29
+**Status:** Approved (Pond, 2026-07-29)
+**Epic:** 1 of the corrected roadmap in `.planning/indypos-overhaul/PLAN.md`
+**Blocks:** Epic 2 (SQLite → PostgreSQL migration hardening) — the migration needs a category model
+to map into.
+
+---
+
+## 1. Problem
+
+`Product.Category` is a free-text string that today holds the *name* of a two-value enum:
+
+```csharp
+public enum ProductCategory { GeneralGoods = 10, Hardware = 50 }
+```
+
+Classification is done by string comparison against that name, in three places —
+`CreateProductCommandHandler`, `UpdateProductCommandHandler`, `GetLegacySalesSummaryQueryHandler`:
+
+```csharp
+var isHardware = string.Equals(command.Category, nameof(ProductCategory.Hardware),
+                               StringComparison.OrdinalIgnoreCase);
+```
+
+The real stores do not work that way. Each has its own fine-grained catalogue, and **the ids collide
+across store types with different meanings** (from the real databases at
+`.planning/indypos-overhaul/sqlite_database/*/Store.db`):
+
+| legacy id | GeneralHardware | MimyMart | MimyShop |
+|-----------|-----------------|----------|----------|
+| 10 | เบ็ดเตล็ด (misc) | เบ็ดเตล็ด | **ของขวัญ (gifts)** |
+| 11 | เครื่องดื่ม (drinks) | เครื่องดื่ม | **ของเล่น (toys)** |
+| 12 | ขนม (snacks) | ขนม | **เครื่องเขียน (stationery)** |
+| 18 | ของเล่น (toys) | ของเล่น | **ของใช้ในบ้าน (household)** |
+| 50–54 | วัสดุ* (hardware) | — | — |
+| categories | 16 | 11 | 17 |
+
+Three consequences:
+
+1. **Two values cannot express three catalogues.** A minimart's เครื่องดื่ม and a gift shop's
+   ของขวัญ both collapse to `GeneralGoods`, losing every distinction the stores actually use.
+2. **Any global id→category mapping is wrong for at least one store.** Mapping `10 → GeneralGoods`
+   is defensible for GeneralHardware and MimyMart, and meaningless for MimyShop where 10 is gifts.
+   This is the same defect class as the payment-method mapping that mis-attributed ~15% of ฿21.2M
+   (see `6c63a6d`): an id treated as globally meaningful when it is only meaningful in context.
+3. **A new category requires a redeploy**, exactly the problem Epic M solved for payment methods.
+
+There is also a third store type, **MimyShop**, which does not exist in `StoreType` yet, and
+`CoffeeShop`, which does exist but should not.
+
+## 2. Goals
+
+- Each store carries its own product-category catalogue as data.
+- Product-type classification (the Hardware gate) stops being a string comparison.
+- Adding a category is a row, not a release.
+- Cross-store reporting works without a translation layer.
+- `MimyShop` becomes a real store type; `CoffeeShop` is removed.
+
+### Non-goals
+
+- **No admin category screen.** Payment methods needed one because government campaigns churn
+  roughly yearly. Categories are stable — a shop does not invent a category set often. Build it when
+  there is a reason to edit categories in the field, not before.
+- **No service/non-stock behaviour.** `Kind = Service` is recorded as data so MimyShop's บริการ has
+  a home, but nothing changes about inventory deduction. That feature needs `Product.IsTrackable`,
+  which v4 does not have (see §8).
+- **No cloud work.** Store-scoped rows sync correctly under any cloud shape (see
+  `.planning/indypos-overhaul/PLAN.md`, Epic I).
+
+## 3. The data model
+
+A store-scoped `product_category` table, mirroring `payment_method`:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `Id` | `Guid` | Per the repo's entity convention |
+| `StoreId` | `string` | **Mandatory scoping** — the whole point. `Code` is unique per store, not globally |
+| `Code` | `string` | Stable readable identifier, e.g. `Gifts`. What `Product.Category` stores |
+| `DisplayName` | `string` | Thai label, e.g. `ของขวัญ`. Reworded freely without touching products |
+| `Kind` | `ProductCategoryKind` | `GeneralGoods` \| `Hardware` \| `Service` |
+| `DisplayOrder` | `int` | Picker ordering |
+| `IsEnabled` | `bool` | Hide from new products; history keeps rendering |
+| `CreatedUtc`, `LastModifiedUtc` | `DateTime` | Repo entity convention |
+
+Unique index on `(StoreId, Code)`.
+
+```csharp
+public enum ProductCategoryKind
+{
+    GeneralGoods = 1,
+    Hardware = 2,
+    Service = 3
+}
+```
+
+`Kind` carries the gate: `MultipleProductTypesEnabled = false` means the store may only use
+categories whose `Kind == GeneralGoods`. The three `nameof(ProductCategory.Hardware)` comparisons are
+replaced by a lookup of the category's `Kind`.
+
+**Removed:** `IndyPOS.Application.Common.Enums.ProductCategory` and
+`HardcodedStoreConstants.ProductCategories`.
+
+**Note on the existing `IndyPOS.Domain.Entities.ProductCategory`** (`{ int Id; string Category; }`) —
+that is the *legacy-side* model used by the WinForms/legacy path, not the StoreHub Core entity. The
+new entity lives in `IndyPOS.Domain.Entities.Core` alongside `PaymentMethod`. Naming them both
+`ProductCategory` in different namespaces is confusing; the new one is authoritative and the legacy
+one should be renamed `LegacyProductCategory` as part of this work to avoid a using-directive trap.
+
+### Why readable codes
+
+`Code = "Gifts"` rather than `Code = "10"`:
+
+- Rows and reports are legible (`Category = 'PlumbingMaterials'`, not `Category = '52'`).
+- A Thai label can be reworded without a data migration.
+- **Cross-store reporting works by construction.** Codes are shared where meanings genuinely match,
+  so `GROUP BY code` gives "Toys sales across all three stores". With legacy ids as codes that query
+  would be silently wrong, since id 10 is misc in GeneralHardware and gifts in MimyShop. This
+  property matters directly for Epic I reporting and the MCP surface.
+- It refuses the id-as-meaning habit that produced the payment-mapping bug.
+
+## 4. Seed data
+
+Codes below are the contract between this epic and the migration (Epic 2), which maps
+`legacy id → Code` **per store**. Translations need Pond's confirmation; they cannot be unit-tested.
+
+### GeneralHardware (16)
+
+| legacy id | Thai | Code | Kind |
+|-----------|------|------|------|
+| 10 | เบ็ดเตล็ด | `Miscellaneous` | GeneralGoods |
+| 11 | เครื่องดื่ม | `Beverages` | GeneralGoods |
+| 12 | ขนม | `Snacks` | GeneralGoods |
+| 13 | เครื่องดื่มแอลกอฮอล์ | `AlcoholicBeverages` | GeneralGoods |
+| 14 | อาหาร | `Food` | GeneralGoods |
+| 15 | เครื่องเขียน | `Stationery` | GeneralGoods |
+| 16 | ของใช้ในบ้าน | `Household` | GeneralGoods |
+| 17 | เครื่องใช้ไฟฟ้า | `ElectricalAppliances` | GeneralGoods |
+| 18 | ของเล่น | `Toys` | GeneralGoods |
+| 19 | ยา | `Medicine` | GeneralGoods |
+| 20 | การเกษตร | `Agriculture` | GeneralGoods |
+| 50 | วัสดุและอุปกรณ์ทั่วไป | `GeneralMaterials` | **Hardware** |
+| 51 | วัสดุและอุปกรณ์ | `MaterialsAndEquipment` | **Hardware** |
+| 52 | วัสดุและอุปกรณ์ระบบประปา | `PlumbingMaterials` | **Hardware** |
+| 53 | วัสดุและอุปกรณ์ระบบไฟฟ้า | `ElectricalMaterials` | **Hardware** |
+| 54 | วัสดุก่อสร้างและอุปกรณ์การช่าง | `ConstructionMaterials` | **Hardware** |
+
+### Minimart / MimyMart (11)
+
+Legacy ids 10–20 with the same Thai labels and codes as GeneralHardware's 10–20, all `GeneralGoods`.
+Legacy id 20 (`การเกษตร`) has zero products in the real MimyMart database but is present in its
+`ProductCategory` table, so it is seeded.
+
+### MimyShop (17)
+
+| legacy id | Thai | Code | Kind |
+|-----------|------|------|------|
+| 10 | ของขวัญ | `Gifts` | GeneralGoods |
+| 11 | ของเล่น | `Toys` | GeneralGoods |
+| 12 | เครื่องเขียน | `Stationery` | GeneralGoods |
+| 13 | หนังสือและสมุด | `BooksAndNotebooks` | GeneralGoods |
+| 14 | เครื่องสำอาง | `Cosmetics` | GeneralGoods |
+| 15 | เครื่องประดับ | `Jewellery` | GeneralGoods |
+| 16 | กระเป๋า | `Bags` | GeneralGoods |
+| 17 | แฟชั่น | `Fashion` | GeneralGoods |
+| 18 | ของใช้ในบ้าน | `Household` | GeneralGoods |
+| 19 | เครื่องครัว | `Kitchenware` | GeneralGoods |
+| 20 | ขนมและเครื่องดื่ม | `SnacksAndBeverages` | GeneralGoods |
+| 21 | อุปกรณ์มือถือ | `MobileAccessories` | GeneralGoods |
+| 22 | อุปกรณ์อิเล็กทรอนิกส์ | `Electronics` | GeneralGoods |
+| 23 | อุปกรณ์งานปาร์ตี้ | `PartySupplies` | GeneralGoods |
+| 24 | สินค้าตามเทศกาล | `SeasonalGoods` | GeneralGoods |
+| 25 | บริการ | `Services` | **Service** |
+| 26 | เบ็ดเตล็ด | `Miscellaneous` | GeneralGoods |
+
+`Toys`, `Stationery`, `Household` and `Miscellaneous` deliberately repeat across store types — the
+key is `(StoreId, Code)`, and shared codes are what make cross-store reporting meaningful.
+
+## 5. Store types
+
+```csharp
+public enum StoreType
+{
+    GeneralHardware = 1,
+    Minimart = 2,
+    // 3 was CoffeeShop, removed 2026-07-29. Do not reuse.
+    MimyShop = 4
+}
+```
+
+- `MimyShop` gets Minimart-equivalent features: `PayLaterEnabled = false`,
+  `MultipleProductTypesEnabled = false`. Today only its category set differs; that is recorded in a
+  comment so the duplication reads as deliberate.
+- **`CoffeeShop` is removed** — its products and services differ enough to deserve a dedicated app
+  (Pond, 2026-07-29). Before deleting: confirm no `appsettings.json` carries `Store:Type=CoffeeShop`
+  and no `store_user`/config row persists the value. The numeric value `3` stays reserved.
+- Installer `--store-type` accepts `MimyShop`; the wizard picker offers it. Documentation updated
+  wherever the supported types are listed.
+
+### Anticipated later divergence (not built now)
+
+MimyShop sells services, and its reporting/receipt needs differ from a minimart's. Payment methods
+will *converge* — MimyMart is expected to offer MimyShop's set. So resist adding feature flags for
+payments; add them for services and presentation when those features are actually specified.
+
+## 6. Seeding, API, data flow
+
+`ProductCategorySeeder` mirrors `PaymentMethodSeeder`: idempotent, inserts only a `Code` absent for
+this store, scoped by `IStoreIdentityService.StoreId`, non-fatal, logged. One difference — the seed
+set is selected by `IStoreIdentityService.StoreType`, because the catalogues genuinely differ. It runs
+in the existing `migrate` step, so a fresh install arrives already correct.
+
+`GET /product-categories` mirrors `GET /payment-methods`: store-scoped rows in `DisplayOrder`, used by
+the POS to render category pickers. `StoreHubInventoryProductService.MapCategoryName` and the
+hardcoded dictionary are removed.
+
+**A window worth exploiting:** no store runs v4 yet, so there is no production `Product.Category`
+data to convert. The EF migration creates and seeds the table; it needs no reclassification data
+migration (unlike Epic M's `MapLegacyPaymentValuesToCodes`) and puts no live data at risk. Dev and
+test databases are simply reseeded. **This window closes when the first store goes live**, which is
+the concrete reason Epic 1 precedes Epic 3.
+
+## 7. Error handling
+
+| Situation | Behaviour |
+|-----------|-----------|
+| Unknown `Code` on product create/update | **400** — a malformed request, not a conflict |
+| Category with `Kind != GeneralGoods` on a store with `MultipleProductTypesEnabled = false` | **409**, reusing the product-type-restriction path and its tests |
+| Disabled category on a **new** product | Treated as unknown → 400 |
+| Disabled category on an **existing** product | Still renders; history is never rewritten (same rule as dead payment campaigns) |
+| Seeder cannot write | Logged, non-fatal — matches `PaymentMethodSeeder` |
+
+## 8. Known gap: `Product.IsTrackable`
+
+v4's `Domain.Entities.Core.Product` has no `IsTrackable`, while the legacy schema does — and the real
+databases contain non-trackable products (21 GeneralHardware, 7 MimyMart, 1 MimyShop). Services are
+inherently non-stock, so `Kind = Service` is only half a feature without it.
+
+Deliberately **not** added here: it is a migration-fidelity concern (Epic 2 must preserve the flag)
+and a service-behaviour feature (later). Recorded so `Kind = Service` is not mistaken for working
+non-stock support.
+
+## 9. Testing
+
+| Layer | Coverage |
+|-------|----------|
+| Domain | `ProductCategoryKind` policy — which kinds each store type may use. Pure, no infrastructure |
+| Application | Create/update handlers: accept a valid code; reject an unknown code (400); reject `Hardware` on a general-only store (409) |
+| Integration (real PostgreSQL) | Endpoint returns store-scoped rows in `DisplayOrder`; seeder idempotent across two runs; **each of the three store types seeds its own expected set** |
+| Migration | `migrate` creates and seeds the table on a fresh database |
+
+The per-store-type seeding test is the one that catches an id or name mix-up between MimyMart and
+MimyShop — the mistake this design exists to prevent.
+
+**Explicit limitation:** no test can confirm a *translation* is right (`Gifts` for `ของขวัญ`). The
+integration tests pin whatever is agreed, so an error is consistent and visible in the seed table
+rather than silent. The §4 tables need Pond's review.
+
+## 10. Decisions log
+
+| Decision | Rationale |
+|----------|-----------|
+| Store-scoped catalogue, not global | Legacy ids collide with different meanings across store types |
+| Readable English `Code` | Legible rows, stable under relabelling, makes cross-store `GROUP BY` correct |
+| `Kind` on the category row | Replaces string comparison against an enum name; extensible to `Service` |
+| No admin screen | Categories are stable, unlike churning government campaigns (YAGNI) |
+| `MimyShop` as a real `StoreType` | Pond's call: services and reporting will diverge |
+| `CoffeeShop` removed, value 3 reserved | Deserves a dedicated app; reserving 3 avoids a future collision |
+| `Kind = Service` as data only | Non-stock behaviour needs `Product.IsTrackable`, which does not exist |
+| Rename legacy `ProductCategory` entity | Two entities with one name in sibling namespaces is a using-directive trap |

--- a/installer/IndyPOS.Bootstrapper/IndyPOS.Bootstrapper.csproj
+++ b/installer/IndyPOS.Bootstrapper/IndyPOS.Bootstrapper.csproj
@@ -21,6 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Connection-string parsing for the upgrade path's pg_dump invocation. Splitting the
+         string by hand would mis-handle a password containing ';' or '=' and silently dump
+         the wrong database. Version tracks the Npgsql that Infrastructure's EF provider pulls. -->
+    <PackageReference Include="Npgsql" Version="10.0.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.1" />
   </ItemGroup>
 

--- a/installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs
@@ -170,6 +170,58 @@ public class DatabaseSetup
 
     internal static void RestrictFilePermissions(string filePath) => TryRestrictFilePermissions(filePath);
 
+    /// <summary>
+    /// Locks a DIRECTORY to Administrators + LocalSystem, with the ACEs marked inheritable
+    /// so everything inside stays reachable.
+    /// <para>Not a convenience overload of <see cref="TryRestrictFilePermissions"/>: that one
+    /// adds ACEs with no inheritance flags, which is correct for a file and catastrophic for a
+    /// directory. Protecting a directory drops its inherited ACEs and Windows recomputes its
+    /// children's, so non-inheritable ACEs leave every existing child with an EMPTY DACL -
+    /// readable by nobody, including Administrators. That is what broke the 2026-07-29 upgrade:
+    /// the freshly copied backup tree became unreadable the moment its parent was locked.</para>
+    /// </summary>
+    internal static bool TryRestrictDirectoryPermissions(string directoryPath)
+    {
+        try
+        {
+            var directoryInfo = new DirectoryInfo(directoryPath);
+            var security = directoryInfo.GetAccessControl();
+
+            security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+
+            var rules = security.GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount));
+            foreach (System.Security.AccessControl.FileSystemAccessRule rule in rules)
+            {
+                security.RemoveAccessRule(rule);
+            }
+
+            const System.Security.AccessControl.InheritanceFlags inheritance =
+                System.Security.AccessControl.InheritanceFlags.ContainerInherit |
+                System.Security.AccessControl.InheritanceFlags.ObjectInherit;
+
+            foreach (var sid in new[]
+                     {
+                         System.Security.Principal.WellKnownSidType.BuiltinAdministratorsSid,
+                         System.Security.Principal.WellKnownSidType.LocalSystemSid
+                     })
+            {
+                security.AddAccessRule(new System.Security.AccessControl.FileSystemAccessRule(
+                    new System.Security.Principal.SecurityIdentifier(sid, null),
+                    System.Security.AccessControl.FileSystemRights.FullControl,
+                    inheritance,
+                    System.Security.AccessControl.PropagationFlags.None,
+                    System.Security.AccessControl.AccessControlType.Allow));
+            }
+
+            directoryInfo.SetAccessControl(security);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     internal static bool TryRestrictFilePermissions(string filePath)
     {
         try

--- a/installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs
@@ -2,12 +2,19 @@ using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using IndyPOS.Bootstrapper.Upgrade;
 using IndyPOS.Vault;
 
 namespace IndyPOS.Bootstrapper.Installers;
 
 /// <summary>
 /// Handles database creation and configuration.
+/// <para>
+/// FRESH INSTALL ONLY. Never runs on an upgrade — the role, its password and the
+/// DPAPI-protected connection string already exist there, so asking the
+/// database-provisioning question at all is what produced the superuser-password
+/// failure this guard reports. See the upgrade design spec, sections 2 and 4.
+/// </para>
 /// </summary>
 public class DatabaseSetup
 {
@@ -37,15 +44,14 @@ public class DatabaseSetup
         // PGPASSWORD is empty, even with stdin redirected).
         if (string.IsNullOrEmpty(postgresPassword))
         {
+            var storeDatabaseExists = StoreHubConfigReader
+                .Read(Path.Combine(config.StoreHubInstallPath, "appsettings.json"))
+                .ConnectionStringUsable;
+
             return new DatabaseSetupResult
             {
                 Success = false,
-                ErrorMessage =
-                    "PostgreSQL 18 is already installed, but its superuser password is unknown " +
-                    "(the installer doesn't persist it across runs). To proceed, either:\n" +
-                    "  - Uninstall PostgreSQL: scripts\\cleanup-v4.ps1 -Force -RemovePostgres\n" +
-                    "  - Or remove C:\\Program Files\\PostgreSQL\\18 manually,\n" +
-                    "then re-run this installer for a clean Postgres install."
+                ErrorMessage = BuildSuperuserGuardMessage(storeDatabaseExists)
             };
         }
 
@@ -142,6 +148,24 @@ public class DatabaseSetup
         RandomNumberGenerator.Fill(bytes);
         return Convert.ToBase64String(bytes);
     }
+
+    /// <summary>
+    /// The superuser password is deliberately not persisted (spec section 1), so an existing
+    /// PostgreSQL cannot be provisioned into. What the operator should do next depends
+    /// entirely on whether there is a store database to protect.
+    /// </summary>
+    internal static string BuildSuperuserGuardMessage(bool storeDatabaseExists) =>
+        storeDatabaseExists
+            ? "PostgreSQL 18 is already installed and this machine has an existing IndyPOS database.\n" +
+              "Do NOT remove PostgreSQL — that would destroy the store's sales history.\n" +
+              "Upgrade in place instead:\n" +
+              "  IndyPOS-Setup.exe --silent\n" +
+              "See docs\\operations\\upgrade-procedure.md."
+            : "PostgreSQL 18 is already installed, but its superuser password is unknown " +
+              "(the installer doesn't persist it across runs). To proceed, either:\n" +
+              "  - Uninstall PostgreSQL: scripts\\cleanup-v4.ps1 -Force -RemovePostgres\n" +
+              "  - Or remove C:\\Program Files\\PostgreSQL\\18 manually,\n" +
+              "then re-run this installer for a clean Postgres install.";
 
     internal static void RestrictFilePermissions(string filePath) => TryRestrictFilePermissions(filePath);
 

--- a/installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/DatabaseSetup.cs
@@ -44,14 +44,14 @@ public class DatabaseSetup
         // PGPASSWORD is empty, even with stdin redirected).
         if (string.IsNullOrEmpty(postgresPassword))
         {
-            var storeDatabaseExists = StoreHubConfigReader
+            var storeInstallExists = StoreHubConfigReader
                 .Read(Path.Combine(config.StoreHubInstallPath, "appsettings.json"))
-                .ConnectionStringUsable;
+                .Exists;
 
             return new DatabaseSetupResult
             {
                 Success = false,
-                ErrorMessage = BuildSuperuserGuardMessage(storeDatabaseExists)
+                ErrorMessage = BuildSuperuserGuardMessage(storeInstallExists)
             };
         }
 
@@ -152,10 +152,11 @@ public class DatabaseSetup
     /// <summary>
     /// The superuser password is deliberately not persisted (spec section 1), so an existing
     /// PostgreSQL cannot be provisioned into. What the operator should do next depends
-    /// entirely on whether there is a store database to protect.
+    /// entirely on whether IndyPOS was ever installed on this machine (which means a store's
+    /// sales history is at risk).
     /// </summary>
-    internal static string BuildSuperuserGuardMessage(bool storeDatabaseExists) =>
-        storeDatabaseExists
+    internal static string BuildSuperuserGuardMessage(bool storeInstallExists) =>
+        storeInstallExists
             ? "PostgreSQL 18 is already installed and this machine has an existing IndyPOS database.\n" +
               "Do NOT remove PostgreSQL — that would destroy the store's sales history.\n" +
               "Upgrade in place instead:\n" +

--- a/installer/IndyPOS.Bootstrapper/Installers/FreshInstallOrchestrator.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/FreshInstallOrchestrator.cs
@@ -1,9 +1,15 @@
 namespace IndyPOS.Bootstrapper.Installers;
 
 /// <summary>
-/// Orchestrates the complete IndyPOS installation process.
+/// Orchestrates a FRESH IndyPOS installation onto a machine with no existing install.
+/// <para>An in-place upgrade is a different algorithm with different safety requirements,
+/// not a variation on this one — see <c>UpgradeOrchestrator</c>. Forcing both through one
+/// flow is what produced the locked-DLL failure this design exists to fix.</para>
+/// <para>FROZEN: this is the only production-validated path, and its fresh-only branches
+/// (sc create, first-time directory creation, DatabaseSetup, the Postgres install) never
+/// execute on the upgrade VM snapshot. Change it only for a fresh-install reason.</para>
 /// </summary>
-public class InstallationOrchestrator
+public class FreshInstallOrchestrator
 {
     private readonly FontInstaller _fontInstaller = new();
     private readonly DotNetInstaller _dotNetInstaller = new();
@@ -300,7 +306,6 @@ public class InstallationOrchestrator
             HealthOk = healthOk
         };
     }
-
 }
 
 /// <summary>

--- a/installer/IndyPOS.Bootstrapper/Installers/HealthProbe.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/HealthProbe.cs
@@ -1,0 +1,41 @@
+namespace IndyPOS.Bootstrapper.Installers;
+
+/// <summary>
+/// Polls StoreHub's readiness endpoint.
+/// <para>USED BY BOTH INSTALL PATHS — fresh install and in-place upgrade. The upgrade
+/// path also runs it AFTER a rollback: starting the service is not evidence it came
+/// back (see the upgrade design spec, section 5).</para>
+/// </summary>
+public static class HealthProbe
+{
+    public static async Task<bool> IsReadyAsync(
+        int port,
+        int attempts = 5,
+        CancellationToken cancellationToken = default)
+    {
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        // /health/ready is StoreHub's DB-aware readiness probe. /health and /alive are
+        // dev-only (Aspire's IsDevelopment() guard in ServiceDefaults).
+        var healthUrl = $"http://localhost:{port}/health/ready";
+
+        for (var i = 0; i < attempts; i++)
+        {
+            try
+            {
+                var response = await client.GetAsync(healthUrl, cancellationToken);
+                if (response.IsSuccessStatusCode)
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // Retry
+            }
+
+            await Task.Delay(2000, cancellationToken);
+        }
+
+        return false;
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/InstallationOrchestrator.cs
@@ -261,7 +261,7 @@ public class InstallationOrchestrator
 
         // Verify health
         progress.Report(InstallationProgress.Log("Verifying StoreHub health..."));
-        var healthOk = await VerifyStoreHubHealthAsync(config.HealthCheckPort, cancellationToken);
+        var healthOk = await HealthProbe.IsReadyAsync(config.HealthCheckPort, cancellationToken: cancellationToken);
 
         if (healthOk)
         {
@@ -301,33 +301,6 @@ public class InstallationOrchestrator
         };
     }
 
-    private static async Task<bool> VerifyStoreHubHealthAsync(int port, CancellationToken cancellationToken)
-    {
-        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
-        // /health/ready is StoreHub's DB-aware readiness probe. /health and
-        // /alive are dev-only (Aspire's IsDevelopment() guard in ServiceDefaults).
-        var healthUrl = $"http://localhost:{port}/health/ready";
-
-        for (var i = 0; i < 5; i++)
-        {
-            try
-            {
-                var response = await client.GetAsync(healthUrl, cancellationToken);
-                if (response.IsSuccessStatusCode)
-                {
-                    return true;
-                }
-            }
-            catch
-            {
-                // Retry
-            }
-
-            await Task.Delay(2000, cancellationToken);
-        }
-
-        return false;
-    }
 }
 
 /// <summary>

--- a/installer/IndyPOS.Bootstrapper/Installers/MigrationRunner.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/MigrationRunner.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics;
+
+namespace IndyPOS.Bootstrapper.Installers;
+
+public sealed record MigrationRunResult(bool Success, bool AdminSeeded, string? ErrorMessage);
+
+/// <summary>
+/// Runs the StoreHub app's one-shot <c>migrate</c> command (apply EF migrations, seed the
+/// initial admin, exit).
+/// <para>USED BY BOTH INSTALL PATHS — fresh install and in-place upgrade. This is NOT
+/// <see cref="DatabaseSetup"/>, which creates the role, the database and the connection
+/// string and runs on a fresh install only.</para>
+/// <para>Doing this as a console step BEFORE the service starts keeps the first service
+/// start instant, so a schema build can't overrun the 30s SCM start timeout (error 1053).</para>
+/// </summary>
+public static class MigrationRunner
+{
+    public static async Task<MigrationRunResult> RunAsync(
+        string storeHubInstallPath,
+        IProgress<string>? log = null,
+        CancellationToken cancellationToken = default)
+    {
+        var exePath = Path.Combine(storeHubInstallPath, "IndyPOS.StoreHub.exe");
+        if (!File.Exists(exePath))
+        {
+            return new MigrationRunResult(false, false, $"StoreHub executable not found at {exePath}");
+        }
+
+        try
+        {
+            log?.Report("Applying database migrations and seeding admin...");
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = exePath,
+                Arguments = "migrate",
+                WorkingDirectory = storeHubInstallPath,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            // Production is the host default when unset, but be explicit so a stray dev
+            // env var can't divert provisioning to the EnsureCreated path.
+            psi.Environment["ASPNETCORE_ENVIRONMENT"] = "Production";
+
+            using var process = new Process { StartInfo = psi };
+            process.Start();
+
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await Task.WhenAll(stdoutTask, stderrTask);
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
+            await process.WaitForExitAsync(cancellationToken);
+
+            return process.ExitCode != 0
+                ? new MigrationRunResult(false, false,
+                    $"Database provisioning failed (exit {process.ExitCode}): {stderr.Trim()}")
+                : new MigrationRunResult(true, ParseAdminSeeded(stdout), null);
+        }
+        catch (Exception ex)
+        {
+            return new MigrationRunResult(false, false, $"Database provisioning failed: {ex.Message}");
+        }
+    }
+
+    internal static bool ParseAdminSeeded(string stdout) =>
+        stdout.Contains("ADMIN_SEEDED=true", StringComparison.OrdinalIgnoreCase);
+}

--- a/installer/IndyPOS.Bootstrapper/Installers/PostgresInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/PostgresInstaller.cs
@@ -274,6 +274,13 @@ public class PostgresInstaller
     }
 
     /// <summary>
+    /// The bin directory of the PostgreSQL install this machine actually has, or null.
+    /// Exposed for the upgrade path's pg_dump fallback: the manifest's PostgresBinPath
+    /// can be stale. Note this probes 18 -> 17 -> 16, so callers must assert the major.
+    /// </summary>
+    internal static string? FindPostgresBinPath() => FindPostgresInstallation()?.BinPath;
+
+    /// <summary>
     /// Find existing PostgreSQL installation. Requires BOTH psql.exe AND the
     /// matching Windows service to be registered — psql.exe alone is a half-
     /// installed state (e.g. installer killed during extraction) that would

--- a/installer/IndyPOS.Bootstrapper/Installers/ServiceControl.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/ServiceControl.cs
@@ -1,0 +1,81 @@
+using System.ServiceProcess;
+
+namespace IndyPOS.Bootstrapper.Installers;
+
+/// <summary>
+/// Stop / start / query the StoreHub Windows service.
+/// <para>USED BY BOTH INSTALL PATHS — fresh install and in-place upgrade. A change here
+/// ships to every store on the next release, not just to upgrades.</para>
+/// </summary>
+public sealed class ServiceControl(string serviceName)
+{
+    private readonly string _serviceName = serviceName;
+
+    public bool Exists() =>
+        ServiceController.GetServices().Any(s => s.ServiceName == _serviceName);
+
+    public bool IsRunning()
+    {
+        try
+        {
+            using var sc = new ServiceController(_serviceName);
+            return sc.Status == ServiceControllerStatus.Running;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Returns true when the service is stopped afterwards, including when absent.</summary>
+    public async Task<bool> StopAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var sc = new ServiceController(_serviceName);
+
+            if (sc.Status is ServiceControllerStatus.Running or ServiceControllerStatus.StartPending)
+            {
+                sc.Stop();
+                await Task.Run(
+                    () => sc.WaitForStatus(ServiceControllerStatus.Stopped, timeout),
+                    cancellationToken);
+            }
+
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            // Service doesn't exist - that's fine.
+            return true;
+        }
+        catch (System.ServiceProcess.TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> StartAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var sc = new ServiceController(_serviceName);
+
+            if (sc.Status == ServiceControllerStatus.Running)
+            {
+                return true;
+            }
+
+            sc.Start();
+            await Task.Run(
+                () => sc.WaitForStatus(ServiceControllerStatus.Running, timeout),
+                cancellationToken);
+
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Installers/ServiceControl.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/ServiceControl.cs
@@ -2,6 +2,9 @@ using System.ServiceProcess;
 
 namespace IndyPOS.Bootstrapper.Installers;
 
+/// <summary>Result of a start/stop attempt, carrying the failure reason for diagnostics.</summary>
+public sealed record ServiceControlResult(bool Success, string? ErrorMessage);
+
 /// <summary>
 /// Stop / start / query the StoreHub Windows service.
 /// <para>USED BY BOTH INSTALL PATHS — fresh install and in-place upgrade. A change here
@@ -27,8 +30,8 @@ public sealed class ServiceControl(string serviceName)
         }
     }
 
-    /// <summary>Returns true when the service is stopped afterwards, including when absent.</summary>
-    public async Task<bool> StopAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    /// <summary>Succeeds when the service is stopped afterwards, including when absent.</summary>
+    public async Task<ServiceControlResult> StopAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -42,20 +45,20 @@ public sealed class ServiceControl(string serviceName)
                     cancellationToken);
             }
 
-            return true;
+            return new ServiceControlResult(true, null);
         }
         catch (InvalidOperationException)
         {
             // Service doesn't exist - that's fine.
-            return true;
+            return new ServiceControlResult(true, null);
         }
-        catch (System.ServiceProcess.TimeoutException)
+        catch (System.ServiceProcess.TimeoutException ex)
         {
-            return false;
+            return new ServiceControlResult(false, ex.Message);
         }
     }
 
-    public async Task<bool> StartAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    public async Task<ServiceControlResult> StartAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -63,7 +66,7 @@ public sealed class ServiceControl(string serviceName)
 
             if (sc.Status == ServiceControllerStatus.Running)
             {
-                return true;
+                return new ServiceControlResult(true, null);
             }
 
             sc.Start();
@@ -71,11 +74,11 @@ public sealed class ServiceControl(string serviceName)
                 () => sc.WaitForStatus(ServiceControllerStatus.Running, timeout),
                 cancellationToken);
 
-            return true;
+            return new ServiceControlResult(true, null);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            return false;
+            return new ServiceControlResult(false, ex.Message);
         }
     }
 }

--- a/installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs
@@ -134,71 +134,18 @@ public class StoreHubInstaller
         IProgress<string>? log = null,
         CancellationToken cancellationToken = default)
     {
-        var exePath = Path.Combine(Config.StoreHubInstallPath, "IndyPOS.StoreHub.exe");
-        if (!File.Exists(exePath))
+        var result = await MigrationRunner.RunAsync(Config.StoreHubInstallPath, log, cancellationToken);
+
+        return new ProvisionDatabaseResult
         {
-            return new ProvisionDatabaseResult
-            {
-                Success = false,
-                ErrorMessage = $"StoreHub executable not found at {exePath}"
-            };
-        }
-
-        try
-        {
-            log?.Report("Applying database migrations and seeding admin...");
-
-            var psi = new ProcessStartInfo
-            {
-                FileName = exePath,
-                Arguments = "migrate",
-                WorkingDirectory = Config.StoreHubInstallPath,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true
-            };
-            // Production is the host default when unset, but be explicit so a stray
-            // dev env var can't divert provisioning to the EnsureCreated path.
-            psi.Environment["ASPNETCORE_ENVIRONMENT"] = "Production";
-
-            using var process = new Process { StartInfo = psi };
-            process.Start();
-
-            var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
-            await Task.WhenAll(stdoutTask, stderrTask);
-            var stdout = await stdoutTask;
-            var stderr = await stderrTask;
-            await process.WaitForExitAsync(cancellationToken);
-
-            if (process.ExitCode != 0)
-            {
-                return new ProvisionDatabaseResult
-                {
-                    Success = false,
-                    ErrorMessage = $"Database provisioning failed (exit {process.ExitCode}): {stderr.Trim()}"
-                };
-            }
-
-            return new ProvisionDatabaseResult
-            {
-                Success = true,
-                AdminSeeded = ParseAdminSeeded(stdout)
-            };
-        }
-        catch (Exception ex)
-        {
-            return new ProvisionDatabaseResult
-            {
-                Success = false,
-                ErrorMessage = $"Database provisioning failed: {ex.Message}"
-            };
-        }
+            Success = result.Success,
+            AdminSeeded = result.AdminSeeded,
+            ErrorMessage = result.ErrorMessage
+        };
     }
 
     internal static bool ParseAdminSeeded(string stdout) =>
-        stdout.Contains("ADMIN_SEEDED=true", StringComparison.OrdinalIgnoreCase);
+        MigrationRunner.ParseAdminSeeded(stdout);
 
     private async Task<bool> CreateWindowsServiceAsync(
         IProgress<string>? log,

--- a/installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.IO.Compression;
 using System.ServiceProcess;
 
 namespace IndyPOS.Bootstrapper.Installers;
@@ -45,7 +44,8 @@ public class StoreHubInstaller
             // its own DLLs open, so extracting over them throws "being used by another
             // process". A clean install has no service and this is a no-op.
             log?.Report("Checking for existing service...");
-            await StopExistingServiceAsync(cancellationToken);
+            await new ServiceControl(Config.ServiceName)
+                .StopAsync(TimeSpan.FromSeconds(30), cancellationToken);
 
             // Extraction overwrites appsettings.json with the package template and
             // DatabaseSetup only rewrites the real values later, so a failure in between
@@ -54,7 +54,8 @@ public class StoreHubInstaller
                 Path.Combine(Config.StoreHubInstallPath, "appsettings.json"));
 
             log?.Report("Extracting StoreHub binaries...");
-            var extractResult = await ExtractStoreHubBinariesAsync(log, cancellationToken);
+            var extractResult = await StoreHubPayload.ExtractAsync(
+                Config.StoreHubInstallPath, log, cancellationToken);
             if (!extractResult)
             {
                 configSnapshot.Restore();
@@ -98,30 +99,16 @@ public class StoreHubInstaller
     /// </summary>
     public async Task<StoreHubInstallerResult> StartServiceAsync(CancellationToken cancellationToken = default)
     {
-        try
-        {
-            using var sc = new ServiceController(Config.ServiceName);
+        var started = await new ServiceControl(Config.ServiceName)
+            .StartAsync(TimeSpan.FromSeconds(60), cancellationToken);
 
-            if (sc.Status == ServiceControllerStatus.Running)
-            {
-                return new StoreHubInstallerResult { Success = true };
-            }
-
-            sc.Start();
-
-            var timeout = TimeSpan.FromSeconds(60);
-            await Task.Run(() => sc.WaitForStatus(ServiceControllerStatus.Running, timeout), cancellationToken);
-
-            return new StoreHubInstallerResult { Success = true };
-        }
-        catch (Exception ex)
-        {
-            return new StoreHubInstallerResult
+        return started
+            ? new StoreHubInstallerResult { Success = true }
+            : new StoreHubInstallerResult
             {
                 Success = false,
-                ErrorMessage = $"Failed to start service: {ex.Message}"
+                ErrorMessage = $"Failed to start service: {Config.ServiceName}"
             };
-        }
     }
 
     /// <summary>
@@ -200,118 +187,6 @@ public class StoreHubInstaller
 
     internal static bool ParseAdminSeeded(string stdout) =>
         stdout.Contains("ADMIN_SEEDED=true", StringComparison.OrdinalIgnoreCase);
-
-    private async Task<bool> ExtractStoreHubBinariesAsync(
-        IProgress<string>? log,
-        CancellationToken cancellationToken)
-    {
-        var assembly = typeof(StoreHubInstaller).Assembly;
-        var resourceName = "IndyPOS.Bootstrapper.Resources.StoreHub.zip";
-
-        using var resourceStream = assembly.GetManifestResourceStream(resourceName);
-
-        if (resourceStream != null)
-        {
-            log?.Report("Extracting from embedded resources...");
-
-            using var archive = new ZipArchive(resourceStream, ZipArchiveMode.Read);
-            foreach (var entry in archive.Entries)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                if (string.IsNullOrEmpty(entry.Name))
-                {
-                    continue;
-                }
-
-                var destPath = Path.Combine(Config.StoreHubInstallPath, entry.FullName);
-                var destDir = Path.GetDirectoryName(destPath);
-
-                if (!string.IsNullOrEmpty(destDir) && !Directory.Exists(destDir))
-                {
-                    Directory.CreateDirectory(destDir);
-                }
-
-                entry.ExtractToFile(destPath, overwrite: true);
-            }
-
-            return true;
-        }
-
-        var externalZip = Path.Combine(AppContext.BaseDirectory, "StoreHub.zip");
-
-        if (File.Exists(externalZip))
-        {
-            log?.Report("Extracting from external package...");
-            ZipFile.ExtractToDirectory(externalZip, Config.StoreHubInstallPath, overwriteFiles: true);
-            return true;
-        }
-
-        var externalFolder = Path.Combine(AppContext.BaseDirectory, "StoreHub");
-
-        if (Directory.Exists(externalFolder))
-        {
-            log?.Report("Copying from external folder...");
-            await CopyDirectoryAsync(externalFolder, Config.StoreHubInstallPath, cancellationToken);
-            return true;
-        }
-
-        log?.Report("ERROR: StoreHub binaries not found!");
-        log?.Report("Expected locations:");
-        log?.Report($"  - Embedded resource: {resourceName}");
-        log?.Report($"  - External zip: {externalZip}");
-        log?.Report($"  - External folder: {externalFolder}");
-
-        return false;
-    }
-
-    private static async Task CopyDirectoryAsync(
-        string sourceDir,
-        string destDir,
-        CancellationToken cancellationToken)
-    {
-        if (!Directory.Exists(destDir))
-        {
-            Directory.CreateDirectory(destDir);
-        }
-
-        foreach (var file in Directory.GetFiles(sourceDir))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var destFile = Path.Combine(destDir, Path.GetFileName(file));
-            await using var sourceStream = File.OpenRead(file);
-            await using var destStream = File.Create(destFile);
-            await sourceStream.CopyToAsync(destStream, cancellationToken);
-        }
-
-        foreach (var dir in Directory.GetDirectories(sourceDir))
-        {
-            var destSubDir = Path.Combine(destDir, Path.GetFileName(dir));
-            await CopyDirectoryAsync(dir, destSubDir, cancellationToken);
-        }
-    }
-
-    private async Task StopExistingServiceAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            using var sc = new ServiceController(Config.ServiceName);
-
-            if (sc.Status == ServiceControllerStatus.Running ||
-                sc.Status == ServiceControllerStatus.StartPending)
-            {
-                sc.Stop();
-                await Task.Run(() => sc.WaitForStatus(
-                    ServiceControllerStatus.Stopped,
-                    TimeSpan.FromSeconds(30)), cancellationToken);
-            }
-        }
-        catch (InvalidOperationException)
-        {
-            // Service doesn't exist - that's fine
-        }
-    }
 
     private async Task<bool> CreateWindowsServiceAsync(
         IProgress<string>? log,

--- a/installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs
@@ -44,8 +44,20 @@ public class StoreHubInstaller
             // its own DLLs open, so extracting over them throws "being used by another
             // process". A clean install has no service and this is a no-op.
             log?.Report("Checking for existing service...");
-            await new ServiceControl(Config.ServiceName)
+            var serviceStopped = await new ServiceControl(Config.ServiceName)
                 .StopAsync(TimeSpan.FromSeconds(30), cancellationToken);
+            if (!serviceStopped)
+            {
+                // Not yet captured at this point in the sequence - nothing to restore -
+                // but call it defensively so this stays correct if the ordering ever changes.
+                configSnapshot?.Restore();
+
+                return new StoreHubInstallerResult
+                {
+                    Success = false,
+                    ErrorMessage = $"Failed to stop existing service '{Config.ServiceName}' within 30s timeout"
+                };
+            }
 
             // Extraction overwrites appsettings.json with the package template and
             // DatabaseSetup only rewrites the real values later, so a failure in between

--- a/installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/StoreHubInstaller.cs
@@ -44,9 +44,9 @@ public class StoreHubInstaller
             // its own DLLs open, so extracting over them throws "being used by another
             // process". A clean install has no service and this is a no-op.
             log?.Report("Checking for existing service...");
-            var serviceStopped = await new ServiceControl(Config.ServiceName)
+            var stopResult = await new ServiceControl(Config.ServiceName)
                 .StopAsync(TimeSpan.FromSeconds(30), cancellationToken);
-            if (!serviceStopped)
+            if (!stopResult.Success)
             {
                 // Not yet captured at this point in the sequence - nothing to restore -
                 // but call it defensively so this stays correct if the ordering ever changes.
@@ -55,7 +55,7 @@ public class StoreHubInstaller
                 return new StoreHubInstallerResult
                 {
                     Success = false,
-                    ErrorMessage = $"Failed to stop existing service '{Config.ServiceName}' within 30s timeout"
+                    ErrorMessage = $"Failed to stop existing service '{Config.ServiceName}': {stopResult.ErrorMessage}"
                 };
             }
 
@@ -111,15 +111,15 @@ public class StoreHubInstaller
     /// </summary>
     public async Task<StoreHubInstallerResult> StartServiceAsync(CancellationToken cancellationToken = default)
     {
-        var started = await new ServiceControl(Config.ServiceName)
+        var result = await new ServiceControl(Config.ServiceName)
             .StartAsync(TimeSpan.FromSeconds(60), cancellationToken);
 
-        return started
+        return result.Success
             ? new StoreHubInstallerResult { Success = true }
             : new StoreHubInstallerResult
             {
                 Success = false,
-                ErrorMessage = $"Failed to start service: {Config.ServiceName}"
+                ErrorMessage = $"Failed to start service: {result.ErrorMessage}"
             };
     }
 

--- a/installer/IndyPOS.Bootstrapper/Installers/StoreHubPayload.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/StoreHubPayload.cs
@@ -1,0 +1,106 @@
+using System.IO.Compression;
+
+namespace IndyPOS.Bootstrapper.Installers;
+
+/// <summary>
+/// Lays the StoreHub payload down over an install directory.
+/// <para>USED BY BOTH INSTALL PATHS — fresh install and in-place upgrade.</para>
+/// <para>Extraction is per-entry with <c>overwrite: true</c> and has no clean step, so the
+/// result is old-union-new. Rollback must therefore delete before copying back
+/// (see the upgrade design spec, section 5).</para>
+/// </summary>
+public static class StoreHubPayload
+{
+    public const string ResourceName = "IndyPOS.Bootstrapper.Resources.StoreHub.zip";
+
+    public static async Task<bool> ExtractAsync(
+        string destinationPath,
+        IProgress<string>? log = null,
+        CancellationToken cancellationToken = default)
+    {
+        var assembly = typeof(StoreHubPayload).Assembly;
+
+        using var resourceStream = assembly.GetManifestResourceStream(ResourceName);
+
+        if (resourceStream != null)
+        {
+            log?.Report("Extracting from embedded resources...");
+
+            using var archive = new ZipArchive(resourceStream, ZipArchiveMode.Read);
+            foreach (var entry in archive.Entries)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (string.IsNullOrEmpty(entry.Name))
+                {
+                    continue;
+                }
+
+                var destPath = Path.Combine(destinationPath, entry.FullName);
+                var destDir = Path.GetDirectoryName(destPath);
+
+                if (!string.IsNullOrEmpty(destDir) && !Directory.Exists(destDir))
+                {
+                    Directory.CreateDirectory(destDir);
+                }
+
+                entry.ExtractToFile(destPath, overwrite: true);
+            }
+
+            return true;
+        }
+
+        var externalZip = Path.Combine(AppContext.BaseDirectory, "StoreHub.zip");
+
+        if (File.Exists(externalZip))
+        {
+            log?.Report("Extracting from external package...");
+            ZipFile.ExtractToDirectory(externalZip, destinationPath, overwriteFiles: true);
+            return true;
+        }
+
+        var externalFolder = Path.Combine(AppContext.BaseDirectory, "StoreHub");
+
+        if (Directory.Exists(externalFolder))
+        {
+            log?.Report("Copying from external folder...");
+            await CopyDirectoryAsync(externalFolder, destinationPath, cancellationToken);
+            return true;
+        }
+
+        log?.Report("ERROR: StoreHub binaries not found!");
+        log?.Report("Expected locations:");
+        log?.Report($"  - Embedded resource: {ResourceName}");
+        log?.Report($"  - External zip: {externalZip}");
+        log?.Report($"  - External folder: {externalFolder}");
+
+        return false;
+    }
+
+    private static async Task CopyDirectoryAsync(
+        string sourceDir,
+        string destDir,
+        CancellationToken cancellationToken)
+    {
+        if (!Directory.Exists(destDir))
+        {
+            Directory.CreateDirectory(destDir);
+        }
+
+        foreach (var file in Directory.GetFiles(sourceDir))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var destFile = Path.Combine(destDir, Path.GetFileName(file));
+            await using var sourceStream = File.OpenRead(file);
+            await using var destStream = File.Create(destFile);
+            await sourceStream.CopyToAsync(destStream, cancellationToken);
+        }
+
+        foreach (var dir in Directory.GetDirectories(sourceDir))
+        {
+            var destSubDir = Path.Combine(destDir, Path.GetFileName(dir));
+            await CopyDirectoryAsync(dir, destSubDir, cancellationToken);
+        }
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Installers/StoreHubPayload.cs
+++ b/installer/IndyPOS.Bootstrapper/Installers/StoreHubPayload.cs
@@ -13,14 +13,28 @@ public static class StoreHubPayload
 {
     public const string ResourceName = "IndyPOS.Bootstrapper.Resources.StoreHub.zip";
 
+    /// <param name="resourceName">
+    /// Overridable for tests only - production always uses the default. Lets tests point
+    /// at a resource name guaranteed not to exist, so the "not found" branch is
+    /// deterministic regardless of whether this assembly happens to have a
+    /// StoreHub.zip embedded (e.g. after running build-installer.ps1).
+    /// </param>
+    /// <param name="probeDirectory">
+    /// Overridable for tests only - null means the production default, <see cref="AppContext.BaseDirectory"/>.
+    /// Lets tests point the external-zip/external-folder probes at an empty temp
+    /// directory instead of the real test-bin output directory.
+    /// </param>
     public static async Task<bool> ExtractAsync(
         string destinationPath,
         IProgress<string>? log = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string resourceName = ResourceName,
+        string? probeDirectory = null)
     {
+        var baseDirectory = probeDirectory ?? AppContext.BaseDirectory;
         var assembly = typeof(StoreHubPayload).Assembly;
 
-        using var resourceStream = assembly.GetManifestResourceStream(ResourceName);
+        using var resourceStream = assembly.GetManifestResourceStream(resourceName);
 
         if (resourceStream != null)
         {
@@ -50,7 +64,7 @@ public static class StoreHubPayload
             return true;
         }
 
-        var externalZip = Path.Combine(AppContext.BaseDirectory, "StoreHub.zip");
+        var externalZip = Path.Combine(baseDirectory, "StoreHub.zip");
 
         if (File.Exists(externalZip))
         {
@@ -59,7 +73,7 @@ public static class StoreHubPayload
             return true;
         }
 
-        var externalFolder = Path.Combine(AppContext.BaseDirectory, "StoreHub");
+        var externalFolder = Path.Combine(baseDirectory, "StoreHub");
 
         if (Directory.Exists(externalFolder))
         {
@@ -70,7 +84,7 @@ public static class StoreHubPayload
 
         log?.Report("ERROR: StoreHub binaries not found!");
         log?.Report("Expected locations:");
-        log?.Report($"  - Embedded resource: {ResourceName}");
+        log?.Report($"  - Embedded resource: {resourceName}");
         log?.Report($"  - External zip: {externalZip}");
         log?.Report($"  - External folder: {externalFolder}");
 

--- a/installer/IndyPOS.Bootstrapper/Program.cs
+++ b/installer/IndyPOS.Bootstrapper/Program.cs
@@ -1,5 +1,7 @@
+using IndyPOS.Bootstrapper.Installers;
 using IndyPOS.Bootstrapper.Silent;
 using IndyPOS.Bootstrapper.UI;
+using IndyPOS.Bootstrapper.Upgrade;
 
 namespace IndyPOS.Bootstrapper;
 
@@ -25,6 +27,24 @@ internal static class Program
                 "Administrator Required",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Warning);
+            return 0;
+        }
+
+        // One detection result, one router. If the wizard and the silent path each called
+        // the detector, the two forks would drift.
+        var probeConfig = new InstallationConfig { StoreId = "pending", Interactive = true };
+        var detected = InstallModeDetector.Detect(
+            new WindowsInstallProbe(probeConfig), probeConfig.StoreHubInstallPath);
+
+        if (detected.Mode != InstallMode.Fresh)
+        {
+            MessageBox.Show(
+                detected.Mode == InstallMode.Upgrade
+                    ? InstallationWizard.BuildExistingInstallMessage(detected)
+                    : detected.Reason,
+                "Existing Installation Detected",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
             return 0;
         }
 

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentArgs.cs
@@ -1,9 +1,18 @@
+using IndyPOS.Bootstrapper.Upgrade;
 using IndyPOS.Domain.Enums;
 
 namespace IndyPOS.Bootstrapper.Silent;
 
+/// <param name="StoreId">
+/// Null is legal: an upgrade adopts the detected store id. The router rejects a supplied
+/// value that conflicts with the detected one — silently rewriting store identity would
+/// orphan the store's sales history.
+/// </param>
 public sealed record SilentInstallOptions(
-    string StoreId, int TimeoutMinutes, StoreType StoreType = StoreType.GeneralHardware);
+    string? StoreId,
+    int TimeoutMinutes,
+    StoreType StoreType = StoreType.GeneralHardware,
+    UpgradeStage? SimulateFailure = null);
 
 public enum ParseStatus { Silent, NotSilent, UsageError }
 
@@ -31,6 +40,7 @@ public static class SilentArgs
         string? storeId = null;
         var timeoutMinutes = DefaultTimeoutMinutes;
         var storeType = StoreType.GeneralHardware;
+        UpgradeStage? simulateFailure = null;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -61,16 +71,25 @@ public static class SilentArgs
                             "--store-type must be one of: GeneralHardware, Minimart, CoffeeShop.");
                     break;
 
+                case SimulatedFailure.ArgumentName:
+                    if (!TryReadValue(args, ref i, inlineValue, out var stageRaw)
+                        || (simulateFailure = SimulatedFailure.Parse(stageRaw)) is null)
+                        return ParseResult.Usage(
+                            $"{SimulatedFailure.ArgumentName} must name a stage (test hook).");
+                    break;
+
                 default:
                     return ParseResult.Usage($"Unknown argument: {args[i]}");
             }
         }
 
-        storeId = storeId?.Trim();
-        if (string.IsNullOrWhiteSpace(storeId))
-            return ParseResult.Usage("--silent requires --store-id <ID>.");
+        // A supplied-but-blank value is still a usage error; an absent flag is not — the
+        // router decides, because an upgrade adopts the store id it detected.
+        if (storeId is not null && string.IsNullOrWhiteSpace(storeId))
+            return ParseResult.Usage("--store-id requires a non-empty value.");
 
-        return ParseResult.Silent(new SilentInstallOptions(storeId, timeoutMinutes, storeType));
+        return ParseResult.Silent(
+            new SilentInstallOptions(storeId?.Trim(), timeoutMinutes, storeType, simulateFailure));
     }
 
     // Enum.TryParse<StoreType> also accepts defined underlying numeric values (e.g.

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentInstallLogger.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentInstallLogger.cs
@@ -8,9 +8,14 @@ namespace IndyPOS.Bootstrapper.Silent;
 /// on threadpool continuation threads, so all writes are serialized under a lock
 /// and flushed per line — an early crash still leaves a diagnosable log.
 /// </summary>
-public sealed class SilentInstallLogger(TextWriter file) : IProgress<InstallationProgress>, IDisposable
+public sealed class SilentInstallLogger(TextWriter file)
+    : IProgress<InstallationProgress>, IProgress<string>, IDisposable
 {
     private readonly object _gate = new();
+
+    // The upgrade's step units log plain strings (WindowsUpgradeSteps), while the
+    // orchestrators report structured progress. One sink serves both.
+    public void Report(string value) => WriteLine(value);
 
     public void Report(InstallationProgress value)
     {

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs
@@ -4,7 +4,7 @@ namespace IndyPOS.Bootstrapper.Silent;
 
 /// <summary>
 /// Headless entry point for `--silent --store-id <ID>`. Reuses
-/// InstallationOrchestrator unchanged; the durable log file is the authoritative
+/// FreshInstallOrchestrator unchanged; the durable log file is the authoritative
 /// result/marker channel and the exit code is the automation contract.
 /// </summary>
 public static class SilentInstaller
@@ -58,7 +58,7 @@ public static class SilentInstaller
         InstallationResult result;
         try
         {
-            result = new InstallationOrchestrator()
+            result = new FreshInstallOrchestrator()
                 .InstallAsync(config, logger, cts.Token)
                 .GetAwaiter().GetResult();
         }

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentInstaller.cs
@@ -1,4 +1,5 @@
 using IndyPOS.Bootstrapper.Installers;
+using IndyPOS.Bootstrapper.Upgrade;
 
 namespace IndyPOS.Bootstrapper.Silent;
 
@@ -20,18 +21,24 @@ public static class SilentInstaller
             return Emit(new NotElevatedOutcome(), logger: null);
 
         var options = parse.Options!;
-        var config = new InstallationConfig
+
+        // Detect first, with a placeholder store id: only the computed paths are needed to
+        // probe the machine, and StoreId is required on the record.
+        var probeConfig = new InstallationConfig
         {
-            StoreId = options.StoreId,
+            StoreId = options.StoreId ?? "pending",
             StoreType = options.StoreType,
             Interactive = false
         };
+
+        var detected = InstallModeDetector.Detect(
+            new WindowsInstallProbe(probeConfig), probeConfig.StoreHubInstallPath);
 
         string logPath;
         TextWriter writer;
         try
         {
-            (logPath, writer) = OpenLog(config);
+            (logPath, writer) = OpenLog(probeConfig);
         }
         catch (Exception ex)
         {
@@ -40,17 +47,79 @@ public static class SilentInstaller
         }
 
         var logger = new SilentInstallLogger(writer);
+        logger.WriteMarker(SilentOutcomeMapper.ModeMarker(detected.Mode));
 
-        var outcome = RunInstall(config, options, logger);
+        var outcome = detected.Mode switch
+        {
+            InstallMode.Unusable => new UnusableInstall(detected.Reason),
+            InstallMode.Upgrade => RunUpgrade(detected, options, logger),
+            _ => BuildFreshConfig(options) is { } fresh
+                ? RunFreshInstall(fresh, options, logger)
+                : new UsageErrorOutcome("--silent requires --store-id <ID> for a fresh install.")
+        };
+
         var exit = Emit(outcome, logger);
 
         // Dispose (flush + close the file) BEFORE copying to install-latest.log.
         logger.Dispose();
-        CopyLatest(config, logPath);
+        CopyLatest(probeConfig, logPath);
         return exit;
     }
 
-    private static SilentOutcome RunInstall(
+    // A fresh install still requires an explicit store id: there is nothing to adopt.
+    private static InstallationConfig? BuildFreshConfig(SilentInstallOptions options) =>
+        options.StoreId is null
+            ? null
+            : new InstallationConfig
+            {
+                StoreId = options.StoreId,
+                StoreType = options.StoreType,
+                Interactive = false
+            };
+
+    private static SilentOutcome RunUpgrade(
+        DetectedInstall detected, SilentInstallOptions options, SilentInstallLogger logger)
+    {
+        // Rewriting store identity would orphan every sale recorded under the old id.
+        if (options.StoreId is not null &&
+            !string.Equals(options.StoreId, detected.StoreId, StringComparison.Ordinal))
+        {
+            return new UnusableInstall(
+                $"--store-id '{options.StoreId}' does not match the installed store " +
+                $"'{detected.StoreId}'. Re-run without --store-id to upgrade this store.");
+        }
+
+        var config = new InstallationConfig
+        {
+            StoreId = detected.StoreId!,
+            StoreType = detected.StoreType!.Value,
+            Interactive = false
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(options.TimeoutMinutes));
+
+        try
+        {
+            var steps = new WindowsUpgradeSteps(config, logger);
+            return new UpgradeOrchestrator(steps, options.SimulateFailure)
+                .RunAsync(detected, config, logger, cts.Token)
+                .GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            logger.WriteLine("ERROR: upgrade timed out.");
+            return new InstallTimedOut();
+        }
+        catch (Exception ex)
+        {
+            var message = SecretScrubber.Scrub(ex.Message);
+            logger.WriteLine("ERROR: " + message);
+            return new UpgradeFailed(message, RolledBack: false, ServiceStarted: false,
+                HealthOk: false, BackupDir: null);
+        }
+    }
+
+    private static SilentOutcome RunFreshInstall(
         InstallationConfig config, SilentInstallOptions options, SilentInstallLogger logger)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(options.TimeoutMinutes));

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs
@@ -87,6 +87,9 @@ public static class SilentOutcomeMapper
         var markers = new List<string>
         {
             Prefix + "RESULT=failed",
+            // Scrubbed: a pg_dump or Npgsql error can quote the connection string, and this
+            // line lands in a log file that is read by whoever is standing at the till.
+            Prefix + $"REASON={SecretScrubber.Scrub(u.Message)}",
             Prefix + $"ROLLED_BACK={Lower(u.RolledBack)}",
             Prefix + $"SERVICE_STARTED={Lower(u.ServiceStarted)}",
             Prefix + $"HEALTH={(u.HealthOk ? "ok" : "failed")}",

--- a/installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs
+++ b/installer/IndyPOS.Bootstrapper/Silent/SilentOutcomeMapper.cs
@@ -1,3 +1,5 @@
+using IndyPOS.Bootstrapper.Upgrade;
+
 namespace IndyPOS.Bootstrapper.Silent;
 
 public abstract record SilentOutcome;
@@ -12,6 +14,25 @@ public sealed record InstallTimedOut : SilentOutcome;
 public sealed record UsageErrorOutcome(string Message) : SilentOutcome;
 
 public sealed record NotElevatedOutcome : SilentOutcome;
+
+/// <summary>
+/// An in-place upgrade completed. Sibling of <see cref="InstallSucceeded"/> rather than a
+/// widening of it: that record is a five-field positional type belonging to the frozen
+/// fresh path, and an upgrade reports a genuinely different set of facts.
+/// </summary>
+public sealed record UpgradeSucceeded(
+    string? FromVersion, string ToVersion, bool ServiceStarted, bool HealthOk,
+    string BackupDir, bool BackupLocked, bool PosUpdated) : SilentOutcome;
+
+/// <param name="ServiceStarted">Post-rollback when <paramref name="RolledBack"/> is true.</param>
+/// <param name="HealthOk">Post-rollback when <paramref name="RolledBack"/> is true.</param>
+public sealed record UpgradeFailed(
+    string Message, bool RolledBack, bool ServiceStarted, bool HealthOk,
+    string? BackupDir) : SilentOutcome;
+
+public sealed record UnusableInstall(string Reason) : SilentOutcome;
+
+public sealed record DowngradeRefused(string InstalledVersion, string InstallerVersion) : SilentOutcome;
 
 /// <summary>
 /// Pure mapping from a run's outcome to an exit code + the non-secret marker
@@ -30,8 +51,55 @@ public static class SilentOutcomeMapper
         InstallTimedOut => (4, [Prefix + "RESULT=timeout"]),
         UsageErrorOutcome u => (1, [Prefix + "RESULT=failed", Prefix + $"REASON={u.Message}"]),
         NotElevatedOutcome => (3, [Prefix + "RESULT=failed"]),
+        UpgradeSucceeded u => (0, UpgradeSuccessMarkers(u)),
+        UpgradeFailed u => (2, UpgradeFailureMarkers(u)),
+        UnusableInstall u => (5, [Prefix + "RESULT=failed", Prefix + $"REASON={u.Reason}"]),
+        DowngradeRefused d => (6, [
+            Prefix + "RESULT=failed",
+            Prefix + $"REASON=Installed version {d.InstalledVersion} is newer than this " +
+                     $"installer ({d.InstallerVersion}); downgrade refused."]),
         _ => throw new ArgumentOutOfRangeException(nameof(outcome))
     };
+
+    /// <summary>
+    /// Written to the log by the router before either orchestrator runs, so months later a
+    /// store's own install-latest.log answers "which path ran".
+    /// </summary>
+    public static string ModeMarker(InstallMode mode) =>
+        Prefix + "MODE=" + mode.ToString().ToLowerInvariant();
+
+    // No ADMIN_SEEDED / RESET_HINT / CRED_FILE here: those belong to the fresh path, and
+    // on an upgrade the reset hint actively misleads (spec section 7).
+    private static IReadOnlyList<string> UpgradeSuccessMarkers(UpgradeSucceeded u) =>
+    [
+        Prefix + "RESULT=success",
+        Prefix + $"FROM_VERSION={u.FromVersion ?? "unknown"}",
+        Prefix + $"TO_VERSION={u.ToVersion}",
+        Prefix + $"SERVICE_STARTED={Lower(u.ServiceStarted)}",
+        Prefix + $"HEALTH={(u.HealthOk ? "ok" : "failed")}",
+        Prefix + $"BACKUP_DIR={u.BackupDir}",
+        Prefix + $"BACKUP_LOCKED={Lower(u.BackupLocked)}",
+        Prefix + $"POS_UPDATED={Lower(u.PosUpdated)}"
+    ];
+
+    private static IReadOnlyList<string> UpgradeFailureMarkers(UpgradeFailed u)
+    {
+        var markers = new List<string>
+        {
+            Prefix + "RESULT=failed",
+            Prefix + $"ROLLED_BACK={Lower(u.RolledBack)}",
+            Prefix + $"SERVICE_STARTED={Lower(u.ServiceStarted)}",
+            Prefix + $"HEALTH={(u.HealthOk ? "ok" : "failed")}",
+            Prefix + "POS_UPDATED=false"
+        };
+
+        if (u.BackupDir is not null)
+        {
+            markers.Add(Prefix + $"BACKUP_DIR={u.BackupDir}");
+        }
+
+        return markers;
+    }
 
     private static IReadOnlyList<string> SuccessMarkers(InstallSucceeded s)
     {

--- a/installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs
+++ b/installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs
@@ -1,4 +1,5 @@
 using IndyPOS.Bootstrapper.Installers;
+using IndyPOS.Bootstrapper.Upgrade;
 using IndyPOS.Domain.Enums;
 
 namespace IndyPOS.Bootstrapper.UI;
@@ -10,6 +11,20 @@ public partial class InstallationWizard : Form
 {
     private readonly FreshInstallOrchestrator _orchestrator;
     private readonly CancellationTokenSource _cts = new();
+
+    /// <summary>
+    /// The wizard deliberately gains no upgrade UI: it collects StoreId and StoreType up
+    /// front (both already fixed on an upgrade) and its finish screen is built around
+    /// bootstrap credentials that do not exist on one. But it must not silently proceed —
+    /// a double-clicked Setup.exe on a live store reproduces both original failures.
+    /// </summary>
+    internal static string BuildExistingInstallMessage(DetectedInstall detected) =>
+        $"IndyPOS {detected.InstalledVersion ?? "(unknown version)"} is already installed on " +
+        $"this machine (store {detected.StoreId ?? "unknown"}).\n\n" +
+        "The wizard only performs new installations. To upgrade in place, open an " +
+        "administrator command prompt and run:\n\n" +
+        "    IndyPOS-Setup.exe --silent\n\n" +
+        "See docs\\operations\\upgrade-procedure.md.";
 
     // UI Controls
     private Panel _headerPanel = null!;

--- a/installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs
+++ b/installer/IndyPOS.Bootstrapper/UI/InstallationWizard.cs
@@ -8,7 +8,7 @@ namespace IndyPOS.Bootstrapper.UI;
 /// </summary>
 public partial class InstallationWizard : Form
 {
-    private readonly InstallationOrchestrator _orchestrator;
+    private readonly FreshInstallOrchestrator _orchestrator;
     private readonly CancellationTokenSource _cts = new();
 
     // UI Controls
@@ -38,7 +38,7 @@ public partial class InstallationWizard : Form
 
     public InstallationWizard()
     {
-        _orchestrator = new InstallationOrchestrator();
+        _orchestrator = new FreshInstallOrchestrator();
         InitializeComponents();
         WireEvents();
     }

--- a/installer/IndyPOS.Bootstrapper/Upgrade/IInstallProbe.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/IInstallProbe.cs
@@ -1,0 +1,122 @@
+using System.ServiceProcess;
+using System.Text.Json;
+using Microsoft.Win32;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>
+/// Everything <see cref="InstallModeDetector"/> needs to know about the machine.
+/// An interface so the ordered rules can be tested without a real install.
+/// </summary>
+public interface IInstallProbe
+{
+    bool ManifestExists { get; }
+    string? ManifestInstallVersion { get; }
+
+    /// <summary>
+    /// A PostgreSQL install carrying the IndyPOS database. Note DatabaseName is NOT
+    /// version-scoped, so this is true for a v4 store seen by a v5 installer.
+    /// </summary>
+    bool PostgresStoreDatabaseExists { get; }
+
+    /// <summary>The registered service's ImagePath, or null when no such service exists.</summary>
+    string? ServiceImagePath { get; }
+
+    StoreHubConfigFacts Config { get; }
+}
+
+/// <summary>Reads the real machine. Every member is evaluated once, at construction.</summary>
+public sealed class WindowsInstallProbe : IInstallProbe
+{
+    public WindowsInstallProbe(InstallationConfig config)
+    {
+        var manifestPath = Path.Combine(config.SystemRoot, InstallManifestWriter.ManifestFileName);
+        ManifestExists = File.Exists(manifestPath);
+        ManifestInstallVersion = ManifestExists ? ReadManifestVersion(manifestPath) : null;
+
+        Config = StoreHubConfigReader.Read(
+            Path.Combine(config.StoreHubInstallPath, "appsettings.json"));
+
+        ServiceImagePath = ReadServiceImagePath(config.ServiceName);
+        PostgresStoreDatabaseExists = DetectStoreDatabase(config);
+    }
+
+    public bool ManifestExists { get; }
+    public string? ManifestInstallVersion { get; }
+    public bool PostgresStoreDatabaseExists { get; }
+    public string? ServiceImagePath { get; }
+    public StoreHubConfigFacts Config { get; }
+
+    private static string? ReadManifestVersion(string manifestPath)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(manifestPath));
+
+            // ValueKind check, not a bare GetString(): that throws on a non-string token,
+            // and a hand-edited manifest must degrade to "unknown version", never crash.
+            return doc.RootElement.TryGetProperty("installVersion", out var v)
+                   && v.ValueKind == JsonValueKind.String
+                ? v.GetString()
+                : null;
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    // ServiceController does not expose ImagePath, so read the SCM registry key directly.
+    private static string? ReadServiceImagePath(string serviceName)
+    {
+        try
+        {
+            using var key = Registry.LocalMachine.OpenSubKey(
+                $@"SYSTEM\CurrentControlSet\Services\{serviceName}");
+            return key?.GetValue("ImagePath") as string;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    // No superuser credential is available here, so this is a filesystem-and-config
+    // inference rather than a query: a usable connection string means a provisioned
+    // database, and a Postgres data directory means one could exist for another major.
+    private static bool DetectStoreDatabase(InstallationConfig config)
+    {
+        var appSettings = Path.Combine(config.StoreHubInstallPath, "appsettings.json");
+        if (StoreHubConfigReader.Read(appSettings).ConnectionStringUsable)
+        {
+            return true;
+        }
+
+        foreach (var major in new[] { "18", "17", "16" })
+        {
+            var dataDir = $@"C:\Program Files\PostgreSQL\{major}\data\base";
+            if (Directory.Exists(dataDir) && OtherMajorStoreConfigExists())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // C:\ProgramData\IndyPOS\v{N}\StoreHub\appsettings.json for a major other than ours
+    // is the v5-installer-on-a-v4-store case that rule 1 exists to catch.
+    private static bool OtherMajorStoreConfigExists()
+    {
+        var root = @"C:\ProgramData\IndyPOS";
+        if (!Directory.Exists(root))
+        {
+            return false;
+        }
+
+        return Directory.EnumerateDirectories(root, "v*")
+            .Select(d => Path.Combine(d, "StoreHub", "appsettings.json"))
+            .Any(p => StoreHubConfigReader.Read(p).ConnectionStringUsable);
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Upgrade/IInstallProbe.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/IInstallProbe.cs
@@ -1,4 +1,3 @@
-using System.ServiceProcess;
 using System.Text.Json;
 using Microsoft.Win32;
 using IndyPOS.Bootstrapper.Installers;
@@ -54,9 +53,12 @@ public sealed class WindowsInstallProbe : IInstallProbe
         {
             using var doc = JsonDocument.Parse(File.ReadAllText(manifestPath));
 
-            // ValueKind check, not a bare GetString(): that throws on a non-string token,
-            // and a hand-edited manifest must degrade to "unknown version", never crash.
-            return doc.RootElement.TryGetProperty("installVersion", out var v)
+            // ValueKind checks, not a bare GetString()/TryGetProperty(): TryGetProperty
+            // throws InvalidOperationException when the root isn't an object (a bare
+            // string/number/array manifest), and GetString() throws on a non-string
+            // token. A hand-edited manifest must degrade to "unknown version", never crash.
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                   && doc.RootElement.TryGetProperty("installVersion", out var v)
                    && v.ValueKind == JsonValueKind.String
                 ? v.GetString()
                 : null;
@@ -83,40 +85,33 @@ public sealed class WindowsInstallProbe : IInstallProbe
     }
 
     // No superuser credential is available here, so this is a filesystem-and-config
-    // inference rather than a query: a usable connection string means a provisioned
-    // database, and a Postgres data directory means one could exist for another major.
-    private static bool DetectStoreDatabase(InstallationConfig config)
-    {
-        var appSettings = Path.Combine(config.StoreHubInstallPath, "appsettings.json");
-        if (StoreHubConfigReader.Read(appSettings).ConnectionStringUsable)
-        {
-            return true;
-        }
+    // inference rather than a query: a usable connection string in ANOTHER major's
+    // StoreHub config means a database already exists for that major. This major's
+    // own config is already captured in probe.Config and must be excluded here, or a
+    // same-major partial install (config written by DatabaseSetup, manifest not yet
+    // written by InstallManifestWriter -- the exact state a crashed run leaves behind)
+    // would misread as "belongs to another major" instead of "this install is incomplete".
+    private static bool DetectStoreDatabase(InstallationConfig config) =>
+        OtherMajorStoreConfigExists(config.SystemRoot);
 
-        foreach (var major in new[] { "18", "17", "16" })
+    private static bool OtherMajorStoreConfigExists(string ownSystemRoot)
+    {
+        const string root = @"C:\ProgramData\IndyPOS";
+        try
         {
-            var dataDir = $@"C:\Program Files\PostgreSQL\{major}\data\base";
-            if (Directory.Exists(dataDir) && OtherMajorStoreConfigExists())
+            if (!Directory.Exists(root))
             {
-                return true;
+                return false;
             }
+
+            return Directory.EnumerateDirectories(root, "v*")
+                .Where(d => !string.Equals(d, ownSystemRoot, StringComparison.OrdinalIgnoreCase))
+                .Select(d => Path.Combine(d, "StoreHub", "appsettings.json"))
+                .Any(p => StoreHubConfigReader.Read(p).ConnectionStringUsable);
         }
-
-        return false;
-    }
-
-    // C:\ProgramData\IndyPOS\v{N}\StoreHub\appsettings.json for a major other than ours
-    // is the v5-installer-on-a-v4-store case that rule 1 exists to catch.
-    private static bool OtherMajorStoreConfigExists()
-    {
-        var root = @"C:\ProgramData\IndyPOS";
-        if (!Directory.Exists(root))
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             return false;
         }
-
-        return Directory.EnumerateDirectories(root, "v*")
-            .Select(d => Path.Combine(d, "StoreHub", "appsettings.json"))
-            .Any(p => StoreHubConfigReader.Read(p).ConnectionStringUsable);
     }
 }

--- a/installer/IndyPOS.Bootstrapper/Upgrade/IProcessRunner.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/IProcessRunner.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+public sealed record ProcessRunResult(int ExitCode, string StandardOutput, string StandardError);
+
+/// <summary>Seam over external tools (pg_dump, Velopack Setup.exe) so the sequence is testable.</summary>
+public interface IProcessRunner
+{
+    Task<ProcessRunResult> RunAsync(
+        string fileName,
+        string arguments,
+        IReadOnlyDictionary<string, string>? environment,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class ExternalProcessRunner : IProcessRunner
+{
+    public async Task<ProcessRunResult> RunAsync(
+        string fileName,
+        string arguments,
+        IReadOnlyDictionary<string, string>? environment,
+        CancellationToken cancellationToken = default)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        if (environment is not null)
+        {
+            foreach (var (key, value) in environment)
+            {
+                psi.Environment[key] = value;
+            }
+        }
+
+        using var process = new Process { StartInfo = psi };
+        process.Start();
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await Task.WhenAll(stdoutTask, stderrTask);
+        await process.WaitForExitAsync(cancellationToken);
+
+        return new ProcessRunResult(process.ExitCode, await stdoutTask, await stderrTask);
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Upgrade/InstallMode.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/InstallMode.cs
@@ -1,0 +1,25 @@
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>
+/// How this machine should be treated. Three outcomes, not two: a machine can be
+/// neither freshly installable nor upgradeable, and treating that as Fresh sends the
+/// run past the point where it starts mutating the install.
+/// </summary>
+public enum InstallMode
+{
+    Fresh,
+    Upgrade,
+    Unusable
+}
+
+/// <param name="InstalledVersion">From install-manifest.json. Null unless a manifest was found.</param>
+/// <param name="StoreId">From appsettings.json — the manifest does not record it.</param>
+/// <param name="Reason">Operator-facing explanation. Surfaced on Unusable.</param>
+public sealed record DetectedInstall(
+    InstallMode Mode,
+    string? InstalledVersion,
+    string? StoreId,
+    StoreType? StoreType,
+    string Reason);

--- a/installer/IndyPOS.Bootstrapper/Upgrade/InstallModeDetector.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/InstallModeDetector.cs
@@ -46,7 +46,9 @@ public static class InstallModeDetector
                     "Store:Type is missing from appsettings.json (stores installed before " +
                     "2026-07-18 have no such key). It cannot be defaulted: the default is the most " +
                     "permissive store type and would silently re-enable restricted features. " +
-                    "Re-run with --store-type <GeneralHardware|Minimart> to set it.");
+                    "Add \"type\": \"GeneralHardware\" (or \"Minimart\") to the \"store\" section " +
+                    "and re-run - see docs\\operations\\upgrade-procedure.md. Note --store-type " +
+                    "does NOT fix this: the run is refused before arguments are consulted.");
             }
 
             if (!ImagePathResolvesUnder(probe.ServiceImagePath, storeHubInstallPath))

--- a/installer/IndyPOS.Bootstrapper/Upgrade/InstallModeDetector.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/InstallModeDetector.cs
@@ -1,0 +1,99 @@
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>
+/// Classifies a machine. Rules are evaluated IN ORDER and the first match wins —
+/// see the upgrade design spec, section 3. Reordering them reintroduces the data-loss
+/// path rule 1 exists to close.
+/// </summary>
+public static class InstallModeDetector
+{
+    public static DetectedInstall Detect(IInstallProbe probe, string storeHubInstallPath)
+    {
+        ArgumentNullException.ThrowIfNull(probe);
+
+        // Rule 1 — must precede the manifest lookup. SystemRoot is version-scoped but
+        // DatabaseName is not, so a newer major would read a live store as Fresh and
+        // then collide with its database.
+        if (probe.PostgresStoreDatabaseExists && !probe.ManifestExists)
+        {
+            return Unusable(probe,
+                "An IndyPOS database exists on this machine but belongs to another IndyPOS " +
+                "major version. Do not remove PostgreSQL — it holds the store's sales history. " +
+                "Run the installer for the version that owns that install root instead.");
+        }
+
+        // Rule 2 — everything an upgrade needs is present and coherent.
+        if (probe.ManifestExists)
+        {
+            if (!probe.Config.ConnectionStringUsable)
+            {
+                return Unusable(probe,
+                    "The StoreHub connection string is missing, empty, or cannot be decrypted on " +
+                    "this machine. Restore appsettings.json from a backup before upgrading.");
+            }
+
+            if (probe.Config.StoreId is null)
+            {
+                return Unusable(probe,
+                    "Store:Id is missing from appsettings.json. Upgrading without it would seed a " +
+                    "second payment-method catalogue under a fallback store id and orphan the " +
+                    "store's sales history. Set Store:Id to this store's real id first.");
+            }
+
+            if (probe.Config.StoreType is null)
+            {
+                return Unusable(probe,
+                    "Store:Type is missing from appsettings.json (stores installed before " +
+                    "2026-07-18 have no such key). It cannot be defaulted: the default is the most " +
+                    "permissive store type and would silently re-enable restricted features. " +
+                    "Re-run with --store-type <GeneralHardware|Minimart> to set it.");
+            }
+
+            if (!ImagePathResolvesUnder(probe.ServiceImagePath, storeHubInstallPath))
+            {
+                return Unusable(probe,
+                    "The StoreHub service is not registered, or its ImagePath does not resolve " +
+                    $"under {storeHubInstallPath}. Upgrading would deploy binaries the service " +
+                    "does not run.");
+            }
+
+            return new DetectedInstall(
+                InstallMode.Upgrade,
+                probe.ManifestInstallVersion,
+                probe.Config.StoreId,
+                probe.Config.StoreType,
+                "An existing IndyPOS install was detected and can be upgraded in place.");
+        }
+
+        // Rule 3 — a genuinely bare machine. BOTH must be absent.
+        if (!probe.Config.Exists)
+        {
+            return new DetectedInstall(InstallMode.Fresh, null, null, null,
+                "No existing IndyPOS install was found.");
+        }
+
+        // Rule 4 — anything else.
+        return Unusable(probe,
+            "A StoreHub configuration exists but there is no install manifest, so this machine " +
+            "is neither a clean install nor a complete one. Inspect " +
+            $"{storeHubInstallPath} before proceeding.");
+    }
+
+    private static DetectedInstall Unusable(IInstallProbe probe, string reason) =>
+        new(InstallMode.Unusable, probe.ManifestInstallVersion, probe.Config.StoreId,
+            probe.Config.StoreType, reason);
+
+    // sc.exe records binPath with surrounding quotes when the path contains spaces,
+    // and "C:\ProgramData\..." always does not — but a hand-registered service may.
+    private static bool ImagePathResolvesUnder(string? imagePath, string installPath)
+    {
+        if (string.IsNullOrWhiteSpace(imagePath))
+        {
+            return false;
+        }
+
+        var trimmed = imagePath.Trim().Trim('"');
+
+        return trimmed.StartsWith(installPath, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Upgrade/InstallModeDetector.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/InstallModeDetector.cs
@@ -94,6 +94,12 @@ public static class InstallModeDetector
 
         var trimmed = imagePath.Trim().Trim('"');
 
-        return trimmed.StartsWith(installPath, StringComparison.OrdinalIgnoreCase);
+        // Trailing separator turns this into a directory-boundary check, not a bare
+        // string prefix -- otherwise a sibling like "...\v4\StoreHubOLD\..." would
+        // satisfy a plain StartsWith(installPath) even though it is a different folder.
+        var boundary = installPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                       + Path.DirectorySeparatorChar;
+
+        return trimmed.StartsWith(boundary, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/installer/IndyPOS.Bootstrapper/Upgrade/PosAppVersion.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/PosAppVersion.cs
@@ -1,0 +1,50 @@
+using System.Xml.Linq;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>
+/// Reads the POS app version Velopack believes is installed.
+/// <para>A 2026-07-26 VM spike established that <c>Setup.exe --silent</c> exits 0 whether it
+/// upgraded the app or merely repaired the same version, and that the binaries keep their
+/// own build stamp regardless of the package version. Comparing this file before and after
+/// is therefore the only honest way to derive POS_UPDATED.</para>
+/// </summary>
+public static class PosAppVersion
+{
+    public const string VersionFileName = "sq.version";
+
+    /// <param name="velopackCurrentDirectory">
+    /// The Velopack <c>current</c> directory — i.e. <see cref="Installers.InstallationConfig.VelopackInstallPath"/>.
+    /// </param>
+    /// <returns>The package version, or null when it cannot be established.</returns>
+    public static string? Read(string velopackCurrentDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(velopackCurrentDirectory))
+        {
+            return null;
+        }
+
+        var path = Path.Combine(velopackCurrentDirectory, VersionFileName);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            // sq.version is a nuspec document, not a bare version string. Match on local
+            // name so the packaging namespace cannot break this.
+            var version = XDocument.Load(path)
+                .Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "version")
+                ?.Value
+                .Trim();
+
+            return string.IsNullOrWhiteSpace(version) ? null : version;
+        }
+        catch (Exception ex) when (ex is System.Xml.XmlException or IOException)
+        {
+            return null;
+        }
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Upgrade/SimulatedFailure.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/SimulatedFailure.cs
@@ -1,0 +1,37 @@
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+public enum UpgradeStage
+{
+    Preflight,
+    Stop,
+    Backup,
+    Deploy,
+    RestoreConfig,
+    Migrate,
+    Start,
+    PosApp
+}
+
+/// <summary>
+/// Runtime-selected fault injection for VM case 2 (forced mid-upgrade failure).
+/// <para>Runtime, not compile-time, deliberately: at roughly 10 minutes per cycle plus a
+/// 190 MB build, one binary serving both VM cases is the difference between one evening
+/// and two. Undocumented in help output — it is a test hook, not a feature.</para>
+/// </summary>
+public static class SimulatedFailure
+{
+    public const string ArgumentName = "--simulate-failure";
+
+    public static UpgradeStage? Parse(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var matched = Enum.GetNames<UpgradeStage>()
+            .FirstOrDefault(n => n.Equals(value, StringComparison.OrdinalIgnoreCase));
+
+        return matched is null ? null : Enum.Parse<UpgradeStage>(matched);
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Upgrade/StoreHubConfigReader.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/StoreHubConfigReader.cs
@@ -1,0 +1,118 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using IndyPOS.Domain.Enums;
+using IndyPOS.Vault;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>
+/// What an existing StoreHub <c>appsettings.json</c> says about the store on this
+/// machine. Detection (spec section 3) and upgrade preflight (section 4 step 1) both read
+/// through this one type, so the two can never disagree about whether a store is
+/// upgradeable.
+/// </summary>
+public sealed record StoreHubConfigFacts(
+    bool Exists,
+    bool ConnectionStringUsable,
+    string? StoreId,
+    StoreType? StoreType);
+
+public static class StoreHubConfigReader
+{
+    /// <summary>Config key the connection string is DPAPI-bound to. Entropy depends on it.</summary>
+    public const string ConnectionStringKey = "ConnectionStrings:storehub-db";
+
+    private static readonly StoreHubConfigFacts Absent = new(false, false, null, null);
+
+    /// <param name="unprotect">
+    /// Seam for the DPAPI round-trip, so tests need not author a machine-scoped blob.
+    /// Defaults to <see cref="SecretProtector.Unprotect"/>.
+    /// </param>
+    public static StoreHubConfigFacts Read(
+        string appSettingsPath,
+        Func<string, string, string>? unprotect = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(appSettingsPath);
+
+        if (!File.Exists(appSettingsPath))
+        {
+            return Absent;
+        }
+
+        JsonObject? root;
+        try
+        {
+            root = JsonNode.Parse(File.ReadAllText(appSettingsPath))?.AsObject();
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException)
+        {
+            // The file is there but unreadable — that is an Unusable store, not a fresh one.
+            return new StoreHubConfigFacts(Exists: true, false, null, null);
+        }
+
+        if (root is null)
+        {
+            return new StoreHubConfigFacts(Exists: true, false, null, null);
+        }
+
+        var store = Section(root, "store");
+
+        return new StoreHubConfigFacts(
+            Exists: true,
+            ConnectionStringUsable: IsConnectionStringUsable(root, unprotect ?? SecretProtector.Unprotect),
+            StoreId: NonBlank(Value(store, "id")),
+            StoreType: ParseStoreType(Value(store, "type")));
+    }
+
+    private static bool IsConnectionStringUsable(JsonObject root, Func<string, string, string> unprotect)
+    {
+        var value = Value(Section(root, "connectionStrings"), "storehub-db");
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        if (!SecretProtector.IsProtected(value))
+        {
+            return true;
+        }
+
+        try
+        {
+            return !string.IsNullOrWhiteSpace(unprotect(ConnectionStringKey, value));
+        }
+        catch (Exception ex) when (ex is CryptographicException or FormatException)
+        {
+            // Sealed on another machine. Nothing here can recover it.
+            return false;
+        }
+    }
+
+    // Config binding is case-insensitive, so a hand-edited PascalCase file must still bind.
+    private static JsonObject? Section(JsonObject root, string name) =>
+        root.FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase))
+            .Value as JsonObject;
+
+    private static string? Value(JsonObject? section, string name) =>
+        section?.FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase))
+               .Value?.GetValue<string>();
+
+    private static string? NonBlank(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+
+    // Only a defined enum NAME counts; Enum.TryParse would also accept "2".
+    private static StoreType? ParseStoreType(string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var matched = Enum.GetNames<StoreType>()
+            .FirstOrDefault(n => n.Equals(value, StringComparison.OrdinalIgnoreCase));
+
+        return matched is null ? null : Enum.Parse<StoreType>(matched);
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Upgrade/StoreHubConfigReader.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/StoreHubConfigReader.cs
@@ -45,7 +45,7 @@ public static class StoreHubConfigReader
         {
             root = JsonNode.Parse(File.ReadAllText(appSettingsPath))?.AsObject();
         }
-        catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException)
+        catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException or UnauthorizedAccessException)
         {
             // The file is there but unreadable — that is an Unusable store, not a fresh one.
             return new StoreHubConfigFacts(Exists: true, false, null, null);
@@ -95,9 +95,26 @@ public static class StoreHubConfigReader
         root.FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase))
             .Value as JsonObject;
 
-    private static string? Value(JsonObject? section, string name) =>
-        section?.FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase))
-               .Value?.GetValue<string>();
+    private static string? Value(JsonObject? section, string name)
+    {
+        var node = section?.FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase))
+                          .Value;
+
+        if (node is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return node.GetValue<string>();
+        }
+        catch (InvalidOperationException)
+        {
+            // JSON value is not a string (e.g., numeric or object). Return null gracefully.
+            return null;
+        }
+    }
 
     private static string? NonBlank(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value;

--- a/installer/IndyPOS.Bootstrapper/Upgrade/StoreHubConfigReader.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/StoreHubConfigReader.cs
@@ -65,6 +65,44 @@ public static class StoreHubConfigReader
             StoreType: ParseStoreType(Value(store, "type")));
     }
 
+    /// <summary>
+    /// The plaintext connection string, or null when it is absent, unreadable, or sealed to
+    /// another machine. Shares <see cref="Read"/>'s case-insensitive lookup so the upgrade's
+    /// preflight and detection can never disagree about the same file.
+    /// </summary>
+    public static string? ReadConnectionString(
+        string appSettingsPath,
+        Func<string, string, string>? unprotect = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(appSettingsPath);
+
+        if (!File.Exists(appSettingsPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var root = JsonNode.Parse(File.ReadAllText(appSettingsPath))?.AsObject();
+            var value = root is null ? null : Value(Section(root, "connectionStrings"), "storehub-db");
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            return SecretProtector.IsProtected(value)
+                ? (unprotect ?? SecretProtector.Unprotect)(ConnectionStringKey, value)
+                : value;
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException
+                                      or UnauthorizedAccessException or CryptographicException
+                                      or FormatException)
+        {
+            return null;
+        }
+    }
+
     private static bool IsConnectionStringUsable(JsonObject root, Func<string, string, string> unprotect)
     {
         var value = Value(Section(root, "connectionStrings"), "storehub-db");

--- a/installer/IndyPOS.Bootstrapper/Upgrade/UpgradeBackup.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/UpgradeBackup.cs
@@ -1,0 +1,184 @@
+using IndyPOS.Bootstrapper.Installers;
+using Npgsql;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+public sealed record BackupResult(bool Success, string? StampDirectory, bool Locked, string? ErrorMessage);
+
+/// <summary>
+/// Takes and restores the pre-upgrade recovery artifacts (see the upgrade design spec,
+/// sections 4, 5 and 6). Everything here runs ABOVE the mutation line except
+/// <see cref="RestoreStoreHubTree"/>, which runs on the rollback path.
+/// </summary>
+public sealed class UpgradeBackup(
+    string backupsDirectory,
+    string storeHubInstallPath,
+    IProcessRunner processRunner,
+    Func<string> stampFactory,
+    Func<string, bool>? lockPath = null)
+{
+    public const string DumpFileName = "storehub.dump";
+
+    /// <summary>A pg_dump that exits 0 having written less than this did not really succeed.</summary>
+    public const int MinimumDumpBytes = 1024;
+
+    /// <summary>Roughly 130 MB per stamp, forever, on a small unattended retail PC.</summary>
+    public const int RetainedStamps = 2;
+
+    // Verified 2026-07-28: this also works on a directory path — FileInfo's ACL extension
+    // resolves through SE_FILE_OBJECT, so no DirectoryInfo variant is needed. The resulting
+    // ACE carries no inheritance flags, which is why every artifact is locked explicitly
+    // below rather than relying on the stamp directory to propagate.
+    private readonly Func<string, bool> _lockPath =
+        lockPath ?? DatabaseSetup.TryRestrictFilePermissions;
+
+    public async Task<BackupResult> CreateAsync(
+        string pgDumpPath,
+        string connectionString,
+        CancellationToken cancellationToken = default)
+    {
+        var stampDir = Path.Combine(backupsDirectory, stampFactory());
+
+        try
+        {
+            // BackupsDirectory exists in InstallationConfig and the manifest, but only
+            // DatabaseSetup.CreateDirectories guarantees it — and that never runs here.
+            Directory.CreateDirectory(stampDir);
+
+            var dumpPath = Path.Combine(stampDir, DumpFileName);
+            var dumpFailure = await RunPgDumpAsync(pgDumpPath, connectionString, dumpPath, cancellationToken);
+            if (dumpFailure is not null)
+            {
+                return new BackupResult(false, stampDir, false, dumpFailure);
+            }
+
+            var treeDestination = Path.Combine(stampDir, "StoreHub");
+            CopyDirectory(storeHubInstallPath, treeDestination);
+
+            var locked = LockTree(stampDir, dumpPath, treeDestination);
+
+            Prune();
+
+            return new BackupResult(true, stampDir, locked, null);
+        }
+        catch (Exception ex)
+        {
+            return new BackupResult(false, stampDir, false, ex.Message);
+        }
+    }
+
+    /// <returns>An error message, or null on success.</returns>
+    private async Task<string?> RunPgDumpAsync(
+        string pgDumpPath, string connectionString, string dumpPath, CancellationToken cancellationToken)
+    {
+        // NpgsqlConnectionStringBuilder, not string splitting: the password may contain
+        // anything, and a mis-split silently dumps the wrong database.
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+
+        var arguments =
+            $"--host={builder.Host} --port={builder.Port} --username={builder.Username} " +
+            $"--dbname={builder.Database} --no-password -Fc -f \"{dumpPath}\"";
+
+        // PGPASSWORD via the environment, never the command line: a command line is
+        // visible to every local process.
+        var environment = new Dictionary<string, string> { ["PGPASSWORD"] = builder.Password ?? "" };
+
+        var run = await processRunner.RunAsync(pgDumpPath, arguments, environment, cancellationToken);
+
+        if (run.ExitCode != 0)
+        {
+            return $"pg_dump failed (exit {run.ExitCode}): {run.StandardError.Trim()}";
+        }
+
+        if (!File.Exists(dumpPath))
+        {
+            return "pg_dump reported success but produced no file.";
+        }
+
+        var length = new FileInfo(dumpPath).Length;
+        return length < MinimumDumpBytes
+            ? $"pg_dump produced a file that is too small to be a valid dump ({length} bytes)."
+            : null;
+    }
+
+    private bool LockTree(string stampDir, string dumpPath, string treeDestination)
+    {
+        var locked = _lockPath(stampDir) & _lockPath(dumpPath);
+
+        foreach (var file in Directory.EnumerateFiles(treeDestination, "*", SearchOption.AllDirectories))
+        {
+            locked &= _lockPath(file);
+        }
+
+        return locked;
+    }
+
+    /// <summary>
+    /// Puts the backed-up StoreHub tree back. DELETE-then-copy: extraction overwrites
+    /// per entry with no clean step, so the failed tree is old-union-new and copying over
+    /// it would strand new-version files (see the design spec, section 5).
+    /// </summary>
+    public void RestoreStoreHubTree(string stampDirectory)
+    {
+        var source = Path.Combine(stampDirectory, "StoreHub");
+
+        if (!Directory.Exists(source))
+        {
+            throw new DirectoryNotFoundException(
+                $"No StoreHub backup at {source}; cannot roll back. The database dump, if any, " +
+                $"is still at {Path.Combine(stampDirectory, DumpFileName)}.");
+        }
+
+        if (Directory.Exists(storeHubInstallPath))
+        {
+            Directory.Delete(storeHubInstallPath, recursive: true);
+        }
+
+        CopyDirectory(source, storeHubInstallPath);
+    }
+
+    /// <summary>Keeps the newest <see cref="RetainedStamps"/> stamps. Returns how many it removed.</summary>
+    public int Prune()
+    {
+        if (!Directory.Exists(backupsDirectory))
+        {
+            return 0;
+        }
+
+        // Stamp names are yyyyMMdd-HHmmss, so ordinal descending IS newest-first, and it
+        // does not depend on directory timestamps a restore may have rewritten.
+        var stale = Directory.GetDirectories(backupsDirectory)
+            .OrderByDescending(Path.GetFileName, StringComparer.Ordinal)
+            .Skip(RetainedStamps)
+            .ToList();
+
+        foreach (var dir in stale)
+        {
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Retention is housekeeping; never fail an upgrade over it.
+            }
+        }
+
+        return stale.Count;
+    }
+
+    private static void CopyDirectory(string sourceDir, string destDir)
+    {
+        Directory.CreateDirectory(destDir);
+
+        foreach (var file in Directory.GetFiles(sourceDir))
+        {
+            File.Copy(file, Path.Combine(destDir, Path.GetFileName(file)), overwrite: true);
+        }
+
+        foreach (var dir in Directory.GetDirectories(sourceDir))
+        {
+            CopyDirectory(dir, Path.Combine(destDir, Path.GetFileName(dir)));
+        }
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Upgrade/UpgradeBackup.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/UpgradeBackup.cs
@@ -15,7 +15,8 @@ public sealed class UpgradeBackup(
     string storeHubInstallPath,
     IProcessRunner processRunner,
     Func<string> stampFactory,
-    Func<string, bool>? lockPath = null)
+    Func<string, bool>? lockPath = null,
+    Func<string, bool>? lockDirectory = null)
 {
     public const string DumpFileName = "storehub.dump";
 
@@ -25,12 +26,13 @@ public sealed class UpgradeBackup(
     /// <summary>Roughly 130 MB per stamp, forever, on a small unattended retail PC.</summary>
     public const int RetainedStamps = 2;
 
-    // Verified 2026-07-28: this also works on a directory path — FileInfo's ACL extension
-    // resolves through SE_FILE_OBJECT, so no DirectoryInfo variant is needed. The resulting
-    // ACE carries no inheritance flags, which is why every artifact is locked explicitly
-    // below rather than relying on the stamp directory to propagate.
     private readonly Func<string, bool> _lockPath =
         lockPath ?? DatabaseSetup.TryRestrictFilePermissions;
+
+    // Directories need their own helper: a non-inheritable ACE on a protected directory
+    // leaves every child with an empty DACL. See TryRestrictDirectoryPermissions.
+    private readonly Func<string, bool> _lockDirectory =
+        lockDirectory ?? DatabaseSetup.TryRestrictDirectoryPermissions;
 
     public async Task<BackupResult> CreateAsync(
         string pgDumpPath,
@@ -101,16 +103,19 @@ public sealed class UpgradeBackup(
             : null;
     }
 
+    /// <summary>
+    /// Locks the stamp directory with inheritable ACEs, so the dump and the whole tree are
+    /// covered by inheritance rather than by walking hundreds of files.
+    /// <para>The tree is NOT enumerated here. It used to be, and that is what failed on
+    /// 2026-07-29: protecting the parent had already emptied the tree directory's DACL, so
+    /// the walk hit UnauthorizedAccessException on a backup it had just written perfectly.
+    /// Enumerating what you have deliberately made unreachable cannot work.</para>
+    /// </summary>
     private bool LockTree(string stampDir, string dumpPath, string treeDestination)
     {
-        var locked = _lockPath(stampDir) & _lockPath(dumpPath);
-
-        foreach (var file in Directory.EnumerateFiles(treeDestination, "*", SearchOption.AllDirectories))
-        {
-            locked &= _lockPath(file);
-        }
-
-        return locked;
+        // The dump is also locked explicitly: it is the whole sales history plus the BCrypt
+        // admin hashes, so it should not depend on inheritance alone.
+        return _lockDirectory(stampDir) & _lockPath(dumpPath) & _lockDirectory(treeDestination);
     }
 
     /// <summary>

--- a/installer/IndyPOS.Bootstrapper/Upgrade/UpgradeOrchestrator.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/UpgradeOrchestrator.cs
@@ -1,0 +1,218 @@
+using IndyPOS.Bootstrapper.Installers;
+using IndyPOS.Bootstrapper.Silent;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>A captured config, restorable once. Wraps ConfigSnapshot for testability.</summary>
+public sealed class ConfigSnapshotHandle(Action restore)
+{
+    public void Restore() => restore();
+}
+
+/// <summary>
+/// The individual step units the upgrade sequence drives. An interface so the ORDER and
+/// the rollback decisions — the parts that actually failed in production — are unit-testable
+/// without a service, a database or a 190 MB installer.
+/// <para>There is deliberately no DatabaseSetup member: it is fresh-install only.</para>
+/// </summary>
+public interface IUpgradeSteps
+{
+    Task<PreflightResult> PreflightAsync(DetectedInstall detected, InstallationConfig config, CancellationToken ct);
+    Task<bool> StopServiceAsync(CancellationToken ct);
+    Task<BackupResult> BackupAsync(string pgDumpPath, string connectionString, CancellationToken ct);
+    ConfigSnapshotHandle CaptureConfig();
+    Task<bool> DeployAsync(CancellationToken ct);
+    Task<MigrationRunResult> MigrateAsync(CancellationToken ct);
+    Task<bool> StartServiceAsync(CancellationToken ct);
+    Task<bool> HealthAsync(CancellationToken ct);
+    string? ReadPosVersion();
+    Task<bool> InstallPosAppAsync(CancellationToken ct);
+    void RestoreStoreHubTree(string stampDirectory);
+    Task WriteManifestAsync(CancellationToken ct);
+}
+
+/// <summary>
+/// The in-place upgrade sequence (upgrade design spec, sections 4 and 5).
+/// <para>Steps 0-3 mutate nothing: a failure there is a non-event. Steps 4-7 roll back.
+/// Step 8 does not — the server is upgraded and serving, and the 2026-07-26 spike confirmed
+/// the POS step cannot disturb it.</para>
+/// </summary>
+public sealed class UpgradeOrchestrator(IUpgradeSteps steps, UpgradeStage? simulateFailure = null)
+{
+    public async Task<SilentOutcome> RunAsync(
+        DetectedInstall detected,
+        InstallationConfig config,
+        IProgress<InstallationProgress> progress,
+        CancellationToken cancellationToken = default)
+    {
+        // --- Step 1: preflight ------------------------------------------------
+        progress.Report(InstallationProgress.Step("Upgrading", "Checking this machine...", 5));
+
+        var preflight = await steps.PreflightAsync(detected, config, cancellationToken);
+        Fault(UpgradeStage.Preflight);
+
+        if (!preflight.Ok)
+        {
+            return preflight.IsDowngrade
+                ? new DowngradeRefused(detected.InstalledVersion ?? "unknown", config.InstallVersion)
+                : new UpgradeFailed(preflight.FailureReason ?? "Preflight failed.",
+                    RolledBack: false, ServiceStarted: true, HealthOk: true, BackupDir: null);
+        }
+
+        var posVersionBefore = steps.ReadPosVersion();
+
+        // --- Step 2: stop the service ----------------------------------------
+        // Above the mutation line: stopping is reversible, and dumping a live database
+        // would silently discard any sale completed before the restart.
+        progress.Report(InstallationProgress.Step("Upgrading", "Stopping StoreHub...", 10));
+        await steps.StopServiceAsync(cancellationToken);
+        Fault(UpgradeStage.Stop);
+
+        // --- Step 3: back up --------------------------------------------------
+        progress.Report(InstallationProgress.Step("Upgrading", "Backing up database and binaries...", 20));
+
+        var backup = await steps.BackupAsync(preflight.PgDumpPath!, preflight.ConnectionString!, cancellationToken);
+        Fault(UpgradeStage.Backup);
+
+        if (!backup.Success)
+        {
+            // Nothing has been mutated, but the service is stopped — put it back, and
+            // report what actually happened rather than assuming it came up.
+            var restarted = await steps.StartServiceAsync(cancellationToken);
+            return new UpgradeFailed(backup.ErrorMessage ?? "Backup failed.",
+                RolledBack: false, ServiceStarted: restarted,
+                HealthOk: restarted && await steps.HealthAsync(cancellationToken), BackupDir: null);
+        }
+
+        // ============ EVERYTHING BELOW THIS LINE MUTATES THE INSTALL ============
+
+        var snapshot = steps.CaptureConfig();
+
+        try
+        {
+            // --- Step 4: deploy -----------------------------------------------
+            progress.Report(InstallationProgress.Step("Upgrading", "Deploying StoreHub...", 40));
+            Fault(UpgradeStage.Deploy);
+
+            if (!await steps.DeployAsync(cancellationToken))
+            {
+                return await RollBackAsync("Failed to deploy the StoreHub payload.",
+                    backup.StampDirectory!, snapshot, cancellationToken);
+            }
+
+            // --- Step 5: restore the store's real config ----------------------
+            // The heart of the design. Extraction just wrote the package template over
+            // appsettings.json, and DatabaseSetup — which would have rewritten the real
+            // values on a fresh install — never runs here.
+            progress.Report(InstallationProgress.Step("Upgrading", "Restoring store configuration...", 55));
+            snapshot.Restore();
+            Fault(UpgradeStage.RestoreConfig);
+
+            // --- Step 6: migrate ----------------------------------------------
+            progress.Report(InstallationProgress.Step("Upgrading", "Applying database migrations...", 65));
+            Fault(UpgradeStage.Migrate);
+
+            var migration = await steps.MigrateAsync(cancellationToken);
+            if (!migration.Success)
+            {
+                return await RollBackAsync(migration.ErrorMessage ?? "Migration failed.",
+                    backup.StampDirectory!, snapshot, cancellationToken);
+            }
+
+            // --- Step 7: start + verify ---------------------------------------
+            progress.Report(InstallationProgress.Step("Upgrading", "Starting StoreHub...", 80));
+            Fault(UpgradeStage.Start);
+
+            var started = await steps.StartServiceAsync(cancellationToken);
+            var healthy = started && await steps.HealthAsync(cancellationToken);
+
+            if (!healthy)
+            {
+                return await RollBackAsync("StoreHub did not become healthy after the upgrade.",
+                    backup.StampDirectory!, snapshot, cancellationToken);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return await RollBackAsync(ex.Message, backup.StampDirectory!, snapshot, cancellationToken);
+        }
+
+        // ==================== SERVER UPGRADE COMPLETE ====================
+
+        // --- Step 8: the POS app. No rollback past this point. ----------------
+        progress.Report(InstallationProgress.Step("Upgrading", "Updating the POS application...", 90));
+        Fault(UpgradeStage.PosApp);
+
+        var posOk = await steps.InstallPosAppAsync(cancellationToken);
+        if (!posOk)
+        {
+            return new UpgradeFailed(
+                "The StoreHub service upgraded and is serving, but the POS application " +
+                "update failed. Re-run the installer to retry it; the store can keep trading.",
+                RolledBack: false, ServiceStarted: true, HealthOk: true, backup.StampDirectory);
+        }
+
+        // POS_UPDATED cannot come from the exit code: the spike measured 0 for both a real
+        // upgrade and a same-version repair. sq.version is the only truthful record.
+        var posUpdated = steps.ReadPosVersion() is { } after &&
+                         !string.Equals(after, posVersionBefore, StringComparison.Ordinal);
+
+        // --- Steps 9-10: manifest + markers. Non-fatal; the next run repairs a stale one.
+        try
+        {
+            await steps.WriteManifestAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            progress.Report(InstallationProgress.Error($"Warning: could not write install manifest: {ex.Message}"));
+        }
+
+        progress.Report(InstallationProgress.Step("Upgrade Complete", "IndyPOS has been upgraded.", 100));
+
+        return new UpgradeSucceeded(
+            detected.InstalledVersion, config.InstallVersion,
+            ServiceStarted: true, HealthOk: true,
+            backup.StampDirectory!, backup.Locked, posUpdated);
+    }
+
+    /// <summary>
+    /// Delete-then-copy the binaries back, put the config back, restart, and PROVE it came
+    /// back. Without the probe a rollback can report "the store resumed on its previous
+    /// version" while the store is dead.
+    /// </summary>
+    private async Task<UpgradeFailed> RollBackAsync(
+        string reason, string stampDirectory, ConfigSnapshotHandle snapshot, CancellationToken cancellationToken)
+    {
+        try
+        {
+            steps.RestoreStoreHubTree(stampDirectory);
+        }
+        catch (Exception ex)
+        {
+            return new UpgradeFailed(
+                $"{reason} The rollback then failed as well ({ex.Message}). This store needs " +
+                $"manual recovery; the database dump is at {stampDirectory}.",
+                RolledBack: false, ServiceStarted: false, HealthOk: false, stampDirectory);
+        }
+
+        snapshot.Restore();
+
+        var started = await steps.StartServiceAsync(cancellationToken);
+        var healthy = started && await steps.HealthAsync(cancellationToken);
+
+        var message = healthy
+            ? $"{reason} The upgrade was rolled back and the store is serving its previous version."
+            : $"{reason} The upgrade was rolled back but StoreHub is not healthy. Restore the " +
+              $"database dump at {stampDirectory} — see docs\\operations\\upgrade-procedure.md.";
+
+        return new UpgradeFailed(message, RolledBack: true, started, healthy, stampDirectory);
+    }
+
+    private void Fault(UpgradeStage stage)
+    {
+        if (simulateFailure == stage)
+        {
+            throw new InvalidOperationException($"Simulated failure at stage '{stage}' (test hook).");
+        }
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Upgrade/UpgradeOrchestrator.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/UpgradeOrchestrator.cs
@@ -65,7 +65,19 @@ public sealed class UpgradeOrchestrator(IUpgradeSteps steps, UpgradeStage? simul
         // Above the mutation line: stopping is reversible, and dumping a live database
         // would silently discard any sale completed before the restart.
         progress.Report(InstallationProgress.Step("Upgrading", "Stopping StoreHub...", 10));
-        await steps.StopServiceAsync(cancellationToken);
+
+        // Terminal, not advisory: deploying while StoreHub still holds its own DLLs is
+        // exactly how the original upgrade attempt died. The store is untouched and still
+        // serving here, so refusing costs nothing.
+        if (!await steps.StopServiceAsync(cancellationToken))
+        {
+            return new UpgradeFailed(
+                "StoreHub could not be stopped, so its binaries are still locked and cannot " +
+                "be replaced. Stop the service manually and re-run.",
+                RolledBack: false, ServiceStarted: true,
+                HealthOk: await steps.HealthAsync(cancellationToken), BackupDir: null);
+        }
+
         Fault(UpgradeStage.Stop);
 
         // --- Step 3: back up --------------------------------------------------

--- a/installer/IndyPOS.Bootstrapper/Upgrade/UpgradeOrchestrator.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/UpgradeOrchestrator.cs
@@ -55,8 +55,11 @@ public sealed class UpgradeOrchestrator(IUpgradeSteps steps, UpgradeStage? simul
         {
             return preflight.IsDowngrade
                 ? new DowngradeRefused(detected.InstalledVersion ?? "unknown", config.InstallVersion)
+                // Nothing was touched, but "still serving" is a claim, so prove it rather
+                // than assume it - the same reason the rollback probes.
                 : new UpgradeFailed(preflight.FailureReason ?? "Preflight failed.",
-                    RolledBack: false, ServiceStarted: true, HealthOk: true, BackupDir: null);
+                    RolledBack: false, ServiceStarted: true,
+                    HealthOk: await steps.HealthAsync(cancellationToken), BackupDir: null);
         }
 
         var posVersionBefore = steps.ReadPosVersion();
@@ -78,22 +81,33 @@ public sealed class UpgradeOrchestrator(IUpgradeSteps steps, UpgradeStage? simul
                 HealthOk: await steps.HealthAsync(cancellationToken), BackupDir: null);
         }
 
-        Fault(UpgradeStage.Stop);
-
         // --- Step 3: back up --------------------------------------------------
         progress.Report(InstallationProgress.Step("Upgrading", "Backing up database and binaries...", 20));
 
-        var backup = await steps.BackupAsync(preflight.PgDumpPath!, preflight.ConnectionString!, cancellationToken);
-        Fault(UpgradeStage.Backup);
+        BackupResult backup;
+        try
+        {
+            // Inside the try so the test hook cannot leave a VM store down either.
+            Fault(UpgradeStage.Stop);
+
+            backup = await steps.BackupAsync(preflight.PgDumpPath!, preflight.ConnectionString!, cancellationToken);
+            Fault(UpgradeStage.Backup);
+        }
+        catch (Exception ex)
+        {
+            // The service is already stopped, so an exception here - a fired watchdog on a
+            // large database, say - would otherwise leave the till DOWN with nothing mutated.
+            // "Above the mutation line" has to mean the store is still trading.
+            var reason = ex is OperationCanceledException
+                ? "The upgrade timed out while backing up."
+                : $"Backing up failed: {ex.Message}";
+
+            return await ResumeWithoutChangesAsync(reason);
+        }
 
         if (!backup.Success)
         {
-            // Nothing has been mutated, but the service is stopped — put it back, and
-            // report what actually happened rather than assuming it came up.
-            var restarted = await steps.StartServiceAsync(cancellationToken);
-            return new UpgradeFailed(backup.ErrorMessage ?? "Backup failed.",
-                RolledBack: false, ServiceStarted: restarted,
-                HealthOk: restarted && await steps.HealthAsync(cancellationToken), BackupDir: null);
+            return await ResumeWithoutChangesAsync(backup.ErrorMessage ?? "Backup failed.");
         }
 
         // ============ EVERYTHING BELOW THIS LINE MUTATES THE INSTALL ============
@@ -144,9 +158,18 @@ public sealed class UpgradeOrchestrator(IUpgradeSteps steps, UpgradeStage? simul
                     backup.StampDirectory!, snapshot, cancellationToken);
             }
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex)
         {
-            return await RollBackAsync(ex.Message, backup.StampDirectory!, snapshot, cancellationToken);
+            // Cancellation is NOT excluded here. The watchdog can fire below the mutation
+            // line on a slow store PC, and letting it escape leaves new binaries, a stopped
+            // service and no rollback - the worst state this design exists to prevent.
+            var reason = ex is OperationCanceledException
+                ? "The upgrade timed out."
+                : ex.Message;
+
+            // CancellationToken.None deliberately: recovery must not be cancellable by the
+            // token that just fired, or every await in the rollback aborts immediately.
+            return await RollBackAsync(reason, backup.StampDirectory!, snapshot, CancellationToken.None);
         }
 
         // ==================== SERVER UPGRADE COMPLETE ====================
@@ -185,6 +208,19 @@ public sealed class UpgradeOrchestrator(IUpgradeSteps steps, UpgradeStage? simul
             detected.InstalledVersion, config.InstallVersion,
             ServiceStarted: true, HealthOk: true,
             backup.StampDirectory!, backup.Locked, posUpdated);
+    }
+
+    /// <summary>
+    /// Nothing was mutated, but the service was stopped - restart it and report what actually
+    /// happened rather than assuming it came up. Non-cancellable: this runs on paths a fired
+    /// watchdog reaches, and the store must not be left down.
+    /// </summary>
+    private async Task<UpgradeFailed> ResumeWithoutChangesAsync(string reason)
+    {
+        var restarted = await steps.StartServiceAsync(CancellationToken.None);
+
+        return new UpgradeFailed(reason, RolledBack: false, ServiceStarted: restarted,
+            HealthOk: restarted && await steps.HealthAsync(CancellationToken.None), BackupDir: null);
     }
 
     /// <summary>

--- a/installer/IndyPOS.Bootstrapper/Upgrade/UpgradePreflight.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/UpgradePreflight.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+public sealed record PreflightResult(
+    bool Ok,
+    string? PgDumpPath,
+    string? ConnectionString,
+    string? FailureReason,
+    bool IsDowngrade);
+
+/// <summary>
+/// Step 1 of the upgrade sequence. Everything here runs ABOVE the mutation line: a
+/// failure leaves the store untouched and still serving its current version.
+/// </summary>
+public static class UpgradePreflight
+{
+    /// <summary>Enough headroom for the dump plus a full copy of the StoreHub tree.</summary>
+    public const long RequiredFreeBytes = 2L * 1024 * 1024 * 1024;
+
+    private const string PosProcessName = "IndyPOS.Windows.Forms";
+
+    /// <summary>
+    /// Refuse a downgrade; allow a same-version repair. Rollback restores binaries and
+    /// config but not schema, so running older binaries against a newer schema is exactly
+    /// the state the forward-only migration rule cannot protect.
+    /// </summary>
+    public static (bool Ok, string? Reason, bool IsDowngrade) CheckVersions(
+        string? installedVersion, string installerVersion)
+    {
+        if (!Version.TryParse(installedVersion, out var installed) ||
+            !Version.TryParse(installerVersion, out var installing))
+        {
+            return (true, null, false);
+        }
+
+        return installing < installed
+            ? (false,
+               $"This installer is version {installerVersion} but the machine already runs " +
+               $"{installedVersion}. Downgrading is refused: it would leave older binaries " +
+               "against a newer database schema.",
+               true)
+            : (true, null, false);
+    }
+
+    /// <summary>
+    /// Two Velopack processes on one install root can leave the POS unlaunchable, and the
+    /// POS app self-updates independently, so it may be mid-update already.
+    /// </summary>
+    public static bool IsPosAppRunning() =>
+        Process.GetProcessesByName(PosProcessName).Length > 0;
+
+    /// <summary>
+    /// The manifest's PostgresBinPath can be stale, so fall back to probing — but assert
+    /// the major matches, because the fallback happily returns 17 or 16.
+    /// </summary>
+    /// <param name="findInstalledBinPath">
+    /// Seam for the machine-wide probe, so a test can express "no other PostgreSQL here".
+    /// Without it these tests pass or fail according to whether the box running them
+    /// happens to have PostgreSQL 18 — both this dev box and the test VM do.
+    /// Defaults to <see cref="PostgresInstaller.FindPostgresBinPath"/>.
+    /// </param>
+    public static string? LocatePgDump(
+        string manifestBinPath,
+        int expectedMajor,
+        Func<string?>? findInstalledBinPath = null)
+    {
+        var candidate = Probe(manifestBinPath, expectedMajor);
+        if (candidate is not null)
+        {
+            return candidate;
+        }
+
+        var discovered = (findInstalledBinPath ?? PostgresInstaller.FindPostgresBinPath)();
+        return discovered is null ? null : Probe(discovered, expectedMajor);
+    }
+
+    private static string? Probe(string binPath, int expectedMajor)
+    {
+        if (string.IsNullOrWhiteSpace(binPath))
+        {
+            return null;
+        }
+
+        var exe = Path.Combine(binPath, "pg_dump.exe");
+        if (!File.Exists(exe))
+        {
+            return null;
+        }
+
+        // Layout is ...\PostgreSQL\<major>\bin, so the grandparent names the major.
+        var majorDir = Path.GetFileName(Path.GetDirectoryName(binPath.TrimEnd(Path.DirectorySeparatorChar)));
+
+        return int.TryParse(majorDir, out var major) && major == expectedMajor ? exe : null;
+    }
+
+    public static bool HasFreeSpace(string path)
+    {
+        try
+        {
+            return new DriveInfo(Path.GetPathRoot(Path.GetFullPath(path))!).AvailableFreeSpace
+                   >= RequiredFreeBytes;
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException)
+        {
+            // Unknowable is not the same as insufficient; let the dump's own integrity
+            // check be the backstop rather than blocking a legitimate upgrade.
+            return true;
+        }
+    }
+}

--- a/installer/IndyPOS.Bootstrapper/Upgrade/WindowsUpgradeSteps.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/WindowsUpgradeSteps.cs
@@ -55,12 +55,30 @@ public sealed class WindowsUpgradeSteps(InstallationConfig config, IProgress<str
                 "The StoreHub connection string could not be decrypted on this machine.", false);
         }
 
-        // Idempotent check-then-install. Omitting these delivers a UI-polish release that
-        // renders in a fallback face, or binaries the machine cannot run.
+        // Idempotent check-then-install, and the results are checked: the whole point of
+        // running these above the mutation line is that a missing runtime fails here, for
+        // free, instead of surfacing as a service that will not start after the swap.
         log.Report("Ensuring prerequisites (fonts, .NET 10, VC++ redistributable)...");
+
+        // The font is the one genuinely optional prerequisite - a missing FC Subject renders
+        // in a fallback face, which is a cosmetic regression, not a dead store.
         new FontInstaller().Install(log);
-        await new DotNetInstaller().EnsureInstalledAsync(log, ct, cfg.Interactive);
-        await new VCRedistInstaller().EnsureInstalledAsync(null, ct);
+
+        var dotNet = await new DotNetInstaller().EnsureInstalledAsync(log, ct, cfg.Interactive);
+        if (!dotNet.Success)
+        {
+            return new PreflightResult(false, null, null,
+                $"The .NET 10 Desktop Runtime is required but could not be installed: " +
+                $"{dotNet.ErrorMessage}", false);
+        }
+
+        var vcRedist = await new VCRedistInstaller().EnsureInstalledAsync(null, ct);
+        if (!vcRedist.Success)
+        {
+            return new PreflightResult(false, null, null,
+                $"The Visual C++ redistributable is required but could not be installed: " +
+                $"{vcRedist.ErrorMessage}", false);
+        }
 
         return new PreflightResult(true, pgDump, connectionString, null, false);
     }

--- a/installer/IndyPOS.Bootstrapper/Upgrade/WindowsUpgradeSteps.cs
+++ b/installer/IndyPOS.Bootstrapper/Upgrade/WindowsUpgradeSteps.cs
@@ -1,0 +1,100 @@
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Upgrade;
+
+/// <summary>Binds <see cref="IUpgradeSteps"/> to the real machine.</summary>
+public sealed class WindowsUpgradeSteps(InstallationConfig config, IProgress<string> log) : IUpgradeSteps
+{
+    private const int PostgresMajor = 18;
+
+    private static readonly TimeSpan ServiceTimeout = TimeSpan.FromSeconds(60);
+
+    private readonly ServiceControl _service = new(config.ServiceName);
+
+    private readonly UpgradeBackup _backup = new(
+        config.BackupsDirectory,
+        config.StoreHubInstallPath,
+        new ExternalProcessRunner(),
+        () => DateTime.Now.ToString("yyyyMMdd-HHmmss"));
+
+    private string ConfigPath => Path.Combine(config.StoreHubInstallPath, "appsettings.json");
+
+    public async Task<PreflightResult> PreflightAsync(
+        DetectedInstall detected, InstallationConfig cfg, CancellationToken ct)
+    {
+        var (ok, reason, isDowngrade) = UpgradePreflight.CheckVersions(
+            detected.InstalledVersion, cfg.InstallVersion);
+        if (!ok)
+        {
+            return new PreflightResult(false, null, null, reason, isDowngrade);
+        }
+
+        if (UpgradePreflight.IsPosAppRunning())
+        {
+            return new PreflightResult(false, null, null,
+                "The IndyPOS POS application is running. Close it on this machine and re-run.", false);
+        }
+
+        if (!UpgradePreflight.HasFreeSpace(cfg.BackupsDirectory))
+        {
+            return new PreflightResult(false, null, null,
+                "Not enough free disk space to back up the database and binaries.", false);
+        }
+
+        var pgDump = UpgradePreflight.LocatePgDump(cfg.PostgresBinPath, PostgresMajor);
+        if (pgDump is null)
+        {
+            return new PreflightResult(false, null, null,
+                $"pg_dump.exe for PostgreSQL {PostgresMajor} could not be located.", false);
+        }
+
+        var connectionString = StoreHubConfigReader.ReadConnectionString(ConfigPath);
+        if (connectionString is null)
+        {
+            return new PreflightResult(false, null, null,
+                "The StoreHub connection string could not be decrypted on this machine.", false);
+        }
+
+        // Idempotent check-then-install. Omitting these delivers a UI-polish release that
+        // renders in a fallback face, or binaries the machine cannot run.
+        log.Report("Ensuring prerequisites (fonts, .NET 10, VC++ redistributable)...");
+        new FontInstaller().Install(log);
+        await new DotNetInstaller().EnsureInstalledAsync(log, ct, cfg.Interactive);
+        await new VCRedistInstaller().EnsureInstalledAsync(null, ct);
+
+        return new PreflightResult(true, pgDump, connectionString, null, false);
+    }
+
+    public async Task<bool> StopServiceAsync(CancellationToken ct) =>
+        (await _service.StopAsync(ServiceTimeout, ct)).Success;
+
+    public Task<BackupResult> BackupAsync(string pgDumpPath, string connectionString, CancellationToken ct) =>
+        _backup.CreateAsync(pgDumpPath, connectionString, ct);
+
+    public ConfigSnapshotHandle CaptureConfig()
+    {
+        var snapshot = ConfigSnapshot.Capture(ConfigPath);
+        return new ConfigSnapshotHandle(snapshot.Restore);
+    }
+
+    public Task<bool> DeployAsync(CancellationToken ct) =>
+        StoreHubPayload.ExtractAsync(config.StoreHubInstallPath, log, ct);
+
+    public Task<MigrationRunResult> MigrateAsync(CancellationToken ct) =>
+        MigrationRunner.RunAsync(config.StoreHubInstallPath, log, ct);
+
+    public async Task<bool> StartServiceAsync(CancellationToken ct) =>
+        (await _service.StartAsync(ServiceTimeout, ct)).Success;
+
+    public Task<bool> HealthAsync(CancellationToken ct) =>
+        HealthProbe.IsReadyAsync(config.HealthCheckPort, cancellationToken: ct);
+
+    public string? ReadPosVersion() => PosAppVersion.Read(config.VelopackInstallPath);
+
+    public async Task<bool> InstallPosAppAsync(CancellationToken ct) =>
+        (await new VelopackLauncher().InstallAsync(config, null, ct)).Success;
+
+    public void RestoreStoreHubTree(string stampDirectory) => _backup.RestoreStoreHubTree(stampDirectory);
+
+    public Task WriteManifestAsync(CancellationToken ct) => InstallManifestWriter.WriteAsync(config, ct);
+}

--- a/scripts/vm-testing/Reset-AndInstall.ps1
+++ b/scripts/vm-testing/Reset-AndInstall.ps1
@@ -16,13 +16,32 @@
         6. Run Test-IndyPOSInstallation.ps1 in the guest
         7. Pretty-print the report; exit non-zero if any check failed
 
-    Prereqs (run once — see scripts/vm-testing/README.md):
+    Prereqs (run once - see scripts/vm-testing/README.md):
         - VM 'IndyPOS-Test' exists with Windows 11 + PSRemoting enabled
         - Checkpoint 'Clean-Windows' captured
         - VM admin credential cached (first run prompts you)
 
 .PARAMETER InstallerPath
     Path to IndyPOS-Setup.exe. Default: <repo>\publish\IndyPOS-Setup.exe.
+
+.PARAMETER SnapshotName
+    Snapshot to restore. Default: the clean baseline from VMTestConfig.psd1. Upgrade
+    cases need a real store image instead (e.g. 'Pre-Upgrade-2026-07-25').
+
+.PARAMETER InstallerArgs
+    Full argument list for the in-guest installer. Default:
+    --silent --store-id <TestStoreId>. An upgrade passes just --silent, because the
+    store id is adopted from the installed config.
+
+.PARAMETER ExpectRollback
+    Invert the gate: require RESULT=failed with ROLLED_BACK=true, SERVICE_STARTED=true
+    and HEALTH=ok. Use with --simulate-failure to prove a mid-upgrade failure leaves the
+    store serving its previous version. Skips the install verifier, which audits a
+    completed install.
+
+.PARAMETER AssertDatabase
+    Also run the verifier's payment_method / store-id assertions against the live
+    database. Only meaningful on an upgrade of a real store image.
 
 .PARAMETER SkipRestore
     Don't restore the snapshot or start the VM. Use when iterating on a VM
@@ -44,11 +63,25 @@
 .EXAMPLE
     # Iterate without restoring (faster but assumes you already cleaned up):
     .\Reset-AndInstall.ps1 -SkipRestore
+
+.EXAMPLE
+    # Upgrade case 1: in-place upgrade of a real store image, with DB assertions.
+    .\Reset-AndInstall.ps1 -SnapshotName 'Pre-Upgrade-2026-07-25' `
+                           -InstallerArgs '--silent' -AssertDatabase
+
+.EXAMPLE
+    # Upgrade case 2: force a mid-upgrade failure and require a verified rollback.
+    .\Reset-AndInstall.ps1 -SnapshotName 'Pre-Upgrade-2026-07-25' `
+                           -InstallerArgs '--silent','--simulate-failure=deploy' -ExpectRollback
 #>
 
 [CmdletBinding()]
 param(
     [string]$InstallerPath,
+    [string]$SnapshotName,
+    [switch]$ExpectRollback,
+    [string[]]$InstallerArgs,
+    [switch]$AssertDatabase,
     [switch]$SkipRestore,
     [switch]$KeepRunning,
     [switch]$RecreateCredential
@@ -65,6 +98,9 @@ $Config     = Import-PowerShellDataFile (Join-Path $ScriptRoot 'VMTestConfig.psd
 if (-not $InstallerPath) {
     $InstallerPath = Join-Path $RepoRoot 'publish\IndyPOS-Setup.exe'
 }
+
+# Upgrade cases 1/2 run from a real store image; the fresh case from the clean baseline.
+if (-not $SnapshotName) { $SnapshotName = $Config.CleanSnapshotName }
 $VerifierPath = Join-Path $ScriptRoot 'Test-IndyPOSInstallation.ps1'
 
 function Write-Section($title) {
@@ -129,15 +165,15 @@ function Test-Prerequisites {
     }
     Write-OK "VM:        $($Config.VMName) (State: $($vm.State))"
 
-    $snap = Get-VMSnapshot -VMName $Config.VMName -Name $Config.CleanSnapshotName -ErrorAction SilentlyContinue
+    $snap = Get-VMSnapshot -VMName $Config.VMName -Name $SnapshotName -ErrorAction SilentlyContinue
     if (-not $snap) {
         if ($SkipRestore) {
-            Write-Warn2 "Snapshot '$($Config.CleanSnapshotName)' missing — proceeding because -SkipRestore is set."
+            Write-Warn2 "Snapshot '$($SnapshotName)' missing - proceeding because -SkipRestore is set."
         } else {
-            throw "Snapshot '$($Config.CleanSnapshotName)' not found. Capture one after a clean Windows install (see README)."
+            throw "Snapshot '$($SnapshotName)' not found. Capture one after a clean Windows install (see README)."
         }
     } else {
-        Write-OK "Snapshot:  $($Config.CleanSnapshotName)"
+        Write-OK "Snapshot:  $($SnapshotName)"
     }
 }
 
@@ -149,14 +185,14 @@ function Restore-CleanVM {
     if ($SkipRestore) {
         Write-Info '-SkipRestore set; skipping snapshot restore.'
     } else {
-        Write-Info "Restoring snapshot '$($Config.CleanSnapshotName)'..."
-        Restore-VMSnapshot -VMName $Config.VMName -Name $Config.CleanSnapshotName -Confirm:$false
+        Write-Info "Restoring snapshot '$($SnapshotName)'..."
+        Restore-VMSnapshot -VMName $Config.VMName -Name $SnapshotName -Confirm:$false
         Write-OK 'Snapshot restored.'
     }
 
     # Guest Service Interface is the one integration service Hyper-V disables by
     # default, and Copy-VMFile (step 4) rides on it. Snapshots don't reliably
-    # carry the host-side toggle, so assert it here — idempotent, host-side only.
+    # carry the host-side toggle, so assert it here - idempotent, host-side only.
     if (-not (Get-VMIntegrationService -VMName $Config.VMName -Name 'Guest Service Interface').Enabled) {
         Write-Info "Enabling 'Guest Service Interface' integration service..."
         Enable-VMIntegrationService -VMName $Config.VMName -Name 'Guest Service Interface'
@@ -178,7 +214,7 @@ function Restore-CleanVM {
         Start-Sleep -Seconds 2
     }
     if ($vm.Heartbeat -notin 'OkApplicationsHealthy','OkApplicationsUnknown') {
-        Write-Warn2 "Heartbeat not 'Ok' yet ($($vm.Heartbeat)). Continuing — PSDirect probe is authoritative."
+        Write-Warn2 "Heartbeat not 'Ok' yet ($($vm.Heartbeat)). Continuing - PSDirect probe is authoritative."
     } else {
         Write-OK "Heartbeat: $($vm.Heartbeat)"
     }
@@ -229,18 +265,18 @@ function Invoke-SilentInstall {
     Write-Section '5. Run installer (silent)'
 
     $guestInstaller = Join-Path $Config.GuestStagingDir $Config.GuestInstallerName
-    $storeId        = $Config.TestStoreId
     $logDir         = "C:\ProgramData\IndyPOS\v4\logs"
     $latestLog      = Join-Path $logDir 'install-latest.log'
 
-    Write-Info "Running (in guest): $guestInstaller --silent --store-id $storeId"
+    $arguments = if ($InstallerArgs) { $InstallerArgs } else { @('--silent', '--store-id', $Config.TestStoreId) }
+    Write-Info "Running (in guest): $guestInstaller $($arguments -join ' ')"
 
     $timeoutSec = $Config.InstallTimeoutMinutes * 60
     $job = Invoke-Command -VMName $Config.VMName -Credential $Credential -AsJob -ScriptBlock {
-        param($exe, $id)
-        $p = Start-Process -FilePath $exe -ArgumentList '--silent', '--store-id', $id -Wait -PassThru
+        param($exe, $argList)
+        $p = Start-Process -FilePath $exe -ArgumentList $argList -Wait -PassThru
         [pscustomobject]@{ ExitCode = $p.ExitCode }
-    } -ArgumentList $guestInstaller, $storeId
+    } -ArgumentList $guestInstaller, $arguments
 
     if (-not (Wait-Job -Job $job -Timeout $timeoutSec)) {
         Stop-Job -Job $job
@@ -253,10 +289,14 @@ function Invoke-SilentInstall {
 
     Write-Info "Installer exit code: $($run.ExitCode)"
 
+    # Newest install-<stamp>-<pid>.log, NOT install-latest.log: on a re-run the latter can
+    # still carry the previous run's RESULT=success.
     $markers = Invoke-Command -VMName $Config.VMName -Credential $Credential -ScriptBlock {
-        param($p)
-        if (Test-Path $p) { Get-Content $p | Where-Object { $_ -like 'INDYPOS_MARKER *' } } else { @() }
-    } -ArgumentList $latestLog
+        param($dir)
+        $log = Get-ChildItem -Path $dir -Filter 'install-2*.log' -ErrorAction SilentlyContinue |
+               Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if ($log) { Get-Content $log.FullName | Where-Object { $_ -like 'INDYPOS_MARKER *' } } else { @() }
+    } -ArgumentList $logDir
 
     # Parse the LAST occurrence of each marker key (D9).
     $marker = @{}
@@ -264,6 +304,22 @@ function Invoke-SilentInstall {
         if ($line -match '^INDYPOS_MARKER\s+([A-Z_]+)=(.*)$') { $marker[$Matches[1]] = $Matches[2] }
     }
     foreach ($k in $marker.Keys) { Write-Info "marker $k=$($marker[$k])" }
+
+    if ($ExpectRollback) {
+        # A deliberate mid-upgrade failure. Success here means the store came BACK, which
+        # is the only claim the rollback design actually makes.
+        $ok = ($marker['RESULT'] -eq 'failed') -and
+              ($marker['ROLLED_BACK'] -eq 'true') -and
+              ($marker['SERVICE_STARTED'] -eq 'true') -and
+              ($marker['HEALTH'] -eq 'ok')
+        if (-not $ok) {
+            throw ("Expected a verified rollback but got RESULT=$($marker['RESULT']), " +
+                   "ROLLED_BACK=$($marker['ROLLED_BACK']), SERVICE_STARTED=$($marker['SERVICE_STARTED']), " +
+                   "HEALTH=$($marker['HEALTH']). See $latestLog in the guest.")
+        }
+        Write-OK 'Rollback verified: store is serving its previous version.'
+        return
+    }
 
     # Authoritative gating rule: exit code + RESULT + service.
     $failed = ($run.ExitCode -ne 0) -or ($marker['RESULT'] -ne 'success') -or ($marker['SERVICE_STARTED'] -eq 'false')
@@ -273,7 +329,7 @@ function Invoke-SilentInstall {
     if ($marker['CRED_LOCKED'] -eq 'false') {
         Write-Warn2 "Credential file could not be ACL-locked (CRED_LOCKED=false)."
     }
-    Write-OK "Silent install completed (RESULT=success)."
+    Write-OK "Silent install completed (RESULT=$($marker['RESULT']), MODE=$($marker['MODE']))."
 }
 
 # --- Verification + report --------------------------------------------------
@@ -284,8 +340,10 @@ function Invoke-Verifier {
     Write-Section '6. In-VM verification'
 
     Write-Info 'Running Test-IndyPOSInstallation.ps1 inside guest...'
+
+    # -FilePath binds positionally, so the verifier declares -AssertDatabase at Position 0.
     $result = Invoke-Command -VMName $Config.VMName -Credential $Credential `
-                             -FilePath $VerifierPath
+                             -FilePath $VerifierPath -ArgumentList $AssertDatabase.IsPresent
     return $result
 }
 
@@ -324,7 +382,7 @@ function Format-Report {
 
 $start = Get-Date
 Write-Host ''
-Write-Host '=== IndyPOS Stage 4 — VM smoke-test ===' -ForegroundColor Magenta
+Write-Host '=== IndyPOS Stage 4 - VM smoke-test ===' -ForegroundColor Magenta
 
 try {
     Test-Prerequisites
@@ -333,6 +391,13 @@ try {
     Wait-PowerShellDirect -Credential $cred
     Copy-Installer -Credential $cred
     Invoke-SilentInstall -Credential $cred
+
+    if ($ExpectRollback) {
+        # The verifier audits a COMPLETED install; a rolled-back store is not one.
+        Write-OK 'Expect-rollback run complete; skipping the install verifier.'
+        exit 0
+    }
+
     $result = Invoke-Verifier -Credential $cred
     Format-Report -Result $result
 

--- a/scripts/vm-testing/Reset-AndInstall.ps1
+++ b/scripts/vm-testing/Reset-AndInstall.ps1
@@ -269,7 +269,28 @@ function Invoke-SilentInstall {
     $latestLog      = Join-Path $logDir 'install-latest.log'
 
     $arguments = if ($InstallerArgs) { $InstallerArgs } else { @('--silent', '--store-id', $Config.TestStoreId) }
+
+    # A single element holding "--silent,--simulate-failure=deploy" reaches the installer as
+    # ONE unrecognised argument, which silently falls through to the interactive wizard and
+    # crashes headless. Caught once for real on 2026-07-29; never diagnose that twice.
+    foreach ($a in $arguments) {
+        if ($a -match '[,\s]') {
+            throw ("-InstallerArgs element '$a' contains a comma or whitespace, so it would " +
+                   "reach the installer as one malformed argument. Pass each flag as its own " +
+                   "element: -InstallerArgs '--silent','--simulate-failure=deploy'")
+        }
+    }
+
     Write-Info "Running (in guest): $guestInstaller $($arguments -join ' ')"
+
+    # Log names carry a timestamp and pid, so anything not in this set was written by THIS
+    # run. Required because a crash before the first log write leaves the snapshot's own
+    # 2026-07-19 install log as the newest one - which reads as RESULT=success.
+    $preExistingLogs = @(Invoke-Command -VMName $Config.VMName -Credential $Credential -ScriptBlock {
+        param($dir)
+        Get-ChildItem -Path $dir -Filter 'install-2*.log' -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty Name
+    } -ArgumentList $logDir)
 
     $timeoutSec = $Config.InstallTimeoutMinutes * 60
     $job = Invoke-Command -VMName $Config.VMName -Credential $Credential -AsJob -ScriptBlock {
@@ -289,14 +310,28 @@ function Invoke-SilentInstall {
 
     Write-Info "Installer exit code: $($run.ExitCode)"
 
-    # Newest install-<stamp>-<pid>.log, NOT install-latest.log: on a re-run the latter can
-    # still carry the previous run's RESULT=success.
-    $markers = Invoke-Command -VMName $Config.VMName -Credential $Credential -ScriptBlock {
-        param($dir)
+    # THIS run's log only - never install-latest.log (can hold a previous RESULT=success) and
+    # never merely the newest (a snapshot ships with its own install log).
+    $fresh = Invoke-Command -VMName $Config.VMName -Credential $Credential -ScriptBlock {
+        param($dir, $before)
         $log = Get-ChildItem -Path $dir -Filter 'install-2*.log' -ErrorAction SilentlyContinue |
+               Where-Object { $_.Name -notin $before } |
                Sort-Object LastWriteTime -Descending | Select-Object -First 1
-        if ($log) { Get-Content $log.FullName | Where-Object { $_ -like 'INDYPOS_MARKER *' } } else { @() }
-    } -ArgumentList $logDir
+        if (-not $log) { return $null }
+        [pscustomobject]@{
+            Name    = $log.Name
+            Markers = @(Get-Content $log.FullName | Where-Object { $_ -like 'INDYPOS_MARKER *' })
+        }
+    } -ArgumentList $logDir, $preExistingLogs
+
+    if (-not $fresh) {
+        throw ("The installer wrote no log for this run (exit=$($run.ExitCode)), so it died " +
+               "before logging anything - a malformed argument list falling through to the " +
+               "wizard does exactly this. Refusing to grade the run against a stale log.")
+    }
+
+    Write-Info "Log: $($fresh.Name)"
+    $markers = $fresh.Markers
 
     # Parse the LAST occurrence of each marker key (D9).
     $marker = @{}

--- a/scripts/vm-testing/Test-IndyPOSInstallation.ps1
+++ b/scripts/vm-testing/Test-IndyPOSInstallation.ps1
@@ -7,11 +7,16 @@
     -VMName) once the bootstrapper wizard has finished. Returns a structured
     PSCustomObject the host orchestrator (Reset-AndInstall.ps1) summarises.
 
-    Subset of scripts/verify-install.ps1 — drops the v3.7.0 side-by-side
+    Subset of scripts/verify-install.ps1 - drops the v3.7.0 side-by-side
     invariants (a fresh test VM has no v3 footprint to protect) and the deep
     DB auth checks (smoke-test.ps1 covers API behaviour separately).
 
     No elevation required; checks are read-only.
+
+.PARAMETER AssertDatabase
+    Also assert the live payment_method catalogue and that exactly one store id owns
+    it. Decrypts the DPAPI-sealed connection string in-guest and drives psql. Only
+    meaningful after an upgrade of a real store image.
 
 .PARAMETER ManifestPath
     Override the discovered install-manifest.json. Mirrors verify-install.ps1
@@ -30,6 +35,11 @@
 
 [CmdletBinding()]
 param(
+    # Position 0 so the host orchestrator can pass it through Invoke-Command -FilePath,
+    # which binds arguments positionally only.
+    [Parameter(Position = 0)]
+    [switch]$AssertDatabase,
+
     [string]$ManifestPath
 )
 
@@ -224,6 +234,88 @@ function Test-HealthEndpoint {
     }
 }
 
+# --- Database assertions (upgrade runs only) --------------------------------
+
+# Decrypt the DPAPI-sealed connection string in-guest. Machine scope, entropy =
+# SHA256("IndyPOS:ConnectionStrings:storehub-db"). The guest runs PowerShell 5.1, which
+# has no static SHA256.HashData, so use an instance.
+function Get-StoreHubConnectionString {
+    param([string]$AppSettingsPath)
+
+    $raw = (Get-Content $AppSettingsPath -Raw | ConvertFrom-Json).connectionStrings.'storehub-db'
+    if (-not $raw.StartsWith('DPAPI:')) { return $raw }
+
+    Add-Type -AssemblyName System.Security
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    $entropy = $sha.ComputeHash([Text.Encoding]::UTF8.GetBytes('IndyPOS:ConnectionStrings:storehub-db'))
+    $cipher = [Convert]::FromBase64String($raw.Substring(6))
+    $plain = [System.Security.Cryptography.ProtectedData]::Unprotect(
+        $cipher, $entropy, [System.Security.Cryptography.DataProtectionScope]::LocalMachine)
+
+    return [Text.Encoding]::UTF8.GetString($plain)
+}
+
+function Invoke-StoreHubQuery {
+    param([string]$ConnectionString, [string]$Sql, [string]$PsqlPath)
+
+    $parts = @{}
+    foreach ($kv in $ConnectionString.Split(';')) {
+        if ($kv -match '^\s*([^=]+)=(.*)$') { $parts[$Matches[1].Trim()] = $Matches[2].Trim() }
+    }
+
+    $env:PGPASSWORD = $parts['Password']
+    try {
+        # SQL via stdin: native-argument quoting strips the double quotes psql needs.
+        return $Sql | & $PsqlPath -h $parts['Host'] -p $parts['Port'] -U $parts['Username'] `
+                                  -d $parts['Database'] -w -t -A -F '|'
+    }
+    finally { Remove-Item Env:PGPASSWORD -ErrorAction SilentlyContinue }
+}
+
+function Test-Database {
+    $appSettings = Join-Path $ProgramDataRoot 'v4\StoreHub\appsettings.json'
+    $psql = 'C:\Program Files\PostgreSQL\18\bin\psql.exe'
+
+    if (-not (Test-Path $appSettings)) {
+        Add-Check 'Database' 'StoreHub appsettings.json present' $false -Detail $appSettings
+        return
+    }
+    if (-not (Test-Path $psql)) {
+        Add-Check 'Database' 'psql.exe available' $false -Detail $psql
+        return
+    }
+
+    try {
+        $conn = Get-StoreHubConnectionString -AppSettingsPath $appSettings
+    } catch {
+        Add-Check 'Database' 'Connection string decrypts on this machine' $false `
+            -Detail $_.Exception.Message
+        return
+    }
+
+    $rows = Invoke-StoreHubQuery -ConnectionString $conn -PsqlPath $psql `
+        -Sql 'SELECT code, kind, is_enabled FROM payment_method ORDER BY code;'
+
+    # The snapshot is a genuine PRE-reclassification store: PayLater kind=1, WelfareCard kind=1.
+    Add-Check 'Database' 'PayLater reclassified to Special (kind=3)' `
+        ([bool]($rows | Where-Object { $_ -like 'PayLater|3|*' }))
+
+    Add-Check 'Database' 'WelfareCard is GovernmentCampaign (kind=2) and still enabled' `
+        ([bool]($rows | Where-Object { $_ -eq 'WelfareCard|2|t' }))
+
+    Add-Check 'Database' 'Cash and MoneyTransfer are Standard (kind=1)' `
+        (@($rows | Where-Object { $_ -like 'Cash|1|*' -or $_ -like 'MoneyTransfer|1|*' }).Count -eq 2)
+
+    $storeIds = Invoke-StoreHubQuery -ConnectionString $conn -PsqlPath $psql `
+        -Sql 'SELECT DISTINCT store_id FROM payment_method;'
+
+    # A second catalogue under STORE-<MachineName> is the exact orphaning that detection
+    # rule 2's non-empty Store:Id check exists to prevent.
+    Add-Check 'Database' 'Exactly one store id in payment_method' `
+        (@($storeIds | Where-Object { $_ }).Count -eq 1) `
+        -Detail ($storeIds -join ', ')
+}
+
 # --- Run --------------------------------------------------------------------
 
 $manifest = Test-Manifest
@@ -234,6 +326,8 @@ if ($manifest) {
     Test-Filesystem -Manifest $manifest
     Test-VelopackApp -Manifest $manifest
     Test-HealthEndpoint -Manifest $manifest
+
+    if ($AssertDatabase) { Test-Database }
 }
 
 [PSCustomObject]@{

--- a/scripts/vm-testing/VMTestConfig.psd1
+++ b/scripts/vm-testing/VMTestConfig.psd1
@@ -7,6 +7,10 @@
     #   2. Static DNS 8.8.8.8/1.1.1.1 (Default Switch forwarder is flaky)
     # Parent 'Clean-Windows' retained as the pristine bare-OS fallback.
     CleanSnapshotName   = 'Clean-Windows-Ready'
+    # A real store image to upgrade FROM: v4.0.0 installed, service running, catalogue
+    # seeded pre-reclassification. Capture it once from a completed fresh install, then
+    # pass it as -SnapshotName for the upgrade cases.
+    PreUpgradeSnapshotName = 'Pre-Upgrade-2026-07-25'
     SwitchName          = 'Default Switch'
 
     # VM resource sizing (one-time New-VM block in README)

--- a/src/IndyPOS.MigrationTool/Services/LegacyPaymentTypeMap.cs
+++ b/src/IndyPOS.MigrationTool/Services/LegacyPaymentTypeMap.cs
@@ -1,0 +1,43 @@
+using IndyPOS.Application.Common.Constants;
+
+namespace IndyPOS.MigrationTool.Services;
+
+/// <summary>
+/// Legacy SQLite <c>PaymentType.PaymentTypeId</c> to v4 catalogue <c>Code</c>.
+/// <para>Taken from the real store database's own <c>PaymentType</c> lookup table, not from
+/// guesswork:</para>
+/// <list type="table">
+/// <item><term>1</term><description>เงินสด - Cash</description></item>
+/// <item><term>2</term><description>ลงบัญชี - PayLater (charged to the customer's account)</description></item>
+/// <item><term>3</term><description>บัตรสวัสดิการแห่งรัฐ - state WelfareCard</description></item>
+/// <item><term>4</term><description>ม.33 - the M33WeLove campaign</description></item>
+/// <item><term>5</term><description>โอนเข้าบัญชี - bank MoneyTransfer</description></item>
+/// <item><term>6</term><description>ผ่อนชำระ - instalments; NO catalogue equivalent (own table, zero Payment rows)</description></item>
+/// <item><term>7</term><description>คนละครึ่ง - the FiftyFifty campaign</description></item>
+/// <item><term>8</term><description>เราชนะ - the WeWin campaign</description></item>
+/// </list>
+/// <para>Shared by the migrator and the verifier deliberately: the verifier compares per-method
+/// totals, and it can only do that honestly if it derives expectations from the same table the
+/// migration wrote from.</para>
+/// </summary>
+public static class LegacyPaymentTypeMap
+{
+    public static readonly IReadOnlyDictionary<int, string> All = new Dictionary<int, string>
+    {
+        [1] = PaymentMethodCodes.Cash,
+        [2] = PaymentMethodCodes.PayLater,
+        [3] = PaymentMethodCodes.WelfareCard,
+        [4] = PaymentMethodCodes.M33WeLove,
+        [5] = PaymentMethodCodes.MoneyTransfer,
+        [7] = PaymentMethodCodes.FiftyFifty,
+        [8] = PaymentMethodCodes.WeWin
+    };
+
+    /// <returns>
+    /// The catalogue code, or <c>null</c> when the id has no equivalent. Null rather than a
+    /// fallback such as "Other": that is not a catalogue code, so it silently attributes money to
+    /// a method nothing can resolve. Callers must refuse the row instead.
+    /// </returns>
+    public static string? ToCode(int legacyPaymentTypeId) =>
+        All.TryGetValue(legacyPaymentTypeId, out var code) ? code : null;
+}

--- a/src/IndyPOS.MigrationTool/Services/LegacyPaymentTypeMap.cs
+++ b/src/IndyPOS.MigrationTool/Services/LegacyPaymentTypeMap.cs
@@ -11,7 +11,10 @@ namespace IndyPOS.MigrationTool.Services;
 /// <item><term>2</term><description>ลงบัญชี - PayLater (charged to the customer's account)</description></item>
 /// <item><term>3</term><description>บัตรสวัสดิการแห่งรัฐ - state WelfareCard</description></item>
 /// <item><term>4</term><description>ม.33 - the M33WeLove campaign</description></item>
-/// <item><term>5</term><description>โอนเข้าบัญชี - bank MoneyTransfer</description></item>
+/// <item><term>5</term><description>โอนเข้าบัญชี - MoneyTransfer. The legacy label says "transfer
+/// into account", but per Pond (2026-07-29) this is the store's CASHLESS bucket: debit tap,
+/// Apple Pay, Google Pay. It is a Standard method, NOT a government campaign - which is what
+/// the v4 catalogue already says, so no reclassification is needed.</description></item>
 /// <item><term>6</term><description>ผ่อนชำระ - instalments; NO catalogue equivalent (own table, zero Payment rows)</description></item>
 /// <item><term>7</term><description>คนละครึ่ง - the FiftyFifty campaign</description></item>
 /// <item><term>8</term><description>เราชนะ - the WeWin campaign</description></item>

--- a/src/IndyPOS.MigrationTool/Services/MigrationVerifier.cs
+++ b/src/IndyPOS.MigrationTool/Services/MigrationVerifier.cs
@@ -1,5 +1,6 @@
 using System.Data.SQLite;
 using Dapper;
+using IndyPOS.Application.Common.Constants;
 using IndyPOS.Infrastructure.Persistence.StoreHub;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -66,6 +67,12 @@ public class MigrationVerifier
         var pgPayLater = await context.PayLaters.CountAsync(ct);
         result.Checks.Add(new VerificationCheck("PayLater", sqlitePayLater, pgPayLater, sqlitePayLater <= pgPayLater));
 
+        // Verify payments PER METHOD, not just in total. Counts and revenue both reconcile
+        // perfectly when the method mapping is scrambled, which is exactly how a mapping that
+        // filed PayLater as "Card" and bank transfers as "WelfareCard" survived: ~15% of
+        // turnover attributed to the wrong method, with every aggregate check still green.
+        await VerifyPaymentsByMethodAsync(sqliteConnection, context, result, ct);
+
         // Verify total amounts match (within tolerance)
         var sqliteTotalAmount = await sqliteConnection.ExecuteScalarAsync<decimal>(
             "SELECT COALESCE(SUM(Total), 0) FROM Invoice");
@@ -97,6 +104,76 @@ public class MigrationVerifier
 
         _logger.LogInformation("Verification completed. Valid: {IsValid}", result.IsValid);
         return result;
+    }
+
+    /// <summary>
+    /// Compares payment count and amount per catalogue method. Expectations are derived from the
+    /// legacy table through <see cref="LegacyPaymentTypeMap"/> - the same map the migration wrote
+    /// with, so a mis-mapping shows up as a mismatch on both sides rather than cancelling out.
+    /// </summary>
+    private async Task VerifyPaymentsByMethodAsync(
+        SQLiteConnection sqlite, StoreHubDbContext context, VerificationResult result, CancellationToken ct)
+    {
+        var legacyGroups = await sqlite.QueryAsync<(long PaymentTypeId, int Count, decimal Total)>(
+            "SELECT PaymentTypeId, COUNT(*) AS Count, COALESCE(SUM(Amount), 0) AS Total " +
+            "FROM Payment GROUP BY PaymentTypeId");
+
+        var expected = new Dictionary<string, (int Count, decimal Total)>();
+
+        foreach (var group in legacyGroups)
+        {
+            var code = LegacyPaymentTypeMap.ToCode((int)group.PaymentTypeId);
+            if (code is null)
+            {
+                // Unmapped ids are a verification failure in their own right: the migration
+                // refused those rows, so the money is in SQLite and nowhere else.
+                result.Errors.Add(
+                    $"Legacy PaymentTypeId {group.PaymentTypeId} has no payment-method code, so " +
+                    $"{group.Count} payment(s) totalling {group.Total:N2} were not migrated.");
+                result.Checks.Add(new VerificationCheck(
+                    $"Payments [legacy type {group.PaymentTypeId}]", group.Count, 0, false));
+                continue;
+            }
+
+            var current = expected.GetValueOrDefault(code);
+            expected[code] = (current.Count + group.Count, current.Total + group.Total);
+        }
+
+        var actual = (await context.Payments
+                .GroupBy(p => p.Method)
+                .Select(g => new { Method = g.Key, Count = g.Count(), Total = g.Sum(p => p.Amount) })
+                .ToListAsync(ct))
+            .ToDictionary(x => x.Method, x => (x.Count, x.Total));
+
+        // PayLater is migrated from its own legacy table too, so PostgreSQL legitimately holds
+        // MORE PayLater payments than the legacy Payment table alone accounts for.
+        foreach (var (code, want) in expected)
+        {
+            var got = actual.GetValueOrDefault(code);
+            var countOk = code == PaymentMethodCodes.PayLater ? got.Count >= want.Count : got.Count == want.Count;
+            var totalOk = code == PaymentMethodCodes.PayLater
+                ? got.Total >= want.Total - 1.00m
+                : Math.Abs(got.Total - want.Total) < 1.00m;
+
+            result.Checks.Add(new VerificationCheck($"Payments [{code}]", want.Count, got.Count, countOk && totalOk));
+
+            if (!countOk || !totalOk)
+            {
+                result.Errors.Add(
+                    $"Payment method {code}: SQLite has {want.Count} totalling {want.Total:N2}, " +
+                    $"PostgreSQL has {got.Count} totalling {got.Total:N2}.");
+            }
+        }
+
+        // A method PostgreSQL knows about but the legacy data never had means the migration
+        // invented an attribution - the failure mode that produced "Card" and "Other".
+        foreach (var (code, got) in actual.Where(a => !expected.ContainsKey(a.Key)))
+        {
+            result.Errors.Add(
+                $"Payment method {code} exists in PostgreSQL ({got.Count} payment(s) totalling " +
+                $"{got.Total:N2}) but no legacy payment type maps to it.");
+            result.Checks.Add(new VerificationCheck($"Payments [{code}] unexpected", 0, got.Count, false));
+        }
     }
 }
 

--- a/src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs
+++ b/src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs
@@ -2,6 +2,7 @@ using System.Data.SQLite;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Dapper;
+using IndyPOS.Application.Common.Constants;
 using IndyPOS.Application.UseCases.Cloud.Sync.BulkMigration;
 using IndyPOS.Domain.Entities.Core;
 using IndyPOS.Infrastructure.Persistence.StoreHub;
@@ -290,11 +291,25 @@ public class SqliteMigrationService
 
                     foreach (var payment in payments)
                     {
+                        var method = LegacyPaymentTypeMap.ToCode((int)payment.PaymentTypeId);
+                        if (method is null)
+                        {
+                            // Refused, never guessed. The previous fallback wrote "Other", which
+                            // is not a catalogue code, so the amount became unresolvable while
+                            // the row counts still reconciled.
+                            _result.Errors.Add(
+                                $"Invoice {invoice.InvoiceId} payment {payment.PaymentId}: legacy " +
+                                $"PaymentTypeId {payment.PaymentTypeId} has no payment-method code. " +
+                                $"Migrating it would misattribute {payment.Amount:N2}.");
+                            _result.Payments.Failed++;
+                            continue;
+                        }
+
                         context.Payments.Add(new Payment
                         {
                             Id = Guid.NewGuid(),
                             InvoiceId = newInvoice.Id,
-                            Method = MapPaymentType((int)payment.PaymentTypeId),
+                            Method = method,
                             Amount = (decimal)payment.Amount,
                             Note = payment.Note,
                             CreatedUtc = createdUtc
@@ -355,7 +370,7 @@ public class SqliteMigrationService
                     {
                         Id = paymentId,
                         InvoiceId = invoiceId,
-                        Method = "PayLater",
+                        Method = PaymentMethodCodes.PayLater,
                         Amount = (decimal)payLater.PaymentAmount,
                         Note = payLater.CustomerName,
                         CreatedUtc = createdUtc
@@ -503,16 +518,6 @@ public class SqliteMigrationService
 
     private static string Truncate(string value, int maxLength) =>
         value.Length <= maxLength ? value : value[..maxLength];
-
-    private static string MapPaymentType(int typeId) => typeId switch
-    {
-        1 => "Cash",
-        2 => "Card",
-        3 => "Transfer",
-        4 => "PayLater",
-        5 => "WelfareCard",
-        _ => "Other"
-    };
 
     // Legacy entity classes for Dapper
     private class LegacyUser

--- a/tests/IndyPOS.Bootstrapper.Tests/Installers/DatabaseSetupTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Installers/DatabaseSetupTests.cs
@@ -170,6 +170,35 @@ public class DatabaseSetupTests
         result.JwtSecret.Should().NotBeNullOrEmpty();
         logs.Should().Contain(msg => msg.Contains("Creating database"));
     }
+
+    [Fact]
+    public void BuildSuperuserGuardMessage_WhenAStoreDatabaseExists_ShouldNeverRecommendTheCleanupScript()
+    {
+        // cleanup-v4.ps1 drops indypos_storehub unconditionally unless -SkipDatabase.
+        // Recommending it to a live store destroys every sale ever recorded.
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: true);
+
+        message.Should().NotContain("cleanup-v4");
+        message.Should().NotContain("-RemovePostgres");
+    }
+
+    [Fact]
+    public void BuildSuperuserGuardMessage_WhenAStoreDatabaseExists_ShouldPointAtTheUpgradeCommand()
+    {
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: true);
+
+        message.Should().Contain("--silent");
+        message.Should().Contain("existing IndyPOS database");
+    }
+
+    [Fact]
+    public void BuildSuperuserGuardMessage_OnABareMachine_ShouldStillOfferTheCleanupScript()
+    {
+        // No store data to lose here, so the fast path stays available.
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: false);
+
+        message.Should().Contain("cleanup-v4.ps1");
+    }
 }
 
 public class JwtSecretGenerationTests

--- a/tests/IndyPOS.Bootstrapper.Tests/Installers/DatabaseSetupTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Installers/DatabaseSetupTests.cs
@@ -172,20 +172,20 @@ public class DatabaseSetupTests
     }
 
     [Fact]
-    public void BuildSuperuserGuardMessage_WhenAStoreDatabaseExists_ShouldNeverRecommendTheCleanupScript()
+    public void BuildSuperuserGuardMessage_WhenStoreInstallExists_ShouldNeverRecommendTheCleanupScript()
     {
         // cleanup-v4.ps1 drops indypos_storehub unconditionally unless -SkipDatabase.
         // Recommending it to a live store destroys every sale ever recorded.
-        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: true);
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeInstallExists: true);
 
         message.Should().NotContain("cleanup-v4");
         message.Should().NotContain("-RemovePostgres");
     }
 
     [Fact]
-    public void BuildSuperuserGuardMessage_WhenAStoreDatabaseExists_ShouldPointAtTheUpgradeCommand()
+    public void BuildSuperuserGuardMessage_WhenStoreInstallExists_ShouldPointAtTheUpgradeCommand()
     {
-        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: true);
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeInstallExists: true);
 
         message.Should().Contain("--silent");
         message.Should().Contain("existing IndyPOS database");
@@ -195,9 +195,32 @@ public class DatabaseSetupTests
     public void BuildSuperuserGuardMessage_OnABareMachine_ShouldStillOfferTheCleanupScript()
     {
         // No store data to lose here, so the fast path stays available.
-        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeDatabaseExists: false);
+        // Assert the full message to catch accidental wording drift.
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeInstallExists: false);
 
-        message.Should().Contain("cleanup-v4.ps1");
+        var expectedMessage = "PostgreSQL 18 is already installed, but its superuser password is unknown " +
+                              "(the installer doesn't persist it across runs). To proceed, either:\n" +
+                              "  - Uninstall PostgreSQL: scripts\\cleanup-v4.ps1 -Force -RemovePostgres\n" +
+                              "  - Or remove C:\\Program Files\\PostgreSQL\\18 manually,\n" +
+                              "then re-run this installer for a clean Postgres install.";
+
+        message.Should().Be(expectedMessage);
+    }
+
+    [Fact]
+    public void BuildSuperuserGuardMessage_WhenConfigExistsButConnectionStringUnusable_ShouldStillGuardTheStore()
+    {
+        // The config file exists (Exists: true) but the DPAPI-protected connection string
+        // cannot be unprotected (ConnectionStringUsable: false). This happens when:
+        // - The file is malformed JSON, or
+        // - The DPAPI blob is sealed on another machine (e.g., restored POS terminal).
+        // Both are real-world cases. We must NOT recommend cleanup-v4.ps1 because it
+        // would destroy the store's sales history. Branch on .Exists, not .ConnectionStringUsable.
+        var message = DatabaseSetup.BuildSuperuserGuardMessage(storeInstallExists: true);
+
+        message.Should().NotContain("cleanup-v4");
+        message.Should().NotContain("-RemovePostgres");
+        message.Should().Contain("--silent");
     }
 }
 

--- a/tests/IndyPOS.Bootstrapper.Tests/Installers/DirectoryLockTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Installers/DirectoryLockTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Tests.Installers;
+
+/// <summary>
+/// The inheritance semantics of <see cref="DatabaseSetup.TryRestrictDirectoryPermissions"/>.
+/// A directory locked without inheritable ACEs makes everything inside it unreachable, which
+/// is how the 2026-07-29 upgrade destroyed access to a backup it had just written correctly.
+/// </summary>
+public class DirectoryLockTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "indypos-dirlock-" + Guid.NewGuid().ToString("N"));
+
+    public DirectoryLockTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try
+        {
+            var info = new DirectoryInfo(_dir);
+            var security = info.GetAccessControl();
+            security.SetAccessRuleProtection(isProtected: false, preserveInheritance: true);
+            info.SetAccessControl(security);
+        }
+        catch { /* best effort */ }
+
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void TryRestrictDirectoryPermissions_ShouldProtectTheDirectory()
+    {
+        DatabaseSetup.TryRestrictDirectoryPermissions(_dir).Should().BeTrue();
+
+        new DirectoryInfo(_dir).GetAccessControl().AreAccessRulesProtected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryRestrictDirectoryPermissions_ShouldMarkEveryAceInheritable()
+    {
+        // This single flag is the whole fix. Without it, protecting the directory drops the
+        // inherited ACEs and Windows recomputes its children's as nothing at all.
+        DatabaseSetup.TryRestrictDirectoryPermissions(_dir);
+
+        var rules = new DirectoryInfo(_dir).GetAccessControl()
+            .GetAccessRules(true, true, typeof(System.Security.Principal.NTAccount))
+            .Cast<System.Security.AccessControl.FileSystemAccessRule>()
+            .ToList();
+
+        rules.Should().NotBeEmpty();
+        rules.Should().OnlyContain(r =>
+            r.InheritanceFlags.HasFlag(System.Security.AccessControl.InheritanceFlags.ContainerInherit) &&
+            r.InheritanceFlags.HasFlag(System.Security.AccessControl.InheritanceFlags.ObjectInherit));
+    }
+
+    [Fact]
+    public void TryRestrictDirectoryPermissions_ShouldLeaveContentCreatedAfterwardsReachable()
+    {
+        // The operation that actually failed in production: write into the locked directory,
+        // then walk it.
+        DatabaseSetup.TryRestrictDirectoryPermissions(_dir);
+
+        var child = Path.Combine(_dir, "StoreHub", "runtimes");
+        Directory.CreateDirectory(child);
+        File.WriteAllText(Path.Combine(child, "native.dll"), "native");
+
+        var act = () => Directory.GetFiles(_dir, "*", SearchOption.AllDirectories);
+
+        act.Should().NotThrow<UnauthorizedAccessException>();
+        act().Should().ContainSingle();
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Installers/FreshInstallOrchestratorTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Installers/FreshInstallOrchestratorTests.cs
@@ -30,13 +30,13 @@ public class InstallationExceptionTests
     }
 }
 
-public class InstallationOrchestratorTests
+public class FreshInstallOrchestratorTests
 {
     [Fact]
-    public void InstallationOrchestrator_CanBeInstantiated()
+    public void FreshInstallOrchestrator_CanBeInstantiated()
     {
         // Act
-        var orchestrator = new InstallationOrchestrator();
+        var orchestrator = new FreshInstallOrchestrator();
 
         // Assert
         orchestrator.Should().NotBeNull();
@@ -54,7 +54,7 @@ public class InstallationOrchestratorTests
     public async Task InstallAsync_WithCancellation_ShouldThrow()
     {
         // Arrange
-        var orchestrator = new InstallationOrchestrator();
+        var orchestrator = new FreshInstallOrchestrator();
         var config = new InstallationConfig
         {
             StoreId = "TEST-001",

--- a/tests/IndyPOS.Bootstrapper.Tests/Installers/MigrationRunnerTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Installers/MigrationRunnerTests.cs
@@ -1,0 +1,29 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Tests.Installers;
+
+public class MigrationRunnerTests
+{
+    [Theory]
+    [InlineData("ADMIN_SEEDED=true", true)]
+    [InlineData("admin_seeded=TRUE", true)]
+    [InlineData("noise\nADMIN_SEEDED=true\nmore noise", true)]
+    [InlineData("ADMIN_SEEDED=false", false)]
+    [InlineData("", false)]
+    public void ParseAdminSeeded_WithVariousStdout_ShouldReturnExpected(string stdout, bool expected)
+    {
+        MigrationRunner.ParseAdminSeeded(stdout).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheExecutableIsMissing_ShouldFailWithTheProbedPath()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "indypos-no-such-" + Guid.NewGuid().ToString("N"));
+
+        var result = await MigrationRunner.RunAsync(missing, log: null, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("IndyPOS.StoreHub.exe");
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Installers/StoreHubPayloadTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Installers/StoreHubPayloadTests.cs
@@ -5,6 +5,12 @@ namespace IndyPOS.Bootstrapper.Tests.Installers;
 
 public class StoreHubPayloadTests : IDisposable
 {
+    // A resource name guaranteed not to exist and an empty probe directory (distinct
+    // from the destination folder), so these tests exercise the "binaries not found"
+    // branch deterministically - regardless of whether this machine has ever run
+    // build-installer.ps1, which stages a real Resources/StoreHub.zip that gets embedded.
+    private const string MissingResourceName = "IndyPOS.Bootstrapper.Tests.NoSuchResource.zip";
+
     private readonly string _dir =
         Path.Combine(Path.GetTempPath(), "indypos-payload-" + Guid.NewGuid().ToString("N"));
 
@@ -21,12 +27,11 @@ public class StoreHubPayloadTests : IDisposable
     [Fact]
     public async Task ExtractAsync_WithNoPayloadAvailable_ShouldReturnFalse()
     {
-        // The test host has no embedded StoreHub.zip and no sibling folder, so this
-        // exercises the "binaries not found" branch without a 67 MB fixture.
-        var dest = Path.Combine(_dir, "StoreHub");
+        var dest = Path.Combine(_dir, "Dest");
         Directory.CreateDirectory(dest);
 
-        var result = await StoreHubPayload.ExtractAsync(dest, log: null, CancellationToken.None);
+        var result = await StoreHubPayload.ExtractAsync(
+            dest, log: null, CancellationToken.None, MissingResourceName, probeDirectory: _dir);
 
         result.Should().BeFalse();
     }
@@ -35,11 +40,11 @@ public class StoreHubPayloadTests : IDisposable
     public async Task ExtractAsync_WithNoPayloadAvailable_ShouldReportEveryLocationItTried()
     {
         var messages = new List<string>();
-        var dest = Path.Combine(_dir, "StoreHub");
+        var dest = Path.Combine(_dir, "Dest");
         Directory.CreateDirectory(dest);
 
         await StoreHubPayload.ExtractAsync(
-            dest, new Progress<string>(messages.Add), CancellationToken.None);
+            dest, new Progress<string>(messages.Add), CancellationToken.None, MissingResourceName, probeDirectory: _dir);
 
         // Progress<T> marshals asynchronously; drain before asserting.
         await Task.Delay(50);

--- a/tests/IndyPOS.Bootstrapper.Tests/Installers/StoreHubPayloadTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Installers/StoreHubPayloadTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+
+namespace IndyPOS.Bootstrapper.Tests.Installers;
+
+public class StoreHubPayloadTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "indypos-payload-" + Guid.NewGuid().ToString("N"));
+
+    public StoreHubPayloadTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExtractAsync_WithNoPayloadAvailable_ShouldReturnFalse()
+    {
+        // The test host has no embedded StoreHub.zip and no sibling folder, so this
+        // exercises the "binaries not found" branch without a 67 MB fixture.
+        var dest = Path.Combine(_dir, "StoreHub");
+        Directory.CreateDirectory(dest);
+
+        var result = await StoreHubPayload.ExtractAsync(dest, log: null, CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_WithNoPayloadAvailable_ShouldReportEveryLocationItTried()
+    {
+        var messages = new List<string>();
+        var dest = Path.Combine(_dir, "StoreHub");
+        Directory.CreateDirectory(dest);
+
+        await StoreHubPayload.ExtractAsync(
+            dest, new Progress<string>(messages.Add), CancellationToken.None);
+
+        // Progress<T> marshals asynchronously; drain before asserting.
+        await Task.Delay(50);
+        messages.Should().Contain(m => m.Contains("StoreHub.zip"));
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentArgsTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using IndyPOS.Bootstrapper.Silent;
+using IndyPOS.Bootstrapper.Upgrade;
 using IndyPOS.Domain.Enums;
 using Xunit;
 
@@ -84,7 +85,8 @@ public class SilentArgsTests
 
     public static TheoryData<string[]> BadSilentArgs => new()
     {
-        new[] { "--silent" },
+        // "--silent" alone is NOT here: an upgrade adopts the detected store id, so the
+        // router — not the parser — decides whether a missing one is fatal.
         new[] { "--silent", "--store-id" },
         new[] { "--silent", "--store-id", " " },
         new[] { "--silent", "--store-id", "A", "--timeout-minutes", "0" },
@@ -112,5 +114,53 @@ public class SilentArgsTests
     public void Parse_WithoutSilent_ShouldReturnNotSilent(string[] args)
     {
         SilentArgs.Parse(args).Status.Should().Be(ParseStatus.NotSilent);
+    }
+
+    [Fact]
+    public void Parse_WithSilentAndNoStoreId_ShouldSucceedWithANullStoreId()
+    {
+        // On an upgrade the store id is adopted from the detected config. Requiring it
+        // would force a comparison on every upgrade with no correct behaviour when the
+        // detected value is null.
+        var result = SilentArgs.Parse(["--silent"]);
+
+        result.Status.Should().Be(ParseStatus.Silent);
+        result.Options!.StoreId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_WithSilentAndAStoreId_ShouldStillCarryIt()
+    {
+        var result = SilentArgs.Parse(["--silent", "--store-id", "Rungrat-001"]);
+
+        result.Options!.StoreId.Should().Be("Rungrat-001");
+    }
+
+    [Fact]
+    public void Parse_WithAnEmptyStoreIdValue_ShouldStillBeAUsageError()
+    {
+        SilentArgs.Parse(["--silent", "--store-id", "   "]).Status.Should().Be(ParseStatus.UsageError);
+    }
+
+    [Fact]
+    public void Parse_WithSimulateFailure_ShouldCarryTheStage()
+    {
+        var result = SilentArgs.Parse(["--silent", "--simulate-failure=deploy"]);
+
+        result.Options!.SimulateFailure.Should().Be(UpgradeStage.Deploy);
+    }
+
+    [Fact]
+    public void Parse_WithoutSimulateFailure_ShouldLeaveTheHookOff()
+    {
+        // The hook must never arm itself: an unset stage is what every real run passes.
+        SilentArgs.Parse(["--silent", "--store-id", "A"]).Options!.SimulateFailure.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_WithAnUnknownSimulateFailureStage_ShouldBeAUsageError()
+    {
+        SilentArgs.Parse(["--silent", "--simulate-failure=nonsense"]).Status
+            .Should().Be(ParseStatus.UsageError);
     }
 }

--- a/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using IndyPOS.Bootstrapper.Silent;
+using IndyPOS.Bootstrapper.Upgrade;
 
 namespace IndyPOS.Bootstrapper.Tests.Silent;
 
@@ -80,5 +81,152 @@ public class SilentOutcomeMapperTests
     public void Map_WithNotElevated_ShouldReturnThree()
     {
         SilentOutcomeMapper.Map(new NotElevatedOutcome()).ExitCode.Should().Be(3);
+    }
+
+    [Fact]
+    public void Map_WithUpgradeSucceeded_ShouldReturnZeroAndTheUpgradeMarkers()
+    {
+        var outcome = new UpgradeSucceeded("4.0.0", "4.1.0", ServiceStarted: true, HealthOk: true,
+            BackupDir: @"C:\ProgramData\IndyPOS\v4\backups\20260726-010203", BackupLocked: true,
+            PosUpdated: true);
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(0);
+        markers.Should().Contain("INDYPOS_MARKER RESULT=success");
+        markers.Should().Contain("INDYPOS_MARKER SERVICE_STARTED=true");
+        markers.Should().Contain("INDYPOS_MARKER HEALTH=ok");
+        markers.Should().Contain(@"INDYPOS_MARKER BACKUP_DIR=C:\ProgramData\IndyPOS\v4\backups\20260726-010203");
+        markers.Should().Contain("INDYPOS_MARKER BACKUP_LOCKED=true");
+        markers.Should().Contain("INDYPOS_MARKER POS_UPDATED=true");
+        markers.Should().Contain("INDYPOS_MARKER FROM_VERSION=4.0.0");
+        markers.Should().Contain("INDYPOS_MARKER TO_VERSION=4.1.0");
+    }
+
+    [Fact]
+    public void Map_WithUpgradeSucceeded_ShouldSuppressTheFreshPathAdminMarkers()
+    {
+        // ADMIN_SEEDED is necessarily false on an upgrade, and its else-branch would
+        // advise reissuing a bootstrap password for a store whose admin is fine.
+        var outcome = new UpgradeSucceeded("4.0.0", "4.1.0", true, true, @"C:\b", true, true);
+
+        var (_, markers) = SilentOutcomeMapper.Map(outcome);
+
+        markers.Should().NotContain(m => m.StartsWith("INDYPOS_MARKER ADMIN_SEEDED="));
+        markers.Should().NotContain(m => m.StartsWith("INDYPOS_MARKER RESET_HINT="));
+        markers.Should().NotContain(m => m.StartsWith("INDYPOS_MARKER CRED_FILE="));
+    }
+
+    [Fact]
+    public void Map_WithAnUnknownFromVersion_ShouldSayUnknownRatherThanEmpty()
+    {
+        // A manifest without installVersion still upgrades; an empty marker value reads
+        // as a broken installer to whoever greps the log.
+        var outcome = new UpgradeSucceeded(null, "4.1.0", true, true, @"C:\b", true, true);
+
+        var (_, markers) = SilentOutcomeMapper.Map(outcome);
+
+        markers.Should().Contain("INDYPOS_MARKER FROM_VERSION=unknown");
+    }
+
+    [Fact]
+    public void Map_WithAPosOnlyFailure_ShouldStillReportTheServerAsServing()
+    {
+        // Spec section 5 row 8: no rollback -- the server is upgraded and serving. The 2026-07-26
+        // spike confirmed the POS step cannot disturb the service.
+        var outcome = new UpgradeFailed("Velopack exited 1", RolledBack: false,
+            ServiceStarted: true, HealthOk: true, BackupDir: @"C:\b");
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(2);
+        markers.Should().Contain("INDYPOS_MARKER RESULT=failed");
+        markers.Should().Contain("INDYPOS_MARKER SERVICE_STARTED=true");
+        markers.Should().Contain("INDYPOS_MARKER POS_UPDATED=false");
+        markers.Should().Contain("INDYPOS_MARKER ROLLED_BACK=false");
+    }
+
+    [Fact]
+    public void Map_WithARolledBackFailure_ShouldReportThePostRollbackHealth()
+    {
+        // Starting the service is not evidence it came back; without the probe a rollback
+        // can claim the store resumed while the store is dead.
+        var outcome = new UpgradeFailed("migrate failed", RolledBack: true,
+            ServiceStarted: true, HealthOk: false, BackupDir: @"C:\b\20260726-010203");
+
+        var (exit, markers) = SilentOutcomeMapper.Map(outcome);
+
+        exit.Should().Be(2);
+        markers.Should().Contain("INDYPOS_MARKER ROLLED_BACK=true");
+        markers.Should().Contain("INDYPOS_MARKER HEALTH=failed");
+        markers.Should().Contain(@"INDYPOS_MARKER BACKUP_DIR=C:\b\20260726-010203");
+    }
+
+    [Fact]
+    public void Map_WithAFailureBeforeAnyBackup_ShouldOmitTheBackupDirMarker()
+    {
+        // Preflight failures happen above the mutation line, so there is no backup to
+        // point an operator at.
+        var outcome = new UpgradeFailed("pg_dump not found", RolledBack: false,
+            ServiceStarted: true, HealthOk: true, BackupDir: null);
+
+        var (_, markers) = SilentOutcomeMapper.Map(outcome);
+
+        markers.Should().NotContain(m => m.StartsWith("INDYPOS_MARKER BACKUP_DIR="));
+    }
+
+    [Fact]
+    public void Map_WithAnUnusableInstall_ShouldReturnFive()
+    {
+        var (exit, markers) = SilentOutcomeMapper.Map(new UnusableInstall("service missing"));
+
+        exit.Should().Be(5);
+        markers.Should().Contain("INDYPOS_MARKER RESULT=failed");
+        markers.Should().Contain("INDYPOS_MARKER REASON=service missing");
+    }
+
+    [Fact]
+    public void Map_WithADowngrade_ShouldReturnSix()
+    {
+        var (exit, markers) = SilentOutcomeMapper.Map(new DowngradeRefused("4.1.0", "4.0.0"));
+
+        exit.Should().Be(6);
+        markers.Should().Contain("INDYPOS_MARKER RESULT=failed");
+        markers.Should().Contain(m => m.Contains("4.1.0") && m.Contains("4.0.0"));
+    }
+
+    [Theory]
+    [InlineData(InstallMode.Fresh, "INDYPOS_MARKER MODE=fresh")]
+    [InlineData(InstallMode.Upgrade, "INDYPOS_MARKER MODE=upgrade")]
+    [InlineData(InstallMode.Unusable, "INDYPOS_MARKER MODE=unusable")]
+    public void ModeMarker_ForEachMode_ShouldEmitTheLowercaseName(InstallMode mode, string expected)
+    {
+        // Months later, a store's own install-latest.log must answer "which path ran"
+        // without anyone reading C#.
+        SilentOutcomeMapper.ModeMarker(mode).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Map_ForEveryOutcomeType_ShouldHaveAnExplicitArm()
+    {
+        // Map ends in a throwing discard, so a new outcome silently crashes the run.
+        var outcomes = new SilentOutcome[]
+        {
+            new InstallSucceeded(true, @"C:\x", true, true, true),
+            new InstallFailed("x"),
+            new InstallTimedOut(),
+            new UsageErrorOutcome("x"),
+            new NotElevatedOutcome(),
+            new UpgradeSucceeded("4.0.0", "4.1.0", true, true, @"C:\b", true, true),
+            new UpgradeFailed("x", false, true, true, @"C:\b"),
+            new UnusableInstall("x"),
+            new DowngradeRefused("4.1.0", "4.0.0")
+        };
+
+        foreach (var outcome in outcomes)
+        {
+            var act = () => SilentOutcomeMapper.Map(outcome);
+            act.Should().NotThrow($"{outcome.GetType().Name} needs an explicit arm");
+        }
     }
 }

--- a/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Silent/SilentOutcomeMapperTests.cs
@@ -176,6 +176,32 @@ public class SilentOutcomeMapperTests
     }
 
     [Fact]
+    public void Map_WithAnUpgradeFailure_ShouldReportTheReason()
+    {
+        // Without this the log records THAT an upgrade failed and nothing about why -- the
+        // 2026-07-29 VM run failed in the backup step and said nothing at all.
+        var outcome = new UpgradeFailed("pg_dump failed (exit 1): could not connect",
+            RolledBack: false, ServiceStarted: true, HealthOk: true, BackupDir: null);
+
+        var (_, markers) = SilentOutcomeMapper.Map(outcome);
+
+        markers.Should().Contain("INDYPOS_MARKER REASON=pg_dump failed (exit 1): could not connect");
+    }
+
+    [Fact]
+    public void Map_WithAReasonContainingAPassword_ShouldRedactIt()
+    {
+        // Npgsql and pg_dump both quote the connection string back on failure, and this
+        // line is read by whoever is standing at the till.
+        var outcome = new UpgradeFailed("failed for Host=127.0.0.1;Password=hunter2;Database=x",
+            RolledBack: false, ServiceStarted: true, HealthOk: true, BackupDir: null);
+
+        var (_, markers) = SilentOutcomeMapper.Map(outcome);
+
+        markers.Should().Contain(m => m.StartsWith("INDYPOS_MARKER REASON=") && !m.Contains("hunter2"));
+    }
+
+    [Fact]
     public void Map_WithAnUnusableInstall_ShouldReturnFive()
     {
         var (exit, markers) = SilentOutcomeMapper.Map(new UnusableInstall("service missing"));

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/InstallModeDetectorTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/InstallModeDetectorTests.cs
@@ -146,6 +146,19 @@ public class InstallModeDetectorTests
     }
 
     [Fact]
+    public void Detect_WhenTheServicePointsToASiblingDirectoryWithASimilarName_ShouldReturnUnusable()
+    {
+        // "StoreHub" is a string prefix of "StoreHubOLD" -- a bare StartsWith(installPath)
+        // would wrongly treat this sibling folder as resolving under the install path.
+        var probe = HealthyUpgrade() with
+        {
+            ServiceImagePath = InstallPath + @"OLD\IndyPOS.StoreHub.exe"
+        };
+
+        InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Unusable);
+    }
+
+    [Fact]
     public void Detect_WithAManifestButNoConfig_ShouldReturnUnusable()
     {
         // Rule 4. This is the exact state the second failed VM run left behind.

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/InstallModeDetectorTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/InstallModeDetectorTests.cs
@@ -1,0 +1,174 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Upgrade;
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class InstallModeDetectorTests
+{
+    private const string InstallPath = @"C:\ProgramData\IndyPOS\v4\StoreHub";
+
+    private sealed record FakeProbe : IInstallProbe
+    {
+        public bool ManifestExists { get; init; }
+        public string? ManifestInstallVersion { get; init; }
+        public bool PostgresStoreDatabaseExists { get; init; }
+        public string? ServiceImagePath { get; init; }
+        public StoreHubConfigFacts Config { get; init; } = new(false, false, null, null);
+    }
+
+    private static FakeProbe HealthyUpgrade() => new()
+    {
+        ManifestExists = true,
+        ManifestInstallVersion = "4.0.0",
+        PostgresStoreDatabaseExists = true,
+        ServiceImagePath = InstallPath + @"\IndyPOS.StoreHub.exe",
+        Config = new StoreHubConfigFacts(true, true, "Rungrat-001", StoreType.Minimart)
+    };
+
+    [Fact]
+    public void Detect_OnABareMachine_ShouldReturnFresh()
+    {
+        var result = InstallModeDetector.Detect(new FakeProbe(), InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Fresh);
+    }
+
+    [Fact]
+    public void Detect_OnAHealthyInstall_ShouldReturnUpgradeWithEveryDetectedValue()
+    {
+        var result = InstallModeDetector.Detect(HealthyUpgrade(), InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Upgrade);
+        result.InstalledVersion.Should().Be("4.0.0");
+        result.StoreId.Should().Be("Rungrat-001");
+        result.StoreType.Should().Be(StoreType.Minimart);
+    }
+
+    [Fact]
+    public void Detect_WithAStoreDatabaseButNoManifestForThisMajor_ShouldReturnUnusable()
+    {
+        // Rule 1, and it must beat rule 3. A v5 installer on a live v4 store finds no
+        // manifest under v5\ and would otherwise read as Fresh -- but DatabaseName is
+        // NOT version-scoped, so that "side-by-side" install collides with the v4 database.
+        var probe = new FakeProbe { PostgresStoreDatabaseExists = true, ManifestExists = false };
+
+        var result = InstallModeDetector.Detect(probe, InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Unusable);
+        result.Reason.Should().Contain("another IndyPOS major version");
+    }
+
+    [Fact]
+    public void Detect_WithAStoreDatabaseAndNoManifest_ShouldNotRecommendTheCleanupScript()
+    {
+        var probe = new FakeProbe { PostgresStoreDatabaseExists = true, ManifestExists = false };
+
+        InstallModeDetector.Detect(probe, InstallPath).Reason.Should().NotContain("cleanup-v4");
+    }
+
+    [Fact]
+    public void Detect_WithAnEmptyStoreId_ShouldReturnUnusable()
+    {
+        // StoreIdentityService falls back to STORE-{MachineName}, and payment_method is
+        // keyed on (StoreId, Code) -- the seeder would insert a second full catalogue and
+        // every later sale would be written against it.
+        var probe = HealthyUpgrade() with
+        {
+            Config = new StoreHubConfigFacts(true, true, null, StoreType.Minimart)
+        };
+
+        var result = InstallModeDetector.Detect(probe, InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Unusable);
+        result.Reason.Should().Contain("Store:Id");
+    }
+
+    [Fact]
+    public void Detect_WithAnAbsentStoreType_ShouldReturnUnusable()
+    {
+        // Added 2026-07-18. Absent binds to GeneralHardware -- the MOST permissive value --
+        // which would silently re-enable PayLater and Hardware products on a Minimart.
+        var probe = HealthyUpgrade() with
+        {
+            Config = new StoreHubConfigFacts(true, true, "Rungrat-001", null)
+        };
+
+        var result = InstallModeDetector.Detect(probe, InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Unusable);
+        result.Reason.Should().Contain("Store:Type");
+    }
+
+    [Fact]
+    public void Detect_WithAnUndecryptableConnectionString_ShouldReturnUnusable()
+    {
+        var probe = HealthyUpgrade() with
+        {
+            Config = new StoreHubConfigFacts(true, false, "Rungrat-001", StoreType.Minimart)
+        };
+
+        var result = InstallModeDetector.Detect(probe, InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Unusable);
+        result.Reason.Should().Contain("connection string");
+    }
+
+    [Fact]
+    public void Detect_WhenTheServiceIsNotRegistered_ShouldReturnUnusable()
+    {
+        var probe = HealthyUpgrade() with { ServiceImagePath = null };
+
+        InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Unusable);
+    }
+
+    [Fact]
+    public void Detect_WhenTheServicePointsSomewhereElse_ShouldReturnUnusable()
+    {
+        var probe = HealthyUpgrade() with
+        {
+            ServiceImagePath = @"C:\Some\Other\Place\IndyPOS.StoreHub.exe"
+        };
+
+        InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Unusable);
+    }
+
+    [Fact]
+    public void Detect_WithAQuotedServiceImagePath_ShouldStillMatch()
+    {
+        // sc.exe records binPath with quotes when the path contains spaces.
+        var probe = HealthyUpgrade() with
+        {
+            ServiceImagePath = "\"" + InstallPath + "\\IndyPOS.StoreHub.exe\""
+        };
+
+        InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Upgrade);
+    }
+
+    [Fact]
+    public void Detect_WithAManifestButNoConfig_ShouldReturnUnusable()
+    {
+        // Rule 4. This is the exact state the second failed VM run left behind.
+        var probe = new FakeProbe
+        {
+            ManifestExists = true,
+            ManifestInstallVersion = "4.0.0",
+            ServiceImagePath = InstallPath + @"\IndyPOS.StoreHub.exe",
+            Config = new StoreHubConfigFacts(true, false, null, null)
+        };
+
+        InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Unusable);
+    }
+
+    [Fact]
+    public void Detect_WithConfigButNoManifest_ShouldReturnUnusableNotFresh()
+    {
+        // Rule 3 requires BOTH absent. A leftover config means this is not a bare machine.
+        var probe = new FakeProbe
+        {
+            Config = new StoreHubConfigFacts(true, true, "Rungrat-001", StoreType.Minimart)
+        };
+
+        InstallModeDetector.Detect(probe, InstallPath).Mode.Should().Be(InstallMode.Unusable);
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/InstallModeDetectorTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/InstallModeDetectorTests.cs
@@ -27,6 +27,27 @@ public class InstallModeDetectorTests
     };
 
     [Fact]
+    public void Detect_OnAMachineRunningOnlyV3_ShouldReturnFresh()
+    {
+        // The real deployment case for all three live stores: they run v3.7.0, which predates
+        // this layout entirely - no v4 manifest, no versioned StoreHub config, SQLite rather
+        // than a Postgres store database. v4 installs alongside it, so this must be Fresh;
+        // Unusable would block every store, and Upgrade would be worse.
+        var v3Machine = new FakeProbe
+        {
+            ManifestExists = false,
+            ManifestInstallVersion = null,
+            PostgresStoreDatabaseExists = false,
+            ServiceImagePath = null,
+            Config = new StoreHubConfigFacts(Exists: false, false, null, null)
+        };
+
+        var result = InstallModeDetector.Detect(v3Machine, InstallPath);
+
+        result.Mode.Should().Be(InstallMode.Fresh);
+    }
+
+    [Fact]
     public void Detect_OnABareMachine_ShouldReturnFresh()
     {
         var result = InstallModeDetector.Detect(new FakeProbe(), InstallPath);

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/PosAppVersionTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/PosAppVersionTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Upgrade;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class PosAppVersionTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "indypos-sqver-" + Guid.NewGuid().ToString("N"));
+
+    public PosAppVersionTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+    }
+
+    // Verbatim shape captured from the VM on 2026-07-26.
+    private const string RealSqVersion = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+        <metadata>
+        <id>IndyPOS.POS.v4</id>
+        <title>IndyPOS.POS.v4</title>
+        <version>4.0.1</version>
+        <channel>stable</channel>
+        <mainExe>IndyPOS.Windows.Forms.exe</mainExe>
+        </metadata>
+        </package>
+        """;
+
+    [Fact]
+    public void Read_WithARealSqVersionFile_ShouldReturnThePackageVersion()
+    {
+        File.WriteAllText(Path.Combine(_dir, "sq.version"), RealSqVersion);
+
+        PosAppVersion.Read(_dir).Should().Be("4.0.1");
+    }
+
+    [Fact]
+    public void Read_WhenTheFileIsAbsent_ShouldReturnNull()
+    {
+        PosAppVersion.Read(_dir).Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WhenTheDirectoryIsAbsent_ShouldReturnNull()
+    {
+        PosAppVersion.Read(Path.Combine(_dir, "nope")).Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithMalformedXml_ShouldReturnNull()
+    {
+        // Never throw on the reporting path: POS_UPDATED is telemetry, not a gate.
+        File.WriteAllText(Path.Combine(_dir, "sq.version"), "<package><metadata>");
+
+        PosAppVersion.Read(_dir).Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithNoVersionElement_ShouldReturnNull()
+    {
+        File.WriteAllText(Path.Combine(_dir, "sq.version"),
+            """<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"><metadata><id>x</id></metadata></package>""");
+
+        PosAppVersion.Read(_dir).Should().BeNull();
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/StoreHubConfigReaderTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/StoreHubConfigReaderTests.cs
@@ -157,4 +157,30 @@ public class StoreHubConfigReaderTests : IDisposable
         facts.ConnectionStringUsable.Should().BeFalse();
         facts.StoreId.Should().BeNull();
     }
+
+    [Fact]
+    public void Read_WithNonStringStoreId_ShouldDegradeGracefully()
+    {
+        // Hand-edited config with numeric store ID instead of string.
+        var path = Write("""{ "store": { "id": 12345, "type": "Minimart" } }""");
+
+        var facts = StoreHubConfigReader.Read(path, PassThrough);
+
+        facts.Exists.Should().BeTrue();
+        facts.StoreId.Should().BeNull();
+        facts.StoreType.Should().Be(StoreType.Minimart);
+    }
+
+    [Fact]
+    public void Read_WithNonStringStoreType_ShouldDegradeGracefully()
+    {
+        // Hand-edited config with numeric store type instead of string enum name.
+        var path = Write("""{ "store": { "id": "Rungrat-001", "type": 2 } }""");
+
+        var facts = StoreHubConfigReader.Read(path, PassThrough);
+
+        facts.Exists.Should().BeTrue();
+        facts.StoreId.Should().Be("Rungrat-001");
+        facts.StoreType.Should().BeNull();
+    }
 }

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/StoreHubConfigReaderTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/StoreHubConfigReaderTests.cs
@@ -1,0 +1,160 @@
+using System.Security.Cryptography;
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Upgrade;
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class StoreHubConfigReaderTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "indypos-cfgread-" + Guid.NewGuid().ToString("N"));
+
+    public StoreHubConfigReaderTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+    }
+
+    // Tests never touch real DPAPI: a machine-scoped blob cannot be authored
+    // portably, and the reader's contract is "whatever unprotect does".
+    private static string PassThrough(string key, string value) => value;
+
+    private static string Fail(string key, string value) =>
+        throw new CryptographicException("Key not valid for use in specified state.");
+
+    private string Write(string json)
+    {
+        var path = Path.Combine(_dir, "appsettings.json");
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    [Fact]
+    public void Read_WhenFileIsAbsent_ShouldReportNotExists()
+    {
+        var facts = StoreHubConfigReader.Read(Path.Combine(_dir, "appsettings.json"), PassThrough);
+
+        facts.Exists.Should().BeFalse();
+        facts.ConnectionStringUsable.Should().BeFalse();
+        facts.StoreId.Should().BeNull();
+        facts.StoreType.Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithARealStoreConfig_ShouldReturnEveryFact()
+    {
+        var path = Write("""
+        {
+          "connectionStrings": { "storehub-db": "DPAPI:AQAAANCM" },
+          "store": { "id": "Rungrat-001", "type": "Minimart" }
+        }
+        """);
+
+        var facts = StoreHubConfigReader.Read(path, PassThrough);
+
+        facts.Exists.Should().BeTrue();
+        facts.ConnectionStringUsable.Should().BeTrue();
+        facts.StoreId.Should().Be("Rungrat-001");
+        facts.StoreType.Should().Be(StoreType.Minimart);
+    }
+
+    [Fact]
+    public void Read_WithPascalCaseKeys_ShouldStillBindThem()
+    {
+        // ASP.NET config binding is case-insensitive, so a hand-edited file is valid.
+        var path = Write("""
+        {
+          "ConnectionStrings": { "storehub-db": "Host=127.0.0.1" },
+          "Store": { "Id": "Rungrat-001", "Type": "GeneralHardware" }
+        }
+        """);
+
+        var facts = StoreHubConfigReader.Read(path, PassThrough);
+
+        facts.StoreId.Should().Be("Rungrat-001");
+        facts.StoreType.Should().Be(StoreType.GeneralHardware);
+    }
+
+    [Fact]
+    public void Read_WhenDpapiValueFailsToDecrypt_ShouldReportUnusable()
+    {
+        // A value protected on another machine. That store is Unusable, not upgradeable.
+        var path = Write("""
+        {
+          "connectionStrings": { "storehub-db": "DPAPI:AQAAANCM" },
+          "store": { "id": "Rungrat-001", "type": "Minimart" }
+        }
+        """);
+
+        var facts = StoreHubConfigReader.Read(path, Fail);
+
+        facts.Exists.Should().BeTrue();
+        facts.ConnectionStringUsable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Read_WhenDpapiValueIsNotBase64_ShouldReportUnusable()
+    {
+        // Unprotect throws FormatException, not CryptographicException, on bad base64.
+        var path = Write("""{ "connectionStrings": { "storehub-db": "DPAPI:not-base64!!" } }""");
+
+        var facts = StoreHubConfigReader.Read(
+            path, (_, _) => throw new FormatException("Invalid base64."));
+
+        facts.ConnectionStringUsable.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Read_WithBlankConnectionString_ShouldReportUnusable(string value)
+    {
+        var path = Write($$"""{ "connectionStrings": { "storehub-db": "{{value}}" } }""");
+
+        StoreHubConfigReader.Read(path, PassThrough).ConnectionStringUsable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Read_WithBlankStoreId_ShouldReturnNullStoreId()
+    {
+        // Empty is as dangerous as absent: StoreIdentityService falls back to the
+        // machine name, which would orphan the store's sales history.
+        var path = Write("""{ "store": { "id": "   ", "type": "Minimart" } }""");
+
+        StoreHubConfigReader.Read(path, PassThrough).StoreId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithAbsentStoreType_ShouldReturnNullStoreType()
+    {
+        // Stores installed before 2026-07-18 have no Store:Type key.
+        var path = Write("""{ "store": { "id": "Rungrat-001" } }""");
+
+        StoreHubConfigReader.Read(path, PassThrough).StoreType.Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithUnparseableStoreType_ShouldReturnNullStoreType()
+    {
+        var path = Write("""{ "store": { "id": "Rungrat-001", "type": "Bakery" } }""");
+
+        StoreHubConfigReader.Read(path, PassThrough).StoreType.Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WithMalformedJson_ShouldReportExistsButUnusable()
+    {
+        var path = Write("{ this is not json");
+
+        var facts = StoreHubConfigReader.Read(path, PassThrough);
+
+        facts.Exists.Should().BeTrue();
+        facts.ConnectionStringUsable.Should().BeFalse();
+        facts.StoreId.Should().BeNull();
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/StoreHubConfigReaderTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/StoreHubConfigReaderTests.cs
@@ -183,4 +183,51 @@ public class StoreHubConfigReaderTests : IDisposable
         facts.StoreId.Should().Be("Rungrat-001");
         facts.StoreType.Should().BeNull();
     }
+
+    [Fact]
+    public void ReadConnectionString_WithAProtectedValue_ShouldReturnThePlaintext()
+    {
+        // The upgrade's backup step needs the real value, not just "is it usable".
+        var path = Write("""{ "connectionStrings": { "storehub-db": "DPAPI:blob" } }""");
+
+        StoreHubConfigReader.ReadConnectionString(path, (key, _) =>
+        {
+            key.Should().Be(StoreHubConfigReader.ConnectionStringKey);
+            return "Host=127.0.0.1;Database=indypos_storehub";
+        }).Should().Be("Host=127.0.0.1;Database=indypos_storehub");
+    }
+
+    [Fact]
+    public void ReadConnectionString_WithAPlaintextValue_ShouldReturnItUnchanged()
+    {
+        // A dev-authored config is not DPAPI-wrapped; unprotect must not be invoked.
+        var path = Write("""{ "connectionStrings": { "storehub-db": "Host=127.0.0.1" } }""");
+
+        StoreHubConfigReader.ReadConnectionString(path, Fail).Should().Be("Host=127.0.0.1");
+    }
+
+    [Fact]
+    public void ReadConnectionString_WithPascalCaseKeys_ShouldStillFindIt()
+    {
+        // Config binding is case-insensitive, so a hand-edited file must not look like a
+        // machine whose connection string cannot be decrypted.
+        var path = Write("""{ "ConnectionStrings": { "Storehub-Db": "Host=127.0.0.1" } }""");
+
+        StoreHubConfigReader.ReadConnectionString(path, Fail).Should().Be("Host=127.0.0.1");
+    }
+
+    [Fact]
+    public void ReadConnectionString_WhenSealedToAnotherMachine_ShouldReturnNull()
+    {
+        var path = Write("""{ "connectionStrings": { "storehub-db": "DPAPI:blob" } }""");
+
+        StoreHubConfigReader.ReadConnectionString(path, Fail).Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadConnectionString_WhenAbsent_ShouldReturnNull()
+    {
+        StoreHubConfigReader.ReadConnectionString(Path.Combine(_dir, "appsettings.json"), PassThrough)
+            .Should().BeNull();
+    }
 }

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeBackupAclTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeBackupAclTests.cs
@@ -1,0 +1,116 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Upgrade;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+/// <summary>
+/// Exercises the REAL ACL helper, unlike <see cref="UpgradeBackupTests"/> which fakes the
+/// lock seam. That fake is what let the 2026-07-29 VM failure through: locking the stamp
+/// directory with a protected, non-inheritable DACL retroactively strips its children's
+/// inherited ACEs, so the freshly copied tree became readable by nobody - and the very next
+/// statement enumerates that tree.
+/// </summary>
+public class UpgradeBackupAclTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "indypos-backup-acl-" + Guid.NewGuid().ToString("N"));
+
+    private readonly string _backups;
+    private readonly string _storeHub;
+
+    public UpgradeBackupAclTests()
+    {
+        _backups = Path.Combine(_root, "backups");
+        _storeHub = Path.Combine(_root, "StoreHub");
+        Directory.CreateDirectory(_backups);
+        Directory.CreateDirectory(Path.Combine(_storeHub, "runtimes", "win-x64"));
+        File.WriteAllText(Path.Combine(_storeHub, "appsettings.json"), "{}");
+        File.WriteAllText(Path.Combine(_storeHub, "IndyPOS.StoreHub.exe"), "old binary");
+        File.WriteAllText(Path.Combine(_storeHub, "runtimes", "win-x64", "native.dll"), "native");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            // The stamp is deliberately ACL-locked; re-grant before cleanup or this leaks temp dirs.
+            foreach (var dir in Directory.EnumerateDirectories(_backups))
+            {
+                GrantFullControl(dir);
+            }
+        }
+        catch { /* best effort */ }
+
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static void GrantFullControl(string path)
+    {
+        var info = new DirectoryInfo(path);
+        var security = info.GetAccessControl();
+        security.SetAccessRuleProtection(isProtected: false, preserveInheritance: true);
+        info.SetAccessControl(security);
+    }
+
+    private sealed class FakePgDump : IProcessRunner
+    {
+        public Task<ProcessRunResult> RunAsync(
+            string fileName, string arguments,
+            IReadOnlyDictionary<string, string>? environment, CancellationToken ct)
+        {
+            const string marker = "-f \"";
+            var start = arguments.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+            File.WriteAllBytes(arguments[start..arguments.IndexOf('"', start)], new byte[4096]);
+
+            return Task.FromResult(new ProcessRunResult(0, "", ""));
+        }
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithRealAcls_ShouldLeaveTheBackedUpTreeReadable()
+    {
+        // A backup nobody can read is not a backup: RestoreStoreHubTree enumerates this
+        // exact directory, so an unreadable tree also breaks every rollback.
+        var backup = new UpgradeBackup(_backups, _storeHub, new FakePgDump(), () => "20260729-010203");
+
+        var result = await backup.CreateAsync(
+            "pg_dump.exe",
+            "Host=127.0.0.1;Port=5432;Database=indypos_storehub;Username=indypos_app;Password=s3cret",
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue(result.ErrorMessage);
+
+        // Guard against a vacuous pass: if the real ACL helper silently no-opped, the
+        // readability assertion below would prove nothing.
+        result.Locked.Should().BeTrue("the real ACL helper must actually apply the lock");
+        new DirectoryInfo(result.StampDirectory!).GetAccessControl()
+            .AreAccessRulesProtected.Should().BeTrue("the stamp directory must drop inherited ACEs");
+
+        var tree = Path.Combine(result.StampDirectory!, "StoreHub");
+        var act = () => Directory.GetFiles(tree, "*", SearchOption.AllDirectories);
+
+        act.Should().NotThrow<UnauthorizedAccessException>();
+        act().Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldNotWalkTheTreeItJustLocked()
+    {
+        // The 2026-07-29 failure was the walk itself, so assert it does not happen. A lock
+        // seam that throws on any path under the tree would have failed the old code and
+        // passes now: inheritance covers those files, nothing enumerates them.
+        var treeFilesTouched = new List<string>();
+
+        var backup = new UpgradeBackup(
+            _backups, _storeHub, new FakePgDump(), () => "20260729-020304",
+            lockPath: p => { treeFilesTouched.Add(p); return true; });
+
+        var result = await backup.CreateAsync(
+            "pg_dump.exe",
+            "Host=127.0.0.1;Port=5432;Database=indypos_storehub;Username=indypos_app;Password=s3cret",
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue(result.ErrorMessage);
+        treeFilesTouched.Should().ContainSingle().Which.Should().EndWith("storehub.dump");
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeBackupTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeBackupTests.cs
@@ -1,0 +1,182 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Upgrade;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class UpgradeBackupTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "indypos-backup-" + Guid.NewGuid().ToString("N"));
+
+    private readonly string _backups;
+    private readonly string _storeHub;
+    private readonly List<string> _lockedPaths = [];
+
+    public UpgradeBackupTests()
+    {
+        _backups = Path.Combine(_root, "backups");
+        _storeHub = Path.Combine(_root, "StoreHub");
+        Directory.CreateDirectory(_backups);
+        Directory.CreateDirectory(_storeHub);
+        File.WriteAllText(Path.Combine(_storeHub, "IndyPOS.StoreHub.exe"), "old binary");
+        File.WriteAllText(Path.Combine(_storeHub, "appsettings.json"), """{"store":{"id":"Rungrat-001"}}""");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    // Writes a dump of the requested size instead of shelling out to pg_dump.
+    private sealed class FakePgDump(int exitCode, int dumpBytes) : IProcessRunner
+    {
+        public string? LastArguments { get; private set; }
+
+        public Task<ProcessRunResult> RunAsync(
+            string fileName, string arguments,
+            IReadOnlyDictionary<string, string>? environment, CancellationToken ct)
+        {
+            LastArguments = arguments;
+
+            // -f <path> is the last argument; mirror what pg_dump would produce.
+            var marker = "-f \"";
+            var start = arguments.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+            var path = arguments[start..arguments.IndexOf('"', start)];
+
+            if (dumpBytes > 0)
+            {
+                File.WriteAllBytes(path, new byte[dumpBytes]);
+            }
+
+            return Task.FromResult(new ProcessRunResult(exitCode, "", exitCode == 0 ? "" : "boom"));
+        }
+    }
+
+    private UpgradeBackup Build(IProcessRunner runner, string stamp = "20260726-010203") =>
+        new(_backups, _storeHub, runner, () => stamp, p => { _lockedPaths.Add(p); return true; });
+
+    private const string Conn = "Host=127.0.0.1;Port=5432;Database=indypos_storehub;Username=indypos_app;Password=s3cret";
+
+    [Fact]
+    public async Task CreateAsync_OnSuccess_ShouldCopyTheStoreHubTreeIntoTheStamp()
+    {
+        var result = await Build(new FakePgDump(0, 4096)).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        File.ReadAllText(Path.Combine(result.StampDirectory!, "StoreHub", "IndyPOS.StoreHub.exe"))
+            .Should().Be("old binary");
+    }
+
+    [Fact]
+    public async Task CreateAsync_OnSuccess_ShouldWriteTheDumpBesideTheTree()
+    {
+        var result = await Build(new FakePgDump(0, 4096)).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        File.Exists(Path.Combine(result.StampDirectory!, "storehub.dump")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateAsync_OnSuccess_ShouldLockTheStampAndBothArtifacts()
+    {
+        // BackupsDirectory inherits ProgramData's DACL, which grants BUILTIN\Users read.
+        // The dump is the whole sales history plus BCrypt admin hashes.
+        var result = await Build(new FakePgDump(0, 4096)).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        result.Locked.Should().BeTrue();
+        _lockedPaths.Should().Contain(result.StampDirectory!);
+        _lockedPaths.Should().Contain(Path.Combine(result.StampDirectory!, "storehub.dump"));
+        _lockedPaths.Should().Contain(Path.Combine(result.StampDirectory!, "StoreHub", "appsettings.json"));
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenPgDumpFails_ShouldReportFailure()
+    {
+        var result = await Build(new FakePgDump(1, 4096)).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("pg_dump");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenTheDumpIsTruncated_ShouldRejectIt()
+    {
+        // A disk-full pg_dump can exit 0 having written almost nothing; "present" is not
+        // "restorable", and BACKUP_DIR would otherwise advertise a dead artifact.
+        var result = await Build(new FakePgDump(0, 10)).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("too small");
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldNeverPutThePasswordOnTheCommandLine()
+    {
+        // A command line is visible to every local process.
+        var runner = new FakePgDump(0, 4096);
+        await Build(runner).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        runner.LastArguments.Should().NotContain("s3cret");
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldUseCustomFormatSoPgRestoreCanReadIt()
+    {
+        var runner = new FakePgDump(0, 4096);
+        await Build(runner).CreateAsync("pg_dump.exe", Conn, CancellationToken.None);
+
+        runner.LastArguments.Should().Contain("-Fc");
+    }
+
+    [Fact]
+    public void RestoreStoreHubTree_ShouldDeleteBeforeCopying()
+    {
+        // Extraction is per-entry overwrite with no clean step, so after a deploy the tree
+        // is old-union-new. Copying over that leaves new-version files behind.
+        var stamp = Path.Combine(_backups, "20260726-010203");
+        Directory.CreateDirectory(Path.Combine(stamp, "StoreHub"));
+        File.WriteAllText(Path.Combine(stamp, "StoreHub", "IndyPOS.StoreHub.exe"), "old binary");
+
+        File.WriteAllText(Path.Combine(_storeHub, "BrandNew.dll"), "from the failed upgrade");
+
+        Build(new FakePgDump(0, 4096)).RestoreStoreHubTree(stamp);
+
+        File.Exists(Path.Combine(_storeHub, "BrandNew.dll")).Should().BeFalse();
+        File.ReadAllText(Path.Combine(_storeHub, "IndyPOS.StoreHub.exe")).Should().Be("old binary");
+    }
+
+    [Fact]
+    public void RestoreStoreHubTree_WhenTheBackupIsMissing_ShouldThrow()
+    {
+        // Silently doing nothing here would report a rollback that never happened.
+        var act = () => Build(new FakePgDump(0, 4096))
+            .RestoreStoreHubTree(Path.Combine(_backups, "no-such-stamp"));
+
+        act.Should().Throw<DirectoryNotFoundException>();
+    }
+
+    [Fact]
+    public void Prune_WithMoreThanTheRetainedStamps_ShouldKeepOnlyTheNewest()
+    {
+        foreach (var stamp in new[] { "20260101-000000", "20260201-000000", "20260301-000000", "20260401-000000" })
+        {
+            Directory.CreateDirectory(Path.Combine(_backups, stamp));
+        }
+
+        var removed = Build(new FakePgDump(0, 4096)).Prune();
+
+        removed.Should().Be(2);
+        Directory.GetDirectories(_backups).Select(Path.GetFileName)
+            .Should().BeEquivalentTo("20260301-000000", "20260401-000000");
+    }
+
+    [Fact]
+    public void Prune_WithFewerThanTheRetainedStamps_ShouldRemoveNothing()
+    {
+        Directory.CreateDirectory(Path.Combine(_backups, "20260101-000000"));
+
+        Build(new FakePgDump(0, 4096)).Prune().Should().Be(0);
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeBackupTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeBackupTests.cs
@@ -55,8 +55,12 @@ public class UpgradeBackupTests : IDisposable
         }
     }
 
+    // Both lock seams record into the same list; which helper ran is asserted separately by
+    // UpgradeBackupAclTests, which uses the real ACL code.
     private UpgradeBackup Build(IProcessRunner runner, string stamp = "20260726-010203") =>
-        new(_backups, _storeHub, runner, () => stamp, p => { _lockedPaths.Add(p); return true; });
+        new(_backups, _storeHub, runner, () => stamp,
+            p => { _lockedPaths.Add(p); return true; },
+            p => { _lockedPaths.Add(p); return true; });
 
     private const string Conn = "Host=127.0.0.1;Port=5432;Database=indypos_storehub;Username=indypos_app;Password=s3cret";
 
@@ -88,7 +92,12 @@ public class UpgradeBackupTests : IDisposable
         result.Locked.Should().BeTrue();
         _lockedPaths.Should().Contain(result.StampDirectory!);
         _lockedPaths.Should().Contain(Path.Combine(result.StampDirectory!, "storehub.dump"));
-        _lockedPaths.Should().Contain(Path.Combine(result.StampDirectory!, "StoreHub", "appsettings.json"));
+        _lockedPaths.Should().Contain(Path.Combine(result.StampDirectory!, "StoreHub"));
+
+        // Individual files inside the tree are covered by the stamp directory's inheritable
+        // ACEs. Walking them was not merely wasteful (483 files on a real store) - the walk
+        // itself was the 2026-07-29 failure, see UpgradeBackupAclTests.
+        _lockedPaths.Should().NotContain(Path.Combine(result.StampDirectory!, "StoreHub", "appsettings.json"));
     }
 
     [Fact]

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeOrchestratorTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeOrchestratorTests.cs
@@ -1,0 +1,334 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Installers;
+using IndyPOS.Bootstrapper.Silent;
+using IndyPOS.Bootstrapper.Upgrade;
+using IndyPOS.Domain.Enums;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class UpgradeOrchestratorTests
+{
+    private const string BackupDir = @"C:\ProgramData\IndyPOS\v4\backups\20260726-010203";
+
+    private static readonly DetectedInstall Detected = new(
+        InstallMode.Upgrade, "4.0.0", "Rungrat-001", StoreType.Minimart, "ok");
+
+    private static InstallationConfig Config() => new() { StoreId = "Rungrat-001", Interactive = false };
+
+    private sealed class FakeSteps : IUpgradeSteps
+    {
+        public List<string> Calls { get; } = [];
+
+        public bool PreflightOk { get; init; } = true;
+        public string PreflightReason { get; init; } = "preflight failed";
+        public bool IsDowngrade { get; init; }
+        public bool BackupOk { get; init; } = true;
+        public bool DeployOk { get; init; } = true;
+        public bool MigrateOk { get; init; } = true;
+        public bool StartOk { get; init; } = true;
+        public bool HealthOk { get; set; } = true;
+        public bool PostRollbackHealthOk { get; init; } = true;
+        public bool PosOk { get; init; } = true;
+        public string? PosVersionAfter { get; init; } = "4.1.0";
+        public bool RestoreThrows { get; init; }
+
+        // Keyed off the rollback itself, not a call count: when deploy fails, step 7 never
+        // probes, so the rollback's probe IS the first one.
+        private bool _rolledBack;
+
+        public Task<PreflightResult> PreflightAsync(DetectedInstall d, InstallationConfig c, CancellationToken ct)
+        {
+            Calls.Add("preflight");
+            return Task.FromResult(new PreflightResult(
+                PreflightOk, @"C:\pg\bin\pg_dump.exe", "Host=127.0.0.1",
+                PreflightOk ? null : PreflightReason, IsDowngrade));
+        }
+
+        public Task<bool> StopServiceAsync(CancellationToken ct)
+        {
+            Calls.Add("stop");
+            return Task.FromResult(true);
+        }
+
+        public Task<BackupResult> BackupAsync(string pgDump, string conn, CancellationToken ct)
+        {
+            Calls.Add("backup");
+            return Task.FromResult(new BackupResult(BackupOk, BackupDir, true,
+                BackupOk ? null : "pg_dump failed"));
+        }
+
+        public ConfigSnapshotHandle CaptureConfig()
+        {
+            Calls.Add("capture");
+            return new ConfigSnapshotHandle(() => Calls.Add("restore-config"));
+        }
+
+        public Task<bool> DeployAsync(CancellationToken ct)
+        {
+            Calls.Add("deploy");
+            return Task.FromResult(DeployOk);
+        }
+
+        public Task<MigrationRunResult> MigrateAsync(CancellationToken ct)
+        {
+            Calls.Add("migrate");
+            return Task.FromResult(new MigrationRunResult(MigrateOk, false, MigrateOk ? null : "42703"));
+        }
+
+        public Task<bool> StartServiceAsync(CancellationToken ct)
+        {
+            Calls.Add("start");
+            return Task.FromResult(StartOk);
+        }
+
+        public Task<bool> HealthAsync(CancellationToken ct)
+        {
+            Calls.Add("health");
+            return Task.FromResult(_rolledBack ? PostRollbackHealthOk : HealthOk);
+        }
+
+        public string? ReadPosVersion()
+        {
+            Calls.Add("pos-version");
+            return Calls.Count(c => c == "pos-version") == 1 ? "4.0.0" : PosVersionAfter;
+        }
+
+        public Task<bool> InstallPosAppAsync(CancellationToken ct)
+        {
+            Calls.Add("pos-install");
+            return Task.FromResult(PosOk);
+        }
+
+        public void RestoreStoreHubTree(string stampDir)
+        {
+            Calls.Add("restore-tree");
+            if (RestoreThrows) throw new DirectoryNotFoundException("no backup");
+            _rolledBack = true;
+        }
+
+        public Task WriteManifestAsync(CancellationToken ct)
+        {
+            Calls.Add("manifest");
+            return Task.CompletedTask;
+        }
+    }
+
+    private static async Task<SilentOutcome> Run(FakeSteps steps, UpgradeStage? fault = null) =>
+        await new UpgradeOrchestrator(steps, fault).RunAsync(
+            Detected, Config(), new Progress<InstallationProgress>(_ => { }), CancellationToken.None);
+
+    [Fact]
+    public async Task RunAsync_OnTheHappyPath_ShouldSucceed()
+    {
+        var outcome = await Run(new FakeSteps());
+
+        outcome.Should().BeOfType<UpgradeSucceeded>()
+            .Which.BackupDir.Should().Be(BackupDir);
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldStopTheServiceBeforeDumping()
+    {
+        // A sale completed between the dump and the restart would exist only in the live
+        // database, and "restore the dump" is the documented recovery -- so that window
+        // would be silently discarded.
+        var steps = new FakeSteps();
+
+        await Run(steps);
+
+        steps.Calls.IndexOf("stop").Should().BeLessThan(steps.Calls.IndexOf("backup"));
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldRestoreConfigAfterDeploy()
+    {
+        // Extraction overwrites appsettings.json with the package template; step 5 is what
+        // puts the store's real config back, and it must land before migrate reads it.
+        var steps = new FakeSteps();
+
+        await Run(steps);
+
+        steps.Calls.IndexOf("deploy").Should().BeLessThan(steps.Calls.IndexOf("restore-config"));
+        steps.Calls.IndexOf("restore-config").Should().BeLessThan(steps.Calls.IndexOf("migrate"));
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldNeverCallDatabaseSetup()
+    {
+        // Enforced structurally: IUpgradeSteps exposes no such member. This test documents
+        // the invariant so a future widening of the seam is a deliberate act.
+        typeof(IUpgradeSteps).GetMethods().Select(m => m.Name)
+            .Should().NotContain(n => n.Contains("DatabaseSetup", StringComparison.OrdinalIgnoreCase));
+
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenPreflightFails_ShouldNotTouchAnything()
+    {
+        var steps = new FakeSteps { PreflightOk = false };
+
+        var outcome = await Run(steps);
+
+        outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeFalse();
+        steps.Calls.Should().NotContain("stop");
+        steps.Calls.Should().NotContain("deploy");
+    }
+
+    [Fact]
+    public async Task RunAsync_OnADowngrade_ShouldReturnDowngradeRefused()
+    {
+        var outcome = await Run(new FakeSteps { PreflightOk = false, IsDowngrade = true });
+
+        outcome.Should().BeOfType<DowngradeRefused>();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheBackupFails_ShouldStopBeforeTheMutationLine()
+    {
+        var steps = new FakeSteps { BackupOk = false };
+
+        var outcome = await Run(steps);
+
+        outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeFalse();
+        steps.Calls.Should().NotContain("deploy");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheBackupFails_ShouldPutTheServiceBack()
+    {
+        // The service was stopped above the mutation line. Leaving it down turns a
+        // harmless preflight-class failure into an outage.
+        var steps = new FakeSteps { BackupOk = false };
+
+        var failure = (UpgradeFailed)await Run(steps);
+
+        steps.Calls.Should().Contain("start");
+        failure.ServiceStarted.Should().BeTrue();
+        failure.BackupDir.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenDeployFails_ShouldRollBackAndProbeHealth()
+    {
+        var steps = new FakeSteps { DeployOk = false };
+
+        var outcome = await Run(steps);
+
+        var failure = outcome.Should().BeOfType<UpgradeFailed>().Subject;
+        failure.RolledBack.Should().BeTrue();
+        steps.Calls.Should().ContainInOrder("restore-tree", "restore-config", "start", "health");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenMigrateFails_ShouldRollBack()
+    {
+        var steps = new FakeSteps { MigrateOk = false };
+
+        var outcome = await Run(steps);
+
+        outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeTrue();
+        steps.Calls.Should().Contain("restore-tree");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenHealthFailsAfterStart_ShouldRollBack()
+    {
+        var steps = new FakeSteps { HealthOk = false };
+
+        var outcome = await Run(steps);
+
+        outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheServiceDoesNotStart_ShouldNotProbeHealthBeforeRollingBack()
+    {
+        // A dead service answers nothing; probing it just burns the retry budget.
+        var steps = new FakeSteps { StartOk = false };
+
+        var outcome = await Run(steps);
+
+        outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeTrue();
+        steps.Calls.Take(steps.Calls.IndexOf("restore-tree")).Should().NotContain("health");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheRollbackItselfIsUnhealthy_ShouldReportItRatherThanClaimRecovery()
+    {
+        var steps = new FakeSteps { DeployOk = false, PostRollbackHealthOk = false };
+
+        var failure = (UpgradeFailed)await Run(steps);
+
+        failure.RolledBack.Should().BeTrue();
+        failure.HealthOk.Should().BeFalse();
+        failure.Message.Should().Contain(BackupDir);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheBackupTreeIsGone_ShouldReportTheRollbackDidNotHappen()
+    {
+        var steps = new FakeSteps { DeployOk = false, RestoreThrows = true };
+
+        var failure = (UpgradeFailed)await Run(steps);
+
+        failure.RolledBack.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenThePosStepFails_ShouldNotRollBackTheServer()
+    {
+        // Spec section 5 row 8, confirmed by the 2026-07-26 spike: the service survives a
+        // full POS package swap, so the two are genuinely independent.
+        var steps = new FakeSteps { PosOk = false };
+
+        var failure = (UpgradeFailed)await Run(steps);
+
+        failure.RolledBack.Should().BeFalse();
+        failure.ServiceStarted.Should().BeTrue();
+        steps.Calls.Should().NotContain("restore-tree");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenThePosVersionDidNotChange_ShouldReportPosUpdatedFalse()
+    {
+        // A same-version repair exits 0 too (spike, section 12), so the exit code cannot
+        // be trusted -- only sq.version before vs after can.
+        var steps = new FakeSteps { PosVersionAfter = "4.0.0" };
+
+        var success = (UpgradeSucceeded)await Run(steps);
+
+        success.PosUpdated.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenThePosVersionChanged_ShouldReportPosUpdatedTrue()
+    {
+        var success = (UpgradeSucceeded)await Run(new FakeSteps { PosVersionAfter = "4.1.0" });
+
+        success.PosUpdated.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RunAsync_WithASimulatedDeployFailure_ShouldRollBack()
+    {
+        // The fault hook is runtime-selected so ONE 190 MB installer build serves VM
+        // cases 1 and 2 in a single session.
+        var steps = new FakeSteps();
+
+        var outcome = await Run(steps, UpgradeStage.Deploy);
+
+        outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("deploy", UpgradeStage.Deploy)]
+    [InlineData("MIGRATE", UpgradeStage.Migrate)]
+    [InlineData("start", UpgradeStage.Start)]
+    [InlineData("nonsense", null)]
+    [InlineData(null, null)]
+    public void Parse_WithVariousValues_ShouldReturnExpected(string? value, UpgradeStage? expected)
+    {
+        SimulatedFailure.Parse(value).Should().Be(expected);
+    }
+}

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeOrchestratorTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeOrchestratorTests.cs
@@ -51,9 +51,17 @@ public class UpgradeOrchestratorTests
             return Task.FromResult(StopOk);
         }
 
+        public bool BackupThrowsCancellation { get; init; }
+
         public Task<BackupResult> BackupAsync(string pgDump, string conn, CancellationToken ct)
         {
             Calls.Add("backup");
+
+            if (BackupThrowsCancellation)
+            {
+                throw new OperationCanceledException("watchdog fired during pg_dump");
+            }
+
             return Task.FromResult(new BackupResult(BackupOk, BackupDir, true,
                 BackupOk ? null : "pg_dump failed"));
         }
@@ -64,9 +72,17 @@ public class UpgradeOrchestratorTests
             return new ConfigSnapshotHandle(() => Calls.Add("restore-config"));
         }
 
+        public bool DeployThrowsCancellation { get; init; }
+
         public Task<bool> DeployAsync(CancellationToken ct)
         {
             Calls.Add("deploy");
+
+            if (DeployThrowsCancellation)
+            {
+                throw new OperationCanceledException("watchdog fired mid-deploy");
+            }
+
             return Task.FromResult(DeployOk);
         }
 
@@ -226,6 +242,23 @@ public class UpgradeOrchestratorTests
     }
 
     [Fact]
+    public async Task RunAsync_WhenTheWatchdogFiresDuringTheBackup_ShouldPutTheStoreBackUp()
+    {
+        // Above the mutation line a failure is supposed to be a non-event, but the service is
+        // already stopped by this point. Letting the timeout escape leaves the till DOWN with
+        // nothing mutated and nothing restarted - the invariant broken for no benefit.
+        var steps = new FakeSteps { BackupThrowsCancellation = true };
+
+        var failure = (UpgradeFailed)await Run(steps);
+
+        failure.RolledBack.Should().BeFalse();
+        failure.ServiceStarted.Should().BeTrue();
+        steps.Calls.Should().Contain("start");
+        steps.Calls.Should().NotContain("deploy");
+        steps.Calls.Should().NotContain("restore-tree");
+    }
+
+    [Fact]
     public async Task RunAsync_WhenDeployFails_ShouldRollBackAndProbeHealth()
     {
         var steps = new FakeSteps { DeployOk = false };
@@ -268,6 +301,52 @@ public class UpgradeOrchestratorTests
 
         outcome.Should().BeOfType<UpgradeFailed>().Which.RolledBack.Should().BeTrue();
         steps.Calls.Take(steps.Calls.IndexOf("restore-tree")).Should().NotContain("health");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheWatchdogFiresMidDeploy_ShouldStillRollBack()
+    {
+        // The 45-minute watchdog can fire below the mutation line on a slow store PC. Letting
+        // cancellation escape leaves new binaries, a stopped service and no rollback - the
+        // worst state this design exists to prevent.
+        var steps = new FakeSteps { DeployThrowsCancellation = true };
+
+        var failure = (UpgradeFailed)await new UpgradeOrchestrator(steps).RunAsync(
+            Detected, Config(), new Progress<InstallationProgress>(_ => { }), CancellationToken.None);
+
+        failure.RolledBack.Should().BeTrue();
+        failure.Message.Should().Contain("timed out");
+        steps.Calls.Should().ContainInOrder("restore-tree", "restore-config", "start", "health");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheTokenIsAlreadyCancelled_ShouldStillCompleteTheRollback()
+    {
+        // Rolling back with the token that just fired cannot work: every await would abort
+        // immediately. The recovery has to be non-cancellable.
+        var steps = new FakeSteps { DeployThrowsCancellation = true };
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var failure = (UpgradeFailed)await new UpgradeOrchestrator(steps).RunAsync(
+            Detected, Config(), new Progress<InstallationProgress>(_ => { }), cts.Token);
+
+        failure.RolledBack.Should().BeTrue();
+        failure.ServiceStarted.Should().BeTrue();
+        failure.HealthOk.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenPreflightFails_ShouldProveTheStoreIsStillServing()
+    {
+        // Every other failure path probes. Claiming HEALTH=ok without asking is exactly the
+        // unverified-recovery claim the rollback probe exists to prevent.
+        var steps = new FakeSteps { PreflightOk = false, HealthOk = false };
+
+        var failure = (UpgradeFailed)await Run(steps);
+
+        steps.Calls.Should().Contain("health");
+        failure.HealthOk.Should().BeFalse();
     }
 
     [Fact]
@@ -324,6 +403,20 @@ public class UpgradeOrchestratorTests
         var success = (UpgradeSucceeded)await Run(new FakeSteps { PosVersionAfter = "4.1.0" });
 
         success.PosUpdated.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RunAsync_WithASimulatedStopFailure_ShouldLeaveTheStoreTrading()
+    {
+        // The fault hook exists to test recovery, so it must not itself strand a VM (or a real
+        // store, if anyone ever pastes the flag) with the service down.
+        var steps = new FakeSteps();
+
+        var failure = (UpgradeFailed)await Run(steps, UpgradeStage.Stop);
+
+        failure.ServiceStarted.Should().BeTrue();
+        steps.Calls.Should().Contain("start");
+        steps.Calls.Should().NotContain("deploy");
     }
 
     [Fact]

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeOrchestratorTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradeOrchestratorTests.cs
@@ -22,6 +22,7 @@ public class UpgradeOrchestratorTests
         public bool PreflightOk { get; init; } = true;
         public string PreflightReason { get; init; } = "preflight failed";
         public bool IsDowngrade { get; init; }
+        public bool StopOk { get; init; } = true;
         public bool BackupOk { get; init; } = true;
         public bool DeployOk { get; init; } = true;
         public bool MigrateOk { get; init; } = true;
@@ -47,7 +48,7 @@ public class UpgradeOrchestratorTests
         public Task<bool> StopServiceAsync(CancellationToken ct)
         {
             Calls.Add("stop");
-            return Task.FromResult(true);
+            return Task.FromResult(StopOk);
         }
 
         public Task<BackupResult> BackupAsync(string pgDump, string conn, CancellationToken ct)
@@ -181,6 +182,22 @@ public class UpgradeOrchestratorTests
         var outcome = await Run(new FakeSteps { PreflightOk = false, IsDowngrade = true });
 
         outcome.Should().BeOfType<DowngradeRefused>();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenTheServiceWillNotStop_ShouldNotDeployOverLockedBinaries()
+    {
+        // The locked-DLL failure this whole design exists to fix. Deploying while StoreHub
+        // still holds its own DLLs is precisely how the original upgrade attempt died, so a
+        // failed stop has to be terminal, not advisory.
+        var steps = new FakeSteps { StopOk = false };
+
+        var failure = (UpgradeFailed)await Run(steps);
+
+        failure.RolledBack.Should().BeFalse();
+        failure.ServiceStarted.Should().BeTrue();
+        steps.Calls.Should().NotContain("backup");
+        steps.Calls.Should().NotContain("deploy");
     }
 
     [Fact]

--- a/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradePreflightTests.cs
+++ b/tests/IndyPOS.Bootstrapper.Tests/Upgrade/UpgradePreflightTests.cs
@@ -1,0 +1,119 @@
+using FluentAssertions;
+using IndyPOS.Bootstrapper.Upgrade;
+
+namespace IndyPOS.Bootstrapper.Tests.Upgrade;
+
+public class UpgradePreflightTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "indypos-preflight-" + Guid.NewGuid().ToString("N"));
+
+    public UpgradePreflightTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CheckVersions_WhenTheInstallerIsNewer_ShouldPass()
+    {
+        var (ok, _, isDowngrade) = UpgradePreflight.CheckVersions("4.0.0", "4.1.0");
+
+        ok.Should().BeTrue();
+        isDowngrade.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CheckVersions_WithTheSameVersion_ShouldPassAsARepair()
+    {
+        // Directory.Build.props pins the version and needs a manual bump, so a
+        // same-version run is the common case during development. The 2026-07-26 spike
+        // measured it as a safe 2.5s repair.
+        var (ok, _, isDowngrade) = UpgradePreflight.CheckVersions("4.0.0", "4.0.0");
+
+        ok.Should().BeTrue();
+        isDowngrade.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CheckVersions_WhenTheInstallerIsOlder_ShouldRefuse()
+    {
+        var (ok, reason, isDowngrade) = UpgradePreflight.CheckVersions("4.1.0", "4.0.0");
+
+        ok.Should().BeFalse();
+        isDowngrade.Should().BeTrue();
+        reason.Should().Contain("4.1.0");
+    }
+
+    [Fact]
+    public void CheckVersions_WithAnUnreadableInstalledVersion_ShouldPass()
+    {
+        // A manifest without installVersion is decorative, not a blocker.
+        UpgradePreflight.CheckVersions(null, "4.0.0").Ok.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LocatePgDump_WhenTheManifestPathIsGood_ShouldUseIt()
+    {
+        var bin = Path.Combine(_dir, "18", "bin");
+        Directory.CreateDirectory(bin);
+        File.WriteAllText(Path.Combine(bin, "pg_dump.exe"), "");
+
+        UpgradePreflight.LocatePgDump(bin, expectedMajor: 18)
+            .Should().Be(Path.Combine(bin, "pg_dump.exe"));
+    }
+
+    // "This machine has no other PostgreSQL." Without this seam the two tests below assert
+    // nothing on a box that happens to have PostgreSQL 18 installed — which both this dev
+    // box and the test VM do.
+    private static string? NoInstalledPostgres() => null;
+
+    [Fact]
+    public void LocatePgDump_WhenTheManifestPathIsStale_ShouldReturnNullRatherThanAWrongMajor()
+    {
+        // FindPostgresInstallation probes 18 -> 17 -> 16; a pg_dump from a different
+        // major can refuse the dump outright, so assert the major rather than guess.
+        var bin = Path.Combine(_dir, "16", "bin");
+        Directory.CreateDirectory(bin);
+        File.WriteAllText(Path.Combine(bin, "pg_dump.exe"), "");
+
+        UpgradePreflight.LocatePgDump(bin, expectedMajor: 18, NoInstalledPostgres).Should().BeNull();
+    }
+
+    [Fact]
+    public void LocatePgDump_WhenTheManifestPathDoesNotExist_ShouldReturnNull()
+    {
+        UpgradePreflight.LocatePgDump(Path.Combine(_dir, "nope"), expectedMajor: 18, NoInstalledPostgres)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void LocatePgDump_WhenTheManifestPathIsStaleButPostgresIsFound_ShouldUseTheDiscoveredPath()
+    {
+        // The reason the fallback exists at all: a manifest written before a PostgreSQL
+        // move still names the old directory.
+        var discovered = Path.Combine(_dir, "18", "bin");
+        Directory.CreateDirectory(discovered);
+        File.WriteAllText(Path.Combine(discovered, "pg_dump.exe"), "");
+
+        UpgradePreflight.LocatePgDump(Path.Combine(_dir, "nope"), expectedMajor: 18, () => discovered)
+            .Should().Be(Path.Combine(discovered, "pg_dump.exe"));
+    }
+
+    [Fact]
+    public void LocatePgDump_WhenTheDiscoveredPathIsAWrongMajor_ShouldStillReturnNull()
+    {
+        // The fallback probes 18 -> 17 -> 16, so it can hand back a major we did not ask
+        // for. Accepting it would dump with a pg_dump that may refuse the server outright.
+        var discovered = Path.Combine(_dir, "17", "bin");
+        Directory.CreateDirectory(discovered);
+        File.WriteAllText(Path.Combine(discovered, "pg_dump.exe"), "");
+
+        UpgradePreflight.LocatePgDump(Path.Combine(_dir, "nope"), expectedMajor: 18, () => discovered)
+            .Should().BeNull();
+    }
+}

--- a/tests/IndyPOS.MigrationTool.Tests/LegacyPaymentTypeMapTests.cs
+++ b/tests/IndyPOS.MigrationTool.Tests/LegacyPaymentTypeMapTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using IndyPOS.Application.Common.Constants;
+using IndyPOS.MigrationTool.Services;
+
+namespace IndyPOS.MigrationTool.Tests;
+
+/// <summary>
+/// The legacy PaymentTypeId -> catalogue Code mapping, verified against the ids and Thai labels
+/// in the real store database (.planning/indypos-overhaul/sqlite_database/Store.db).
+/// <para>The previous mapping was shifted: id 2 (ลงบัญชี / PayLater) was written as "Card",
+/// id 3 (บัตรสวัสดิการแห่งรัฐ / WelfareCard) as "Transfer", id 5 (โอนเข้าบัญชี / MoneyTransfer) as
+/// "WelfareCard", and the campaigns as "Other" - roughly 15% of ฿21.2M attributed to the wrong
+/// method, with ฿836k of customer credit invisible to PayLater tracking.</para>
+/// </summary>
+public class LegacyPaymentTypeMapTests
+{
+    [Theory]
+    [InlineData(1, PaymentMethodCodes.Cash)]          // เงินสด
+    [InlineData(2, PaymentMethodCodes.PayLater)]      // ลงบัญชี
+    [InlineData(3, PaymentMethodCodes.WelfareCard)]   // บัตรสวัสดิการแห่งรัฐ
+    [InlineData(4, PaymentMethodCodes.M33WeLove)]     // ม.33
+    [InlineData(5, PaymentMethodCodes.MoneyTransfer)] // โอนเข้าบัญชี
+    [InlineData(7, PaymentMethodCodes.FiftyFifty)]    // คนละครึ่ง
+    [InlineData(8, PaymentMethodCodes.WeWin)]         // เราชนะ
+    public void ToCode_ForEachLegacyPaymentType_ShouldReturnTheCatalogueCode(int legacyId, string expected)
+    {
+        LegacyPaymentTypeMap.ToCode(legacyId).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ToCode_ForInstallments_ShouldReturnNull()
+    {
+        // id 6 (ผ่อนชำระ) has no catalogue equivalent: instalments are their own table, and the
+        // real store data has zero Payment rows for it.
+        LegacyPaymentTypeMap.ToCode(6).Should().BeNull();
+    }
+
+    [Fact]
+    public void ToCode_ForAnUnknownId_ShouldReturnNullRatherThanGuess()
+    {
+        // The old code funnelled anything unrecognised into "Other", which is not a catalogue
+        // code - money quietly attributed to a method that does not exist.
+        LegacyPaymentTypeMap.ToCode(99).Should().BeNull();
+    }
+
+    [Fact]
+    public void EveryMappedCode_ShouldExistInTheCatalogue()
+    {
+        // Guards the drift that caused this: a code the catalogue does not define cannot be
+        // resolved by reports, the payment buttons, or the refund gate.
+        var catalogue = new[]
+        {
+            PaymentMethodCodes.Cash, PaymentMethodCodes.MoneyTransfer, PaymentMethodCodes.WelfareCard,
+            PaymentMethodCodes.PayLater, PaymentMethodCodes.M33WeLove, PaymentMethodCodes.FiftyFifty,
+            PaymentMethodCodes.WeWin
+        };
+
+        LegacyPaymentTypeMap.All.Values.Should().OnlyContain(code => catalogue.Contains(code));
+    }
+
+    [Fact]
+    public void All_ShouldNotMapTwoLegacyIdsToTheSameCode()
+    {
+        // A shifted mapping shows up here too: collisions mean one method absorbed another's money.
+        LegacyPaymentTypeMap.All.Values.Should().OnlyHaveUniqueItems();
+    }
+}

--- a/tests/IndyPOS.MigrationTool.Tests/RealDatabaseMigrationTests.cs
+++ b/tests/IndyPOS.MigrationTool.Tests/RealDatabaseMigrationTests.cs
@@ -41,6 +41,58 @@ public class RealDatabaseSchemaTests
     }
 
     [Fact]
+    public async Task RealDatabase_EveryPaymentTypeInUse_ShouldMapToACatalogueCode()
+    {
+        // The guard the scrambled mapping needed. Reads the ids this store actually uses and
+        // requires each to resolve, so a store whose data contains an id the map does not know
+        // fails here rather than during a cutover - or worse, silently, as "Other".
+        if (!SampleDatabaseExists())
+        {
+            return;
+        }
+
+        await using var conn = new SQLiteConnection($"Data Source={RealDbPath};Version=3;");
+        await conn.OpenAsync();
+
+        var idsInUse = (await conn.QueryAsync<long>(
+            "SELECT DISTINCT PaymentTypeId FROM Payment ORDER BY PaymentTypeId")).ToList();
+
+        idsInUse.Should().NotBeEmpty("the sample store has payment history");
+
+        var unmapped = idsInUse
+            .Where(id => Services.LegacyPaymentTypeMap.ToCode((int)id) is null)
+            .ToList();
+
+        unmapped.Should().BeEmpty(
+            "every legacy payment type present in real store data must map to a catalogue code");
+    }
+
+    [Fact]
+    public async Task RealDatabase_PaymentTypeLabels_ShouldStillMatchTheAssumedMapping()
+    {
+        // Pins the mapping to the store's OWN lookup table rather than to a translation done
+        // once in a review. If a label ever moves to a different id, this fails loudly.
+        if (!SampleDatabaseExists())
+        {
+            return;
+        }
+
+        await using var conn = new SQLiteConnection($"Data Source={RealDbPath};Version=3;");
+        await conn.OpenAsync();
+
+        var labels = (await conn.QueryAsync<(long Id, string Type)>(
+                "SELECT Id, Type FROM PaymentType"))
+            .ToDictionary(r => (int)r.Id, r => r.Type);
+
+        labels[1].Should().Be("เงินสด");                    // Cash
+        labels[2].Should().Be("ลงบัญชี");                    // PayLater
+        labels[3].Should().Be("บัตรสวัสดิการแห่งรัฐ");        // WelfareCard
+        labels[5].Should().Be("โอนเข้าบัญชี");                // MoneyTransfer
+        labels[7].Should().Be("คนละครึ่ง");                  // FiftyFifty
+        labels[8].Should().Be("เราชนะ");                     // WeWin
+    }
+
+    [Fact]
     public async Task RealDatabase_HasData()
     {
         // Skip if sample database doesn't exist


### PR DESCRIPTION
## What

Adds an **in-place upgrade path** to the installer, and fixes the SQLite→PostgreSQL payment mapping found while validating it.

Re-running `IndyPOS-Setup.exe` on a live store used to fail two ways: locked StoreHub DLLs, and `DatabaseSetup` overwriting the store's real `appsettings.json` with the package template. The fix is a **separate upgrade algorithm**, not a flag on the fresh one.

Spec: `docs/superpowers/specs/2026-07-26-installer-upgrade-support-design.md`
Plan: `docs/superpowers/plans/2026-07-26-installer-upgrade-support.md` (all 14 tasks)

## The load-bearing idea: a mutation line

- **Steps 0–3** (preflight, stop, backup) touch nothing — a failure there is a non-event and the store keeps trading.
- **Steps 4–7** (deploy, config restore, migrate, start) **roll back**, and the rollback *proves* recovery with a health probe. Starting a service is not evidence it came back.
- **Step 8** (POS app) does not roll back — the server is upgraded and serving, and a VM spike confirmed the POS swap cannot disturb it.

`DatabaseSetup` never runs on an upgrade, which is what makes the config-clobbering bug *disappear* rather than be worked around. `IUpgradeSteps` deliberately exposes no such member, and a test asserts it.

`FreshInstallOrchestrator` is **frozen**: it differs from `development` only by the rename, doc comments, and delegations to the extracted shared units (`ServiceControl`, `StoreHubPayload`, `MigrationRunner`, `HealthProbe`). No reordering, no new conditionals.

## VM validation (Hyper-V, real Postgres)

| Case | Result |
|---|---|
| Happy upgrade 4.0.0 → 4.1.0 | **PASS 22/22**, `POS_UPDATED=true`, config + `Store:Id`/`Store:Type` preserved, conn still `DPAPI:`, backup 483-file tree readable |
| Forced mid-upgrade failure | **PASS** — `ROLLED_BACK=true`, service Running, health 200, and `payment_method` still pre-migration, proving the migration is what distinguishes the two |
| Fresh-install regression | **PASS 18/18**, `MODE=fresh` — the frozen path is unregressed |

## 7 bugs the VM gate and review caught

1. Upgrade failures reported **no reason** anywhere → `REASON=`, scrubbed (pg_dump/Npgsql quote the connection string back).
2. `StopServiceAsync`'s result was **discarded** → deployed over locked DLLs, the original failure. Now terminal.
3. **Backup directories were locked with non-inheritable ACEs.** Guest SDDL: stamp `D:PAI(A;;FA;;;SY)(A;;FA;;;BA)`, tree `D:AI` — an *empty DACL*. Protecting a directory drops its inherited ACEs and Windows recomputes its children's, so a freshly copied 483-file tree became readable by nobody, and `LockTree` then walked it. New `TryRestrictDirectoryPermissions` uses `ContainerInherit|ObjectInherit`; the per-file walk is gone (failure site + 483 redundant ACL writes). Also unbreaks `Prune`.
4. A **timeout in the mutating region skipped rollback entirely**; recovery now runs on `CancellationToken.None`, because rolling back with the token that just fired cannot work.
5. A timeout **during the backup left the till down** — above the mutation line, but the service was already stopped.
6. Prerequisite installs **discarded `.Success`**, throwing away the reason they run early: a missing runtime would surface as a dead service *after* the swap.
7. The **harness could report a green run that never happened** — a malformed arg list crashed the installer headless, and the marker read then graded it against an `install-*.log` baked into the snapshot.

## Payment mapping fix (`6c63a6d`)

Found by checking drift against the real store DB. The legacy `PaymentTypeId` mapping was **shifted, not misnamed**: `PayLater`→`"Card"`, `WelfareCard`→`"Transfer"`, `MoneyTransfer`→`"WelfareCard"`, campaigns→`"Other"`. Only Cash was right — ~15% of ฿21.2M attributed to the wrong method, and `Card`/`Transfer`/`Other` aren't catalogue codes at all. Worst case: ฿836k of PayLater customer credit invisible to the ledger.

Nothing could have caught it — the verifier compared only row counts and `SUM(Invoice.Total)`, which reconcile perfectly under a scramble, and **no test anywhere creates a `Payment` table**.

Now: one shared `LegacyPaymentTypeMap`, the migrator refuses unmapped rows instead of guessing, and the verifier compares count **and amount per method**, with guards against the real database.

## Test state

Release build 0 errors · Bootstrapper 223/8-skip · MigrationTool **36** · Migration 15 · StoreHub integration **76** · Application 274 · Domain 8

## Not done / owed

- **PR #52 visual smoke** — payment-button caption clipping on `บัตรสวัสดิการแห่งรัฐ` needs a human at `vmconnect`.
- **v3.7.0 coexistence** is covered by a unit test + the older Stage 3 dev-box run, but not re-validated against a real v3 footprint on this branch.
- `tests/IndyPOS.Migration.Tests` builds a SQLite schema that matches no real store — flagged in STATUS.md, not touched here.
