### PR TITLE
docs: record the Epic 2 test-harness audit verdict

### DIFF
--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -167,18 +167,26 @@ negative, so it is no longer only a migration concern.
 > | MimyShop | 17 | **17** | **0** |
 >
 > **602,114 lines, not a single `0`** — including **73,798** GeneralHardware and **11,890** MimyMart
-> lines sold from products that *are* non-trackable (21 and 7 such products respectively).
+> lines sold from products that *are* non-trackable.
 >
-> **Cause:** the legacy `InvoiceProductRepository`'s `INSERT` omits the `IsTrackable` column, so
-> SQLite applies the schema's `DEFAULT 1` on every row. Nothing has ever written a real value.
-> Legacy stock handling is still correct because the guard filters the **in-memory**
-> `IInvoiceProduct` (flag copied from the product) and never reads the persisted column.
+> **Cause — verified in one codebase, inferred for the other two.** In **MimyShop**'s source,
+> `InvoiceProductRepository`'s `INSERT` omits the `IsTrackable` column, so SQLite applies the
+> schema's `DEFAULT 1` on every row. GeneralHardware's rows were written by **IndyPOS v3.7.0** and
+> MimyMart's by a third codebase, and **neither is in this repo** (`grep 'INSERT INTO
+> InvoiceProduct'` over `src/` returns nothing) — so for those two the same defect is *inferred from
+> an identical symptom*, not read off the code. **The conclusion does not depend on the cause:** it
+> rests on the measurement above, which covers all three stores directly.
+>
+> Legacy stock handling is nevertheless correct, which is why this was never noticed: the guard
+> filters the **in-memory** `IInvoiceProduct` (flag copied from the product) and never reads the
+> persisted column.
 >
 > **Consequence for this defect:** a migration that restores a per-line trackable flag by reading
 > `InvoiceProduct.IsTrackable` will mark **every service line as stock-tracked** — the exact bug
 > defect 7 exists to fix, faithfully reproduced from data that looks legitimate. Join
-> `InventoryProduct` on `InventoryProductId` and take the flag from there; only 28 products across
-> the three stores are non-trackable, and that column *is* maintained.
+> `InventoryProduct` on `InventoryProductId` and take the flag from there: only **29** products
+> across the three stores are non-trackable (**21** GeneralHardware + **7** MimyMart + **1**
+> MimyShop, and zero `NULL`s anywhere), and that column *is* maintained.
 >
 > ⚠️ This also means **`InvoiceProduct.IsTrackable` cannot be used to verify the migration** — it
 > reconciles perfectly against a wrong answer, the same trap as defect 1's payment scramble.
@@ -203,13 +211,25 @@ so defect 2 is a rename, not a redesign.
 
 The suspicion was that its 15 passing tests validate nothing. Confirmed, and it is worse than that.
 
-**1. The tests exercise no shipped code.** `tests/IndyPOS.Migration.Tests/MigrationService.cs` (382
-lines) is a **second, parallel migration implementation**, unreferenced by the product. The shipped
-one is `src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs`. The test copy still carries
-the **pre-`6c63a6d` scrambled payment map** (`2=>"Card"`, `3=>"Transfer"`, `4=>"PayLater"`,
-`5=>"WelfareCard"`, `_=>"Other"`), its own `SpecifyKind(..., Utc)` date bug, and its own
-`Category?.ToString()`. Every one of the 9 defects could be fixed or reintroduced in the real tool
-without moving a single test in this project.
+**1. The tests cannot reach the shipped migrator.** `tests/IndyPOS.Migration.Tests/MigrationService.cs`
+(382 lines) is a **second, parallel migration implementation**. The shipped one is
+`src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs`.
+
+The decisive evidence is structural, not textual: **`IndyPOS.Migration.Tests.csproj` has no
+`ProjectReference` to `IndyPOS.MigrationTool`** — only to `IndyPOS.Domain` and
+`IndyPOS.Infrastructure`. No test in that project *can* touch the shipped migrator, and a grep for
+`SqliteMigrationService` inside it returns nothing. So every one of the 9 defects could be fixed or
+reintroduced in the real tool without moving a single test here.
+
+The test copy also still carries the **pre-`6c63a6d` scrambled payment map** (`2=>"Card"`,
+`3=>"Transfer"`, `4=>"PayLater"`, `5=>"WelfareCard"`, `_=>"Other"`), its own
+`SpecifyKind(..., Utc)` date bug, and its own `Category?.ToString()` — i.e. it is a frozen copy of
+the bugs Epic 2 exists to fix.
+
+⚠️ **Precisely what is and is not real:** because the project *does* reference
+`IndyPOS.Infrastructure`, `MigrationTestFixture` calls `EnsureCreatedAsync()` on the **real**
+`StoreHubDbContext`. So the **target** schema is genuine; the **source** schema and the **migration
+logic** are not.
 
 **2. The schema it builds exists in no store.** Verified against
 `sqlite_database/GeneralHardware/Store.db`, whose 13 tables are `Customers`, `Installments`,
