### PR TITLE
docs: record post-Epic-1 findings and refresh the roadmap

### DIFF
--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -16,16 +16,32 @@ history intact — not cloud infrastructure.
 
 | # | Epic | Status | Why this order |
 |---|------|--------|----------------|
-| 1 | **Product categories + MimyShop** | 📋 Spec pending | The migration needs a category model to map into. Blocks 2 |
-| 2 | **SQLite → PostgreSQL migration hardening** | 📋 Spec pending | 6 known defects + 3 divergent legacy schemas. The risky half of the rollout |
+| 1 | **Product categories + MimyShop** | ✅ **SHIPPED 2026-07-31 (PR #55)** | The migration needs a category model to map into. Blocked 2 |
+| 2 | **SQLite → PostgreSQL migration hardening** | 📋 **NEXT** — spec pending | 6 open defects + 3 divergent legacy schemas. The risky half of the rollout |
 | 3 | **Store rollout** (fresh v4 install + migrate, per store) | ⏳ Blocked by 2 | Where the business value lands: stores off a 3.7.0-era system |
 | 4 | **Epic I: Cloud infrastructure** | 🔴 Not started | Additive. No longer on the critical path — see "Legacy history" below |
 | 5 | **Epic MCP: agent-facing API** | 🔴 Not started | Depends on 4 |
+| 6 | **Store-type panel consolidation** (3 forked apps → 1) | 🔵 **NEW candidate** — analysed, not spec'd | Retires the MimyMart/MimyShop forks. Scheduled after 3; see `findings-2026-07-31.md` §B |
 
 **Legacy history reaches the cloud for free.** After migration each store's own v4 PostgreSQL holds
 its full legacy history, so ordinary sync carries it upward. There is no separate legacy→cloud
 pipeline to build. The consequence is that "the cloud needs legacy history" is not a new component —
 it is a **correctness requirement on epic 2**.
+
+> **📎 Read alongside this plan:
+> [`findings-2026-07-31.md`](findings-2026-07-31.md)** — cross-repo analysis produced after Epic 1
+> merged. It carries material this plan only summarises:
+> **§A** entity identity (defects 8-9 below, and the UUIDv7 window) ·
+> **§B** the three-app consolidation, measured, incl. **defect B3** — the sales report's
+> hardcoded campaign labels defeat Epic M, so a new government campaign collects money that
+> never appears in the report ·
+> **§C** MimyShop's service requirement, its two blockers, and the pinned service barcodes.
+>
+> A pattern runs through all three: **v4 repeatedly makes something data-driven and leaves one
+> hardcoded remnant behind.** Epic M catalogued payment methods but left four hardcoded report
+> labels; Epic 1 catalogued categories but the `Service` kind is locked out by a flag doing
+> double duty; `SalePanel` gates hardware by feature flag but hardcodes its template barcodes.
+> Worth naming explicitly when epic 6 is spec'd.
 
 ---
 
@@ -42,7 +58,10 @@ per-task ledger in `.superpowers/sdd/progress.md`.
 | **Epic M: data-driven payment methods** | `payment_method` catalogue replaces the hardcoded `PaymentType` enum; store-type gating; `PaymentMethodKind` taxonomy (`Standard`/`GovernmentCampaign`/`Special`); admin management screen; fixed the silent-GeneralHardware default | 2026-07-19 |
 | **Product-type restriction** | `GET /store/features`; server rejects Hardware products on general-only stores; WinForms hides Hardware affordances | 2026-07-19 |
 | **Cosmetic-minors batch** | Kind taxonomy re-spec, Thai Kind labels, grid refresh, payment-button icons, `PUT /products/{id}` → 404, one-shot features-error dialog | PR #52 |
-| **Installer upgrade support** | In-place upgrade with verified rollback. See below | PR #54 (open) |
+| **Installer upgrade support** | In-place upgrade with verified rollback. See below | PR #54 |
+| **Epic 1: product categories + MimyShop** | Store-scoped `product_category` catalogue replaces the two-value enum; `StoreType.MimyShop`, `CoffeeShop` retired with value 3 reserved; `GET /product-categories`; create/update gate on category `Kind`. Verified on 3 fresh VM installs (16/17/10 rows) + live UI | PR #55 |
+| **Global UI error handling** | No unhandled WinForms exception can show the default English crash dialog or go unlogged. Thai message + `ERR-XXXX` reference code, same code in the log. Three framework channels wired. `IndyPOS.Windows.Forms.Tests` 0 → 19 tests. VM-verified end to end | PR #56 |
+| **EAN-13 barcode fix** | The generator emitted 9 digits (`{StoreCode}{Sequence:D8}`), which EAN-13 cannot encode, so every generated barcode crashed the add-product dialog. Now `200 + {StoreCode:D2} + {Sequence:D7}` + check digit, with two real shelf labels as test vectors | PR #55 |
 
 ### Installer upgrade support (PR #54, open)
 
@@ -60,7 +79,7 @@ that never happened, by grading a crashed run against an `install-*.log` baked i
 
 ---
 
-## Epic 1: Product categories + MimyShop 📋
+## Epic 1: Product categories + MimyShop ✅ SHIPPED (PR #55, 2026-07-31)
 
 **Problem.** `ProductCategory { GeneralGoods = 10, Hardware = 50 }` is hardcoded, and `Product.Category`
 stores the enum *name*. The real stores have 16 / 11 / 17 fine-grained Thai categories, and **the ids
@@ -125,7 +144,19 @@ Legacy payment id 6 `ผ่อนชำระ` is dead with them.
 | 4 | `ParseDate` does `SpecifyKind(..., Utc)` on `datetime('now','localtime')` values | **Every timestamp 7h off**; corrupts all daily/monthly totals | ❌ |
 | 5 | `Category = product.Category?.ToString()` writes the raw numeric id | All products uncategorised; breaks the Hardware gate and pickers | ❌ (needs Epic 1) |
 | 6 | `InvoiceProduct` selects 7 of 17 columns, dropping `OriginalUnitPrice`, `GroupPrice`, `IsGroupProduct`, `Note`, `Priority` | **165,690 of 325,780 line items (51%)** were discounted; the record is lost | ❌ |
-| 7 | v4 `Core.Product` has no `IsTrackable`; legacy does (21/7/1 non-trackable products) | Services would be stock-tracked and inventory-deducted | ❌ |
+| 7 | v4 `Core.Product` has no `IsTrackable`; legacy does (21/7/1 non-trackable products) | Services would be stock-tracked and inventory-deducted | ❌ **priority raised** |
+| 8 | **Legacy ids are not preserved** on products, invoices, invoice lines or payments (only `StoreUser.LegacyUserId` is) | The migration cannot be re-run idempotently, and a v4 row cannot be reconciled against its SQLite source | ❌ **new** |
+| 9 | `LegacyIdHelper` is dead code that maps the same legacy id to the same Guid **in every store** | Latent cross-store collision once Epic I syncs three shops into one cloud. Delete it | ❌ **new** |
+
+**Defect 7 reframed (2026-07-31).** It is not merely "legacy has a field we omitted" — the legacy
+sale path **already filters on `IsTrackable` before touching stock, in production**
+(`MimyShop SaleService.cs:413-418`). v4 dropped a working guard, and
+`CompleteSaleCommandHandler` now deducts stock for every line unconditionally. This is the
+difference between v4 supporting services at all and v4 driving service stock permanently
+negative, so it is no longer only a migration concern.
+
+See `findings-2026-07-31.md` §A for defects 8-9 and the UUIDv7 recommendation (worth adopting
+while v4 has never run a store — that window closes at the first migration).
 
 v4's `PayLater` entity is already a field-for-field match for the legacy table
 (`PaymentId, Description, PayLaterAmount, PaidAmount, IsCompleted` + calculated `RemainingAmount`),

--- a/.planning/indypos-overhaul/findings-2026-07-31.md
+++ b/.planning/indypos-overhaul/findings-2026-07-31.md
@@ -1,0 +1,526 @@
+# Findings — 2026-07-31
+
+> **Status:** settled 2026-07-31. Folded into `PLAN.md` (epic 2 defects 7-9, new epic 6).
+> Sections A-C are complete; §C1-C6 carry Pond's confirmed domain knowledge about the
+> per-store-type panels.
+
+Two questions were raised after Epic 1 and the UI error net merged (#55, #56). Both were
+investigated against the real code rather than answered from memory. Recorded here because the
+conclusions change Epic 2's scope and add a new epic candidate.
+
+---
+
+## A. Entity identity — legacy int → UUID
+
+### The premise was already satisfied
+
+Every v4 entity already has `Guid Id` on a `uuid` column with a `gen_random_uuid()` default
+(all 8 `*Configuration.cs` files), and `SqliteMigrationService` already assigns
+`Guid.NewGuid()` in **9** places. **There is no int→UUID migration outstanding.** Capacity was
+never the constraint.
+
+### A1. `LegacyIdHelper` is dead code, and it is a trap — DELETE IT
+
+`src/IndyPOS.Application/Common/Helpers/LegacyIdHelper.cs`. Verified **zero callers** across
+`src/` and `tests/`.
+
+```csharp
+private static readonly byte[] NamespaceBytes = { 'I','n','d','y','P','O','S','-','P','r','o','d' };
+Array.Copy(NamespaceBytes, 0, combined, 0, 12);   // identical for every store
+Array.Copy(idBytes, 0, combined, 12, 4);          // legacy id
+```
+
+Two defects:
+
+1. **Not store-scoped.** Legacy product id 5 in Rungrat and legacy product id 5 in MimyShop
+   produce the *identical* Guid. Latent today; a real collision once Epic I syncs three stores
+   into one cloud.
+2. **Not a valid UUID of any version** — the version/variant nibbles are ASCII bytes from the
+   prefix, so tooling that reasons about UUID versions will misread it.
+
+Risk is that someone reaches for it during Epic 2 believing it is the sanctioned helper. If a
+deterministic legacy→Guid mapping is ever wanted, it must hash **store id + entity type +
+legacy id**, not a fixed 12-byte prefix.
+
+### A2. Legacy ids are not preserved — the actual gap (Epic 2)
+
+Only `StoreUser` keeps one: `LegacyUserId` (`int`, UNIQUE, with `GetByLegacyIdAsync`).
+Products, invoices, invoice lines and payments each get a fresh random Guid with **no link back
+to the legacy row**.
+
+Consequences:
+
+- The migration **cannot be re-run idempotently** — a second run duplicates everything.
+- A v4 invoice **cannot be reconciled** against its SQLite source, so a partial or bad
+  migration cannot be diagnosed or repaired incrementally.
+
+With 6 open migration defects, re-running is near-certain. Adding a legacy-id column per
+migrated entity, following the `StoreUser` pattern, is worth more than any UUID-version change.
+
+### A3. UUIDv7 — recommended, and the window is closing
+
+`Guid.CreateVersion7()` exists in .NET 9+ (this solution is .NET 10) and `uuidv7()` in
+PostgreSQL 18 (the version in use), so no custom code is needed.
+
+- **Why:** random v4 keys scatter B-tree inserts. v7 is time-ordered, which matters when bulk
+  loading 139,680 invoices and 325,780 line items, and for every insert afterwards.
+- **Forward-only safe:** changing a column DEFAULT is additive — no rename, drop, or narrowing.
+- **Why now:** **v4 has never run a store**, so there is no existing data to become
+  inconsistent with. That window closes the day the first shop migrates.
+- **Cost:** v7 embeds a creation timestamp. Irrelevant for a POS.
+
+**Scope honestly.** This is a performance nicety. It must not displace defect 4 (every migrated
+timestamp 7 hours off), which silently corrupts every daily and monthly total.
+
+---
+
+## B. Per-store-type panels — three forked apps
+
+### The actual situation
+
+The three store types are three **separate repositories**, not one app with variants:
+
+| Store type | Repo |
+|---|---|
+| GeneralHardware | `C:\personal\IndyPOS` (this one) |
+| MimyShop | `C:\personal\MimyShop` |
+| Minimart | `C:\personal\MimyMart` |
+
+So the question "assign the right panel per store type at run-time" is really **consolidating
+three forked WinForms apps into one**.
+
+Note it is *startup*-time, not run-time: `Store:Type` is written at install and never changes
+for that machine, so selection happens once when the host is built.
+
+### Measured divergence
+
+| Comparison | Diff lines | Files |
+|---|---|---|
+| MimyMart ↔ MimyShop `SalePanel` | 41 | 373 / 403 |
+| IndyPOS ↔ MimyShop `SalePanel` | 143 | 450 / 403 |
+| IndyPOS ↔ MimyShop `SalesReportPanel` | 108 | 145 / 93 |
+
+### B1. `SalePanel` — IndyPOS is *ahead*, not different. No per-type panel needed.
+
+IndyPOS's extra ~143 lines are Epic M plus the product-type restriction. It already does
+exactly what per-store-type behaviour requires:
+
+```csharp
+var features = await _storeHubClient.GetStoreFeaturesAsync();
+AddHardwareProductButton.Visible = features.MultipleProductTypesEnabled;
+```
+
+plus catalogue-driven payment names via `GetOfferablePaymentMethodsAsync()` and
+`ResolvePaymentTypeDisplay` (code-based, with a legacy `PaymentTypeId` fallback).
+
+MimyMart/MimyShop still use the hardcoded `_paymentTypeDictionary[payment.PaymentTypeId]`.
+**Their panels are pre-Epic-M code, not a different store type's design.** MimyMart ↔ MimyShop
+differ by only 41 lines — the rebrand plus the two payment types added to MimyShop.
+
+Consolidation for the till = adopt IndyPOS's panel, retire the forks.
+
+### B2. `SalesReportPanel` — the real work, but still one panel
+
+MimyShop shows 3 money labels; IndyPOS shows ~17. The difference is **not** arbitrary layout —
+it decomposes onto things already modelled:
+
+| IndyPOS-only rows | Should be driven by |
+|---|---|
+| `GeneralGoodsSaleLabel`, `HardwareSaleLabel`, `ArTotalForHardwareProductsLabel`, `HardwareProductsTotalWithoutArLabel` | `MultipleProductTypesEnabled` — flag exists |
+| `ArTotalLabel`, `CompletedArLabel`, `IncompleteArLabel`, `OverallSaleExcluedIncompleteArLabel` | `PayLaterEnabled` — flag exists |
+| `PaymentByKlkLabel`, `PaymentByM33Label`, `PaymentByWeWinLabel`, `PaymentByWelfareCardLabel` | the `payment_method` catalogue — **see B3** |
+
+Recommended shape: **one panel**, sections gated by the two existing flags, and the payment
+breakdown generated from the catalogue. That is less code than today, not more.
+
+Also noted: MimyShop derives cash as `invoiceTotal - paymentsSummary.NonCashTotal` (the
+corrected form, after a latent bug found during the MimyShop work). Any consolidation must
+carry that form forward, not the older `invoiceTotal - moneyTransferTotal`.
+
+### B3. 🆕 DEFECT — the sales report has hardcoded campaign labels, defeating Epic M
+
+`SalesReportPanel` has a fixed label per campaign (`PaymentByKlkLabel`, `PaymentByM33Label`,
+`PaymentByWeWinLabel`, `PaymentByWelfareCardLabel`).
+
+Epic M made payment methods data-driven precisely so a new government campaign is a DB row
+with no redeploy. But **a campaign added as a row today gets no line in the sales report** — the
+money is collected and is invisible in the report that the owner actually reads.
+
+Same class of bug as the hardcoded category enum Epic 1 just removed. Not previously recorded.
+
+### B4. Open question — can the layout collapse?
+
+Unresolved from code alone: whether IndyPOS's ~17 report labels are absolutely positioned (so
+hiding the hardware and AR groups leaves holes) or sit in containers that reflow. Screenshots
+per store type will settle it. This determines whether B2 is a re-layout or just visibility
+toggles.
+
+### B5. Constraints for whoever implements this
+
+- `MainForm`'s constructor takes **seven panels by concrete type**; panels are registered as
+  concrete singletons (`AddSingleton<SalesReportPanel>()`). Introducing interfaces there is the
+  actual refactor cost — modest, but it is the gate.
+- Because `MainForm` takes every panel in its constructor, **all panels are constructed at
+  login** regardless of navigation. So do not register both variants and choose later — the
+  unused one still gets built and still calls `/store/features`.
+- `StoreTypeFeatures.For()` throws on an unknown store type. That fail-closed behaviour is
+  deliberate (`CoffeeShop` retired, value 3 reserved). Keep the mapping in **one** registry
+  keyed by `StoreType`; do not scatter a parallel switch per panel.
+- Avoid WinForms visual inheritance from `.Designer.cs` partials — painful to maintain. Prefer
+  composition (a shell panel hosting store-type-specific child controls) or separate
+  implementations behind an interface.
+
+### B6. Sequencing recommendation
+
+Consolidating three apps is **substantially larger than Epic 2**, and Epic 2 is what blocks real
+shops from leaving a 3.7.0-era system. Recommendation: spec this while the analysis is fresh,
+schedule it after the rollout. MimyShop is blocked for trading only by its catalogue rebuild,
+so unifying first is defensible if that changes — Pond's call.
+
+---
+
+## C. Pond's domain knowledge
+
+> Being filled in as provided. Still wanted: screenshots of the sales report per store type (see
+> B4).
+
+### C1. MimyShop needs two service buttons on the sale panel
+
+**Requirement (Pond, 2026-07-31):** MimyShop's sale panel gets two more buttons —
+**(1) Add Shipping Service Cost** and **(2) Add Printing Service Cost**. Each behaves like the
+existing "add general product without barcode": it adds a line to the sale invoice using a
+**pre-defined barcode**, and the cashier types the **price/cost** for that transaction.
+
+This is the first concrete use of the `Services` category Epic 1 seeded for MimyShop
+(17 categories = 16 General + **1 Service**).
+
+#### What already works
+
+- **Sale-time price entry is already built.** `AddInvoiceProductForm` has a `UnitPriceTextBox`,
+  validates it (`if (UnitPriceTextBox.Visible && !decimal.TryParse(...))`), and passes it
+  through: `_saleService.AddProduct(_product, unitPrice, quantity, note)`. The `Visible` check
+  implies it is already meant to be shown conditionally. No new mechanism needed.
+- **The template-barcode button pattern exists.** `SalePanel` holds
+  `GeneralGoodsBarcode = "2001000000012"` and `HardwareBarcode = "2005000000027"` and calls
+  `_addInvoiceProductForm.ShowDialog(barcode)`.
+
+So the feature is mostly assembly — *except* it is blocked by two recorded gaps.
+
+#### 🛑 Blocker 1 — MimyShop cannot use its own seeded `Services` category
+
+`ProductCategoryPolicy` is the whole rule:
+
+```csharp
+public static bool IsUsable(ProductCategoryKind kind, StoreTypeFeatures features) =>
+    kind == ProductCategoryKind.GeneralGoods || features.MultipleProductTypesEnabled;
+```
+
+`StoreTypeFeatures.For(StoreType.MimyShop)` sets `MultipleProductTypesEnabled = false`, so
+`Service` evaluates **false**. Epic 1 seeded the category and then the policy locks it out —
+pinned today by `IsUsable_WithServiceOnAGeneralOnlyStore_ShouldBeFalse`.
+
+**Root cause:** the flag conflates two unrelated capabilities — "sells hardware as well as
+general goods" and "sells services". MimyShop is the case that separates them: no hardware,
+but yes services.
+
+**Fix:** add a distinct `ServicesEnabled` flag to `StoreTypeFeatures` (true for MimyShop) and
+gate `ProductCategoryKind.Service` on it rather than on `MultipleProductTypesEnabled`. Small and
+self-contained; it also turns Epic 1's "known gap" into shipped behaviour. The existing test
+above must be re-pointed at Minimart, which genuinely has no services.
+
+#### 🛑 Blocker 2 — a service line would deduct stock forever (Epic 2 defect 7, promoted)
+
+`CompleteSaleCommandHandler` builds an inventory movement for **every** line, unconditionally:
+
+```csharp
+foreach (var lineRequest in command.Lines)
+{
+    var movement = new InventoryMovement { ... QuantityDelta = -lineRequest.Quantity ... };
+}
+```
+
+There is no `IsTrackable` gate — and there cannot be one, because **v4's
+`Domain/Entities/Core/Product.cs` has no `IsTrackable` field.** It exists only on the
+Application-layer `Common/Models/Product.cs` and `InventoryProductDto` (legacy-shaped), never on
+the persisted entity.
+
+Consequence: every shipping or printing service sold writes a negative `inventory_movement` for
+a thing that has no stock, so its balance goes permanently and meaninglessly negative.
+
+This is already recorded as **Epic 2 defect 7** ("v4 `Core.Product` has no `IsTrackable`; legacy
+does — services would be stock-tracked and inventory-deducted"), where it was framed as a
+migration concern for 21/7/1 legacy non-trackable products. **This feature promotes it to a hard
+prerequisite**: it must be fixed before the service buttons can ship, not merely before the
+migration runs.
+
+#### Blocker 3 — the two service products need reserved barcodes and seeded rows
+
+Each button needs a real `product` row to look up, per MimyShop store, filed under the
+`Services` category. Per Epic 1's contract those barcodes must sit in the `200`
+restricted-circulation range with a valid EAN-13 check digit — use
+`Ean13Barcode`/`UiErrorReference`-era helpers rather than typing digits by hand.
+
+#### Design note — do not add two more hardcoded consts
+
+Adding `ShippingServiceBarcode` and `PrintingServiceBarcode` as `SalePanel` constants repeats
+exactly the smell in **B3** (hardcoded campaign labels defeating a data-driven catalogue). Two
+special products today becomes five tomorrow, each needing a code change plus a redeploy —
+which is the problem Epic M and Epic 1 both existed to remove.
+
+Preferred shape: a small **special-products registry** keyed by purpose
+(`GeneralGoodsTemplate`, `HardwareTemplate`, `ShippingService`, `PrintingService`), seeded
+alongside the category catalogue and read at runtime, so the sale panel renders whichever
+buttons its store actually has.
+
+#### ✅ RESOLVED — approach decided (Pond, 2026-07-31)
+
+An alternative was considered and **rejected**: adding a productless invoice line (free-text
+service, no product row) instead of pre-defined service products. Recorded so it is not
+re-litigated.
+
+**Why productless lines were rejected:**
+
+1. **It would break the forward-only migration gate.** `InvoiceLine.ProductId` is a
+   non-nullable `Guid` with `.IsRequired()` *and* a real FK to `Product`
+   (`HasOne(e => e.Product).HasForeignKey(e => e.ProductId)`). Making it nullable means restored
+   binaries — which read a non-nullable `Guid` — would fail on a `NULL`. That directly violates
+   the release gate in `CLAUDE.md` ("an upgrade rolls back binaries and config, **not** schema")
+   and would make the installer's rollback claim false.
+2. **Services would vanish from reporting.** A productless line carries no category, so services
+   could not appear in the general/hardware/service breakdown, and Epic 2's
+   `InvoiceProduct.Category` migration assumes every line carries one. Free text also invites
+   drift — "Shipping" / "shipping" / "ship fee" as three rows in the owner's report — with no
+   price history to compare against.
+3. **The cost that motivated it is avoidable** — see below.
+
+> **⚠️ REVISED below — see C2.** The Kind-gating recommendation that follows was written before
+> discovering that the legacy sale path already filters on `IsTrackable` in production, and that
+> legacy holds non-trackable products which are *not* services. v4 therefore needs `IsTrackable`
+> regardless, for migration fidelity. Kind-gating remains a valid complement, not a substitute.
+
+**Decided approach — pre-defined service products, with the stock deduction gated on category
+`Kind` rather than on a new `IsTrackable` column.**
+
+`CompleteSaleCommandHandler` already loads the product for every line:
+
+```csharp
+var product = await _productRepository.GetByIdAsync(lineRequest.ProductId, cancellationToken);
+```
+
+so `product.Category` is already in hand, and one catalogue lookup yields the `Kind` Epic 1
+introduced. Skip the `InventoryMovement` when that Kind is `Service`.
+
+Why this is better than adding `IsTrackable` to the entity:
+
+- **Unblocks the feature without Epic 2 defect 7** — no schema change at all.
+- **One source of truth** for "does this hold stock" (the category), instead of two fields that
+  can silently disagree.
+- Semantically correct: a service has no stock *because it is a service*, not because someone
+  remembered to tick a box.
+- No extra query — the per-store catalogue is small and cacheable.
+
+`IsTrackable` still has a job for the migration (legacy holds 21/7/1 genuinely non-trackable
+*products* that are not services), so **defect 7 remains open — it simply stops being a
+prerequisite for this feature.**
+
+**Implementation shape — four small, independently testable changes, none touching the schema:**
+
+| # | Change | Where |
+|---|---|---|
+| 1 | Add `ServicesEnabled` (true for MimyShop), decoupling "sells services" from "sells hardware" | `StoreTypeFeatures` |
+| 2 | Gate `ProductCategoryKind.Service` on the new flag instead of `MultipleProductTypesEnabled` | `ProductCategoryPolicy` |
+| 3 | Skip the inventory movement when the line's category `Kind` is `Service` | `CompleteSaleCommandHandler` |
+| 4 | Seed two `Services`-category products per MimyShop store (`200`-range barcodes, valid check digits) and render the buttons from a special-products registry | seeder + `SalePanel` |
+
+Change 2 requires re-pointing `IsUsable_WithServiceOnAGeneralOnlyStore_ShouldBeFalse` at
+Minimart, which genuinely has no services.
+
+#### Latent bug noticed in passing (pre-existing, unrelated)
+
+`CompleteSaleCommandHandler` does `var productName = product?.Name ?? "Unknown Product"` but
+then writes the line with that same `ProductId`, which carries an FK constraint. A missing
+product therefore throws an FK violation on save rather than degrading to "Unknown Product" —
+the null-tolerance there is illusory.
+
+#### ⚠️ Sequencing consequence — build this in v4, not in the MimyShop fork
+
+If this ships inside `C:\personal\MimyShop`, the forks diverge **further** and the consolidation
+in section B gets more expensive. The `Services` category, the `Kind` taxonomy and the price-entry
+plumbing already live in v4; the MimyShop fork has none of it and still runs pre-Epic-M payment
+code. Building it in v4 makes this feature the first real justification for the consolidation
+rather than another reason to postpone it.
+
+### C2. Interim: ship the two service buttons on the MimyShop fork first
+
+**Requirement (Pond, 2026-07-31):** the two buttons are needed on MimyShop **soon**, as an
+interim measure while v4 consolidation is still ahead. This supersedes the "build it in v4, not
+the fork" advice in C1 — a shop need outranks architectural tidiness. The goal is therefore to
+build it in the fork in a way that makes the later v4 port **mechanical rather than a redesign**.
+
+#### The fork is already the right shape
+
+| Concern | Fork (`C:\personal\MimyShop`) | IndyPOS v4 |
+|---|---|---|
+| Template barcode const | `ProductWithoutBarcode = "2001000000012"` | `GeneralGoodsBarcode = "2001000000012"` — **same value** |
+| Button handler pattern | `AddProductWithoutBarcodeButton_Click` | `AddGeneralGoodsProductButton_Click` |
+| Sale-time price entry | `UnitPriceTextBox` → `_saleService.AddProduct(_product, unitPrice, quantity, note)` | **identical call** |
+| Storage | SQLite, int category ids | PostgreSQL, string category codes |
+
+#### ✅ No stock work needed in the fork — it already guards on `IsTrackable`
+
+`MimyShop.Infrastructure/Services/SaleService.cs:413-418`:
+
+```csharp
+var productGroups = invoiceInfo.Products
+                               .Where(p => p.IsTrackable)      // already filtered
+                               .GroupBy(p => p.InventoryProductId);
+```
+
+So seeding the two service products with `IsTrackable = false` makes the existing,
+production-proven path skip them. **Blocker 2 does not apply to the interim at all.**
+
+#### 📌 PINNED — the two barcodes, to be identical in the fork and in v4
+
+Computed in the established legacy scheme (`200` + 2-digit category id + 7-digit sequence +
+EAN-13 check digit), using MimyShop's real `บริการ` category id **25** (verified from
+`sqlite_database/MimyShop/Store.db`, table `ProductCategory (Id, Category)`).
+
+| Button | Barcode | Structure |
+|---|---|---|
+| Add **Shipping** Service Cost | **`2002500000014`** | `200` \| `25` \| `0000001` \| check `4` |
+| Add **Printing** Service Cost | **`2002500000021`** | `200` \| `25` \| `0000002` \| check `1` |
+
+Verified:
+
+- **Algorithm sanity:** recomputing the check digit for the existing template `2001000000012`
+  yields `2`, matching the printed value — so this matches whatever generated the real barcode.
+- **Collision-free in all three real stores** (GeneralHardware, MimyMart, MimyShop): no exact
+  match, and the `20025*` prefix has **zero** rows anywhere. The `200` range currently holds
+  exactly one barcode in MimyShop — `2001000000012`.
+
+**Use these exact values in both codebases.** If the fork invents different barcodes, the v4
+migration has to map them and the labels reprint; if they match, migration carries them for free.
+
+#### Interim implementation in the fork (small)
+
+1. Seed two `InventoryProduct` rows, category id **25** (`บริการ`), with the barcodes above,
+   `IsTrackable = false`, price 0 (the cashier types it per sale).
+2. Add two buttons to `SalePanel`, each delegating to the existing
+   `AddProductWithoutBarcodeButton_Click` logic with its own barcode constant.
+3. Confirm `UnitPriceTextBox.Visible` is true on that path so the cashier can enter the amount.
+
+No schema change, no stock change, no policy change.
+
+#### What the v4 port then needs
+
+Only the parts v4 lacks — the barcodes, seed shape and UI flow already agree:
+
+1. `ServicesEnabled` on `StoreTypeFeatures` + `ProductCategoryPolicy` gating (C1 changes 1-2).
+2. **Restore `IsTrackable` on `Domain/Entities/Core/Product.cs`** and honour it in
+   `CompleteSaleCommandHandler` — see the reframing below.
+3. Seed the two products under the `Services` **code** rather than legacy id 25.
+4. Prefer the special-products registry over two more hardcoded consts (C1 design note).
+
+#### 🔁 Reframing Epic 2 defect 7 — v4 lost a guard legacy actively uses
+
+Defect 7 was filed as "v4 `Core.Product` has no `IsTrackable`; legacy does". The stronger
+statement, now verified: **the legacy sale path already filters on `IsTrackable` before touching
+stock, in production, today.** v4 did not merely omit a field — it dropped a working guard, and
+`CompleteSaleCommandHandler` deducts stock for every line unconditionally as a result.
+
+This also settles the earlier Kind-vs-`IsTrackable` question: legacy holds 21/7/1 non-trackable
+products which are **not** all services, and the migration must preserve that per-product flag
+faithfully. So **v4 needs `IsTrackable` regardless**, for migration fidelity. Gating on category
+`Kind` is a reasonable *additional* safety net (a service should never be stock-tracked even if
+someone ticks the box), but it cannot replace the field.
+
+Practical consequence: defect 7 rises in priority. It is no longer only a migration concern — it
+is the difference between v4 supporting services at all and v4 driving service stock permanently
+negative.
+
+### C3. ✅ B4 RESOLVED — the layouts are card grids, and they are ONE design at two detail levels
+
+Screenshots supplied by Pond (2026-07-31):
+`C:\Users\purin\OneDrive\Documents\ShareX\Screenshots\2026-07\{MimyShop,IndyPOS}`.
+⚠️ The two IndyPOS files are **swapped**: `IndyPOS.CashFlowReport.png` is the sales report, and
+`IndyPOS.SalesReport.png` is the cash-flow screen.
+
+**IndyPOS sales report (ผลประกอบการโดยรวม)** is a card grid with explicit row/column structure.
+Cards even carry index numbers showing the arithmetic (`1`, `4`, `1-4`, `7`, `8` / `2`, `5`,
+`2-5` / `3`, `6`, `3-6`):
+
+| Row | Cards | Gate |
+|---|---|---|
+| 1 — totals | ยอดขาย:ทั้งหมด · ยอดลงบัญชี:ทั้งหมด · ยอดขาย−ยอดลงบัญชี · ยอดลงบัญชี:ชำระแล้ว · ยอดลงบัญชี:ยังไม่ชำระ | always; the ยอดลงบัญชี columns gate on `PayLaterEnabled` |
+| 2 — general | ยอดขาย:สินค้าเบ็ดเตล็ด · ยอดลงบัญชี(เบ็ดเตล็ด) · ยอดขาย(เบ็ดเตล็ด)−ยอดลงบัญชี | always — every store sells general goods |
+| 3 — hardware | ยอดขาย:สินค้าฮาร์ดแวร์ · ยอดลงบัญชี(ฮาร์ดแวร์) · ยอดขาย(ฮาร์ดแวร์)−ยอดลงบัญชี | **`MultipleProductTypesEnabled`** |
+| bottom — รายการเงิน | โอนเงิน · ม.33 · บัตรสวัสดิการแห่งรัฐ · คนละครึ่ง · เราชนะ · ลงบัญชี | **should be catalogue-driven — B3** |
+
+**MimyShop sales report** is the *same design at less detail*: only the totals row, 3 cards
+(ยอดขาย, ยอดเงินสด, ยอดโอนเงิน), with visible empty space to the right.
+
+**Conclusion — B4 answered:** these are not two layouts, they are one layout with sections
+switched off. Cards are uniform, evenly spaced and clearly in containers (the fork's
+`SalesReportPanel.Designer.cs` docks labels inside each card panel with
+`Dock = DockStyle.Fill/Top/Bottom`). Hiding row 3 collapses cleanly; hiding the AR columns
+leaves row 1 with two cards instead of five. **This is visibility gating, not a re-layout.**
+
+So B2's recommendation stands and is now evidence-backed: **one panel**, three flag-gated
+sections, plus a catalogue-driven payment breakdown.
+
+### C4. MimyMart == MimyShop in v4, except services
+
+**Pond, 2026-07-31:** in v4, Minimart (MimyMart) should get the same panels as MimyShop —
+**except the services**.
+
+This collapses the consolidation from three variants to **two**, and it maps exactly onto the
+`ServicesEnabled` flag proposed in C1:
+
+| Store type | MultipleProductTypes | PayLater | **Services** |
+|---|---|---|---|
+| GeneralHardware | ✅ | ✅ | ❌ |
+| MimyShop | ❌ | ❌ | **✅** |
+| Minimart | ❌ | ❌ | ❌ |
+
+It also confirms the C1 note that
+`IsUsable_WithServiceOnAGeneralOnlyStore_ShouldBeFalse` should be re-pointed at **Minimart**,
+which genuinely has no services — while MimyShop must start passing.
+
+### C5. Interim also needed on the fork: WelfareCard + FiftyFifty totals on the sales report
+
+**Pond, 2026-07-31:** MimyShop's sales report still needs totals for **WelfareCard** and
+**FiftyFifty**, alongside the two service buttons.
+
+This is trivial — the data and even the Thai labels already exist inside the same app:
+
+- `MimyShop.Application/Common/Models/PaymentsSummary.cs` already exposes `WelfareCardTotal`
+  and `FiftyFiftyTotal`, and `NonCashTotal` already sums them.
+- The fork's **Cash Flow panel already displays both** —
+  `CashFlowCalculatorPanel.cs:132-133` sets `WelfareCardPaymentTotalLabel` and
+  `FiftyFiftyPaymentTotalLabel`, captioned **ยอดบัตรสวัสดิการ** and **ยอดคนละครึ่ง** (visible in
+  `MimyShop.CashFlowReport.png` as a 2×2 card grid).
+
+So the gap is **presentation in one panel only**. Interim fix: add two cards to
+`SalesReportPanel` bound to the totals already on `PaymentsSummary`, reusing the Cash Flow
+panel's exact Thai captions for consistency.
+
+**And it is the same defect as B3, from the other side.** IndyPOS hardcodes six payment rows
+(so a *new* campaign is invisible); MimyShop hardcodes three cards that *omit* two campaigns it
+already collects. Both are the same root cause: the report's payment breakdown is hand-authored
+instead of generated from the `payment_method` catalogue.
+
+**Consequence for v4:** making that bottom section catalogue-driven fixes B3 **and** delivers
+MimyShop's WelfareCard/FiftyFifty totals for free, with no per-store layout work. That single
+change is the strongest argument for the consolidated report panel.
+
+### C6. Where the two service buttons go on the fork's sale panel
+
+From `MimyShop.Sale.png`: the centre-bottom button stack currently holds a magnifier (product
+lookup), **เพิ่มสินค้า ไม่มีบาร์โค้ด** (add product without barcode) and **เปิดลิ้นชัก** (open cash
+drawer), in a fixed-width column roughly 375px wide. The two service buttons belong in that
+stack, directly beneath เพิ่มสินค้า ไม่มีบาร์โค้ด since they are the same interaction.
+
+Layout note: the stack is already three items tall in the available height, so adding two more
+needs either shorter buttons or a 2-up arrangement. Worth checking against the panel's minimum
+height before choosing. The payment-lines grid to its left has spare width if the stack needs to
+become two columns.


### PR DESCRIPTION
Docs only — no code. Captures the cross-repo analysis produced after #55 and #56 merged, and brings `PLAN.md` back in step with reality.

**New:** `.planning/indypos-overhaul/findings-2026-07-31.md`

**PLAN.md:** Epic 1 marked shipped, epic 2 marked next, the three shipped items added, and a new **epic 6** for consolidating the three forked apps (divergence measured — MimyMart↔MimyShop differ by 41 lines; IndyPOS's sale panel is *ahead* rather than different).

**Epic 2 gains three things:**
- **defect 8** — legacy ids aren't preserved on products/invoices/lines/payments (only `StoreUser`), so the migration can't be re-run idempotently and a v4 row can't be reconciled to its SQLite source. With 6 open defects, re-running is near-certain.
- **defect 9** — `LegacyIdHelper` is dead code that maps the same legacy id to the same Guid *in every store*; a latent cross-store collision once Epic I syncs three shops into one cloud.
- **defect 7 reframed and raised** — v4 didn't merely omit `IsTrackable`; the legacy sale path already filters on it in production, so v4 dropped a working guard and now deducts stock for every line unconditionally.

**Also recorded (previously nowhere):** the sales report hardcodes a label per government campaign, so a campaign added as a catalogue row collects money that never appears in the owner's report — directly defeating what Epic M was for.