@@ -227,10 +247,18 @@ without moving a single test in this project.
 **9**, missing exactly `Manufacturer`, `Brand`, `Category`, `IsTrackable`, `Note`, `GroupPrice`,
 `IsGroupProduct`, `OriginalUnitPrice`.
 
-**Consequence for Epic 2:** do not "fix" this project — deleting it removes 15 misleading green
-tests and no coverage. Real coverage has to be built against `SqliteMigrationService` using a
-fixture whose schema is generated from a real `Store.db`, not hand-written. Until that exists,
-**treat the invoice and product migration paths as untested.**
+**Consequence for Epic 2:** do not "fix" this project — delete it. That removes 15 misleading green
+tests and loses no coverage.
+
+**Why "no coverage" is safe to claim.** The only real thing the project exercises is
+`StoreHubDbContext.EnsureCreatedAsync()` against a live Postgres container — and
+`IndyPOS.StoreHub.IntegrationTests` already does exactly that, on the same context, across its 94
+tests. The target-schema smoke test is therefore duplicated, not lost.
+
+Real coverage has to be built against `SqliteMigrationService` using a fixture whose schema is
+**generated from a real `Store.db`** rather than hand-written — hand-writing it is what produced a
+schema no store has. Until that exists, **treat the invoice and product migration paths as
+untested.**
 
 ---
 

--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -155,6 +155,36 @@ sale path **already filters on `IsTrackable` before touching stock, in productio
 difference between v4 supporting services at all and v4 driving service stock permanently
 negative, so it is no longer only a migration concern.
 
+> ### ⚠️ Defect 7 addendum (2026-08-01): read `IsTrackable` from the PRODUCT, never the invoice line
+>
+> `InvoiceProduct.IsTrackable` exists and looks authoritative. It is **dead data** — measured across
+> all three real store DBs:
+>
+> | Store | `InvoiceProduct` lines | `IsTrackable = 1` | `IsTrackable = 0` |
+> |---|---|---|---|
+> | GeneralHardware | 325,780 | **325,780** | **0** |
+> | MimyMart | 276,317 | **276,317** | **0** |
+> | MimyShop | 17 | **17** | **0** |
+>
+> **602,114 lines, not a single `0`** — including **73,798** GeneralHardware and **11,890** MimyMart
+> lines sold from products that *are* non-trackable (21 and 7 such products respectively).
+>
+> **Cause:** the legacy `InvoiceProductRepository`'s `INSERT` omits the `IsTrackable` column, so
+> SQLite applies the schema's `DEFAULT 1` on every row. Nothing has ever written a real value.
+> Legacy stock handling is still correct because the guard filters the **in-memory**
+> `IInvoiceProduct` (flag copied from the product) and never reads the persisted column.
+>
+> **Consequence for this defect:** a migration that restores a per-line trackable flag by reading
+> `InvoiceProduct.IsTrackable` will mark **every service line as stock-tracked** — the exact bug
+> defect 7 exists to fix, faithfully reproduced from data that looks legitimate. Join
+> `InventoryProduct` on `InventoryProductId` and take the flag from there; only 28 products across
+> the three stores are non-trackable, and that column *is* maintained.
+>
+> ⚠️ This also means **`InvoiceProduct.IsTrackable` cannot be used to verify the migration** — it
+> reconciles perfectly against a wrong answer, the same trap as defect 1's payment scramble.
+> Found while verifying MimyShop's interim service buttons, where the two seeded service products
+> are `IsTrackable = 0` yet both invoice lines persisted as `1`.
+
 See `findings-2026-07-31.md` §A for defects 8-9 and the UUIDv7 recommendation (worth adopting
 while v4 has never run a store — that window closes at the first migration).
 

--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -166,11 +166,41 @@ so defect 2 is a rename, not a redesign.
 
 - `MigrationVerifier` compared only row **counts** and `SUM(Invoice.Total)` — both reconcile
   perfectly under a scrambled mapping. Now compares count *and* amount **per method** (`6c63a6d`).
-- **No test anywhere creates a `Payment` table.** `tests/IndyPOS.Migration.Tests` builds
-  `InvoicePayment` / `AccountsReceivablePayment` and carries its own `MigrationService.cs` — it
-  appears to test an older parallel implementation. Its 15 tests pass while validating a schema no
-  store has. **The invoice and product paths may rest on the same sand.**
+- **No test anywhere creates a `Payment` table** — see the audit below.
 - The real-DB tests skip silently when the `.db` files are absent — including in CI.
+
+### Test-harness audit — ✅ DONE 2026-08-01. Verdict: **delete `tests/IndyPOS.Migration.Tests`**
+
+The suspicion was that its 15 passing tests validate nothing. Confirmed, and it is worse than that.
+
+**1. The tests exercise no shipped code.** `tests/IndyPOS.Migration.Tests/MigrationService.cs` (382
+lines) is a **second, parallel migration implementation**, unreferenced by the product. The shipped
+one is `src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs`. The test copy still carries
+the **pre-`6c63a6d` scrambled payment map** (`2=>"Card"`, `3=>"Transfer"`, `4=>"PayLater"`,
+`5=>"WelfareCard"`, `_=>"Other"`), its own `SpecifyKind(..., Utc)` date bug, and its own
+`Category?.ToString()`. Every one of the 9 defects could be fixed or reintroduced in the real tool
+without moving a single test in this project.
+
+**2. The schema it builds exists in no store.** Verified against
+`sqlite_database/GeneralHardware/Store.db`, whose 13 tables are `Customers`, `Installments`,
+`InventoryProduct`, `Invoice`, `InvoiceProduct`, `PayLater`, `Payment`, `PaymentType`,
+`ProductBarcodeCounter`, `ProductCategory`, `User`, `UserCredential`, `UserRole`:
+
+| Real store | `MigrationTestFixture` builds |
+|---|---|
+| `Payment` | `InvoicePayment` — wrong name *and* shape |
+| `PayLater` | `AccountsReceivable` + `AccountsReceivablePayment` — exist in no store |
+| `PaymentType`, `ProductCategory`, `UserRole` | absent |
+| — | `StoreConstant` — exists in no store |
+
+**3. Defect 6 independently confirmed.** Real `InvoiceProduct` has **17** columns; the fixture's has
+**9**, missing exactly `Manufacturer`, `Brand`, `Category`, `IsTrackable`, `Note`, `GroupPrice`,
+`IsGroupProduct`, `OriginalUnitPrice`.
+
+**Consequence for Epic 2:** do not "fix" this project — deleting it removes 15 misleading green
+tests and no coverage. Real coverage has to be built against `SqliteMigrationService` using a
+fixture whose schema is generated from a real `Store.db`, not hand-written. Until that exists,
+**treat the invoice and product migration paths as untested.**
 
 ---
 
@@ -249,7 +279,7 @@ Remaining items in `.planning/indypos-overhaul/security/`.
 
 | Item | Description | Priority |
 |------|-------------|----------|
-| `Migration.Tests` schema audit | Its SQLite schema matches no real store; invoice/product coverage may be illusory | **HIGH** — see Epic 2 |
+| `Migration.Tests` — **audit DONE 2026-08-01, verdict: delete the project** | Confirmed to test a parallel implementation against a schema no store has. See Epic 2 § *Test-harness audit* | **HIGH** — first task of Epic 2 |
 | Headless installer crash | An unknown argument silently launches the wizard; headless that is a bare CLR crash with no log | MEDIUM |
 | Migration `--sync-to-cloud` | Outbox events for migrated invoices (folds into I6) | LOW |
 | **Auto-Update System (Epic U)** | Remote updates for StoreHub + WinForms. Superseded in part by the installer upgrade path — revisit scope | Future |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,28 +21,42 @@ IndyPOS is a Point-of-Sale system for small retail stores (3 stores, 1-2 termina
 
 ## Project Structure
 
+**`src/` is flat** — one directory per project, no `Core/`/`Services/`/`Tools/` grouping layer.
+
 ```
 src/
-  Core/
-    IndyPOS.Domain/          # Entities, Value Objects, Domain Logic
-    IndyPOS.Application/     # Use Cases (Commands/Queries), Interfaces, DTOs
-    IndyPOS.Infrastructure/  # Repositories, External Services
-  DesktopApp/
-    IndyPOS.Windows.Forms/   # Desktop UI (legacy)
-  Services/
-    IndyPOS.StoreHub/        # Local API service (ASP.NET Core)
-    IndyPOS.CloudApi/        # Central cloud API
-  DevAppHost/
-    IndyPOS.AppHost/         # Aspire orchestrator
-    IndyPOS.ServiceDefaults/ # Shared health checks, OpenTelemetry
-  Tools/
-    IndyPOS.MigrationTool/   # SQLite -> PostgreSQL migration
+  IndyPOS.Domain/            # Entities, Value Objects, Domain Logic
+  IndyPOS.Application/       # Use Cases (Commands/Queries), Interfaces, DTOs
+  IndyPOS.Infrastructure/    # Repositories, External Services
+  IndyPOS.Windows.Forms/     # Desktop UI (legacy)
+  IndyPOS.StoreHub/          # Local API service (ASP.NET Core)
+  IndyPOS.CloudApi/          # Central cloud API
+  IndyPOS.Vault/             # DPAPI secret protection (connection string, JWT key)
+  IndyPOS.MigrationTool/     # SQLite -> PostgreSQL migration
+  IndyPOS.AppHost/           # Aspire orchestrator
+  IndyPOS.ServiceDefaults/   # Shared health checks, OpenTelemetry
 
-tests/                       # Unit, integration, migration tests
+installer/
+  IndyPOS.Bootstrapper/      # Installer: fresh install + in-place upgrade
+
+tests/
+  IndyPOS.Domain.Tests/            IndyPOS.Application.Tests/
+  IndyPOS.Vault.Tests/             IndyPOS.Bootstrapper.Tests/
+  IndyPOS.Windows.Forms.Tests/     IndyPOS.StoreHub.IntegrationTests/   # needs Docker
+  IndyPOS.MigrationTool.Tests/     IndyPOS.Migration.Tests/             # needs Docker
+  IndyPOS.Mock/                                                        # shared fakes, not a test project
+
 docs/                        # Architecture docs, operations
 .planning/                   # Planning docs, diagrams, completed epics
-.claude/                     # Session context (STATUS.md, session-log.md)
+fonts/  scripts/  publish/   # Bundled fonts, helper scripts, build output
+.claude/                     # Session context - GITIGNORED, local only
 ```
+
+⚠️ **`.claude/` is gitignored** (since the BFG history purge), so `STATUS.md` never commits — do not
+try to include it in a PR.
+
+⚠️ **`tests/IndyPOS.Migration.Tests` is scheduled for deletion**, not repair — it tests a parallel
+implementation against a schema no store has. See Epic 2 in `PLAN.md`.
 
 ## Key Documentation
 


### PR DESCRIPTION
## What

Records the outcome of the test-harness audit Epic 2 was gated on, plus a defect 7 addendum.
**Docs only — no code, no schema, no test changes.**

## Finding 1 — `tests/IndyPOS.Migration.Tests` tests nothing shipped

It is not merely "a schema no store has". It carries a **second, parallel migration implementation**
(`MigrationService.cs`, 382 lines). The shipped code is
`src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs`.

The decisive evidence is structural: **the csproj has no `ProjectReference` to
`IndyPOS.MigrationTool`** — only `IndyPOS.Domain` and `IndyPOS.Infrastructure`. No test in that
project *can* reach the shipped migrator. Its copy still holds the pre-`6c63a6d` scrambled payment
map, its own `SpecifyKind(..., Utc)` bug and its own `Category?.ToString()` — a frozen snapshot of
the bugs Epic 2 exists to fix. All 9 defects could be fixed *or reintroduced* with its 15 tests
green.

The fixture's schema matches no real store:

| Real store (13 tables) | `MigrationTestFixture` builds |
|---|---|
| `Payment` | `InvoicePayment` — wrong name *and* shape |
| `PayLater` | `AccountsReceivable` + `AccountsReceivablePayment` |
| `PaymentType`, `ProductCategory`, `UserRole` | absent |
| — | `StoreConstant` (exists in no store) |

Real `InvoiceProduct` has **17** columns to the fixture's **9** — confirming defect 6 from a second
direction.

**Verdict: delete the project.** Removes 15 misleading green tests and loses no coverage — the one
real thing it exercises (`StoreHubDbContext.EnsureCreatedAsync` against live Postgres) is already
duplicated by `StoreHub.IntegrationTests` across its 94 tests.

## Finding 2 — `InvoiceProduct.IsTrackable` is dead data (defect 7 addendum)

Measured across all three real store DBs: **602,114 invoice lines, every one `IsTrackable = 1`, not
a single `0`** — including 73,798 GeneralHardware and 11,890 MimyMart lines sold from products that
*are* non-trackable.

So defect 7 must read the flag from **`InventoryProduct`**, never the invoice line, or it will mark
every service line as stock-tracked — reproducing the exact bug it exists to fix, from data that
looks legitimate. It also **cannot be used to verify** the migration: it reconciles perfectly against
a wrong answer, the same trap that hid defect 1's payment scramble.

## Also fixes `CLAUDE.md`'s repo map

The `Project Structure` block invented five grouping directories (`Core/`, `DesktopApp/`,
`Services/`, `DevAppHost/`, `Tools/`) that **do not exist** — `src/` is flat — and omitted
`IndyPOS.Vault` and the whole `installer/` tree. `CLAUDE.md` is auto-loaded every session, so every
future agent started from a wrong map. Now corrected, with the real tests list (marking which two
suites need Docker) and two warnings that cost time: `.claude/` is gitignored so `STATUS.md` cannot
go in a PR, and `Migration.Tests` is scheduled for deletion rather than repair.

## Self-review applied (`08fc5bf`)

Four claims in the first two commits overstated their evidence and were corrected:

- **28 → 29** non-trackable products (MimyShop's sentinel was omitted); now broken out 21 + 7 + 1.
- **The cause is verified in MimyShop's source only.** GeneralHardware's rows were written by IndyPOS
  v3.7.0 and MimyMart's by a third codebase, neither in this repo. Relabelled as inferred for those
  two, with the conclusion explicitly resting on the measurement instead.
- **"Exercises no shipped code" was too strong** — the real `StoreHubDbContext` *is* exercised. Now
  states precisely that the target schema is genuine while the source schema and migration logic are
  not.
- **Cited the csproj evidence**, which is structural and cannot rot, rather than arguing from the
  duplicated file.