### PR TITLE
docs: add ONBOARDING.md for a fresh clone

### DIFF
--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -127,9 +127,12 @@ never to have been run end-to-end against a real store database.
 
 ### Legacy schema divergence — confirmed, not assumed
 
-All three share 11 tables. GeneralHardware alone adds `PayLater`, `Customers`, `Installments` —
-i.e. the divergence *is* the PayLater feature. `PaymentType` is identical in all three (8 rows), so
-the payment mapping is store-agnostic.
+All three share exactly **10** tables (`InventoryProduct`, `Invoice`, `InvoiceProduct`, `Payment`,
+`PaymentType`, `ProductBarcodeCounter`, `ProductCategory`, `User`, `UserCredential`, `UserRole`) —
+**corrected 2026-08-01 from "11", measured by set intersection.** GeneralHardware adds three
+(`PayLater`, `Customers`, `Installments`) for 13 total; MimyMart and MimyShop add none. So the
+divergence *is* the PayLater feature. `PaymentType` is identical in all three (8 rows), so the
+payment mapping is store-agnostic.
 
 `Customers` and `Installments` are **never used** (0 rows where present) — out of scope permanently.
 Legacy payment id 6 `ผ่อนชำระ` is dead with them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,12 @@
 
 ## Session Start
 
-**Always read first:** `.claude/STATUS.md` (quick checkpoint, ~50 lines)
+**New to this repo, or a fresh clone?** Start with [`ONBOARDING.md`](ONBOARDING.md) — prerequisites,
+build/test, how to run it, and the four traps that waste the most time.
+
+**Resuming work on an existing checkout?** Read `.claude/STATUS.md` (quick checkpoint, ~50 lines).
+⚠️ **That file is gitignored and will not exist in a fresh clone** — this repo is public, so session
+context stays local. Do not try to commit it.
 
 **Need more detail?** `.planning/indypos-overhaul/PLAN.md`
 
@@ -130,17 +135,24 @@ dotnet test
 # Build
 dotnet build
 
-# Docker must be RUNNING for these three suites - they spin up a real Postgres
-# container. With Docker down they fail instantly (~1ms/test), which reads like a
-# code regression but is not:
-#   tests/IndyPOS.StoreHub.IntegrationTests   (94)
+# Docker must be RUNNING for three suites - they spin up a real Postgres container.
+# With Docker down they fail fast (each suite in under a second), which reads like a
+# code regression but is not. Measured with Docker stopped: 117 failures, all here.
+#   tests/IndyPOS.StoreHub.IntegrationTests   (87 of 94; 7 need no container)
 #   tests/IndyPOS.Migration.Tests             (15 - all of them)
-#   tests/IndyPOS.MigrationTool.Tests         (15 of 37; the other 21 are pure units)
+#   tests/IndyPOS.MigrationTool.Tests         (15 of 37; 21 are pure units, 1 skipped)
+
+# The installer is NOT in IndyPOS.sln, so the two commands above never touch it.
+# Run it explicitly (231 tests: 223 pass, 8 skipped):
+dotnet test tests/IndyPOS.Bootstrapper.Tests
 
 # Run with Aspire (requires Docker)
 dotnet run --project src/IndyPOS.AppHost --launch-profile https
 # Dashboard: https://localhost:17222
 ```
+
+Solution suites total **512** with Docker running. See [`ONBOARDING.md`](ONBOARDING.md) for the
+per-suite breakdown, the dev-vs-installed port split, and the `/health` vs `/health/ready` trap.
 
 ## Store Configuration (Required for Debug)
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,247 @@
+# IndyPOS — Getting Started
+
+Everything needed to go from a fresh clone to a running, tested build. Facts only; every number
+below was measured against this repository.
+
+For architecture and coding standards read [`CLAUDE.md`](CLAUDE.md). For the roadmap and open work
+read [`.planning/indypos-overhaul/PLAN.md`](.planning/indypos-overhaul/PLAN.md).
+
+---
+
+## What this is
+
+A Point-of-Sale system for three small retail stores in Thailand, 1–2 terminals each. The UI is Thai.
+
+Three deployable pieces:
+
+| Piece | Project | Role |
+|---|---|---|
+| **Till app** | `src/IndyPOS.Windows.Forms` | Windows Forms desktop UI, one per terminal |
+| **StoreHub** | `src/IndyPOS.StoreHub` | ASP.NET Core API + PostgreSQL, one per store; the till talks to it |
+| **CloudApi** | `src/IndyPOS.CloudApi` | Central API for cross-store reporting |
+
+.NET 10, Clean Architecture, CQRS. PostgreSQL only — SQLite was removed from the application, and
+now appears solely as the *source* format for migrating legacy store data.
+
+Stores currently run the previous generation (v3.7.0, SQLite-backed). v4 installs **side by side**
+with it rather than upgrading it.
+
+---
+
+## Prerequisites
+
+| Requirement | Detail |
+|---|---|
+| **.NET SDK 10** | `global.json` pins `10.0.107` with `rollForward: latestMinor`, so any later 10.0.x works |
+| **Docker Desktop** | Required by 117 of the tests (see below) and by Aspire |
+| **Windows** | Several projects target `net10.0-windows`; the till is Windows Forms |
+| **FC Subject font** | In [`fonts/`](fonts/) — install `Regular` and `Bold`. Every panel names this family explicitly, so without it Windows substitutes a fallback and Thai captions clip |
+
+---
+
+## Build and test
+
+```bash
+dotnet build
+dotnet test
+```
+
+### ⚠️ Trap 1 — three suites need Docker and fail loudly without it
+
+They spin up a real PostgreSQL container via Testcontainers. With Docker stopped they fail **fast**
+(each suite in under a second), which reads exactly like a code regression but is not.
+
+Measured with Docker **stopped**: **117 failures**, all from these three:
+
+| Suite | Total | Fails without Docker |
+|---|---|---|
+| `IndyPOS.Migration.Tests` | 15 | **15** — all of them |
+| `IndyPOS.MigrationTool.Tests` | 37 | **15** (21 are pure units, 1 skipped) |
+| `IndyPOS.StoreHub.IntegrationTests` | 94 | **87** (7 need no container) |
+
+**Start Docker and re-run before investigating any of these.**
+
+### ⚠️ Trap 2 — the installer is not in the solution
+
+`IndyPOS.sln` contains 18 projects and **excludes `installer/IndyPOS.Bootstrapper` and
+`tests/IndyPOS.Bootstrapper.Tests`**. Root `dotnet build` and `dotnet test` never touch them, so a
+green run says nothing about the installer. Run it explicitly:
+
+```bash
+dotnet test tests/IndyPOS.Bootstrapper.Tests
+```
+
+### Expected counts
+
+Solution suites (`dotnet test` at the root), Docker running — **512 total**:
+
+| Suite | Tests |
+|---|---|
+| `IndyPOS.Application.Tests` | 294 |
+| `IndyPOS.StoreHub.IntegrationTests` | 94 (Docker) |
+| `IndyPOS.MigrationTool.Tests` | 37 (1 skipped) |
+| `IndyPOS.Domain.Tests` | 36 |
+| `IndyPOS.Windows.Forms.Tests` | 19 |
+| `IndyPOS.Vault.Tests` | 17 |
+| `IndyPOS.Migration.Tests` | 15 (Docker) |
+
+Outside the solution: `IndyPOS.Bootstrapper.Tests` — **231** (223 pass, 8 skipped).
+
+`tests/IndyPOS.Mock` is shared fakes, not a test project.
+
+> `tests/IndyPOS.Migration.Tests` is **scheduled for deletion, not repair** — it exercises a
+> parallel migration implementation the product never references, against a SQLite schema no real
+> store has. Do not build on it. See Epic 2 in `PLAN.md`.
+
+---
+
+## Running it
+
+### With Aspire (recommended for development)
+
+```bash
+dotnet run --project src/IndyPOS.AppHost --launch-profile https
+```
+
+Dashboard: `https://localhost:17222`. Aspire starts PostgreSQL in Docker and wires StoreHub to it,
+so no local PostgreSQL install is needed.
+
+### StoreHub directly
+
+Dev ports come from `src/IndyPOS.StoreHub/Properties/launchSettings.json`:
+
+- `http` profile → `http://localhost:5012`
+- `https` profile → `https://localhost:7150` + `http://localhost:5012`
+
+An **installed** StoreHub listens on **`:5000`**.
+
+### ⚠️ Trap 3 — the till points at the installed port, not the dev one
+
+`src/IndyPOS.Windows.Forms/appsettings.json` sets `BaseUrl` to `http://localhost:5000`, while a
+dev-run StoreHub listens on `:5012`. Running both straight from source, the till cannot reach the
+API until you change one of them.
+
+### Health endpoints
+
+Registered in `src/IndyPOS.ServiceDefaults/Extensions.cs`:
+
+| Path | Runs | Availability |
+|---|---|---|
+| `/health/live` | checks tagged `live` — process is up | always |
+| `/health/ready` | checks tagged `ready` — dependencies healthy | always |
+| `/health` | all checks, verbose body | **Development only** |
+
+### ⚠️ Trap 4 — `/health` returns 404 on an installed service
+
+That is by design: the verbose endpoint sits inside an `IsDevelopment()` branch because it leaks
+implementation detail. **Use `/health/ready`** against a real install. A 404 on `/health` is the
+wrong path, not a sick service.
+
+### Store configuration (required by the till)
+
+The Windows Forms app reads `C:\ProgramData\IndyPOS\Config\StoreConfiguration.json`. Create it before
+running in Debug — see the *Store Configuration* section of `CLAUDE.md` for the exact shape.
+
+---
+
+## Where knowledge lives
+
+| Source | Contents |
+|---|---|
+| `CLAUDE.md` | Architecture, layer rules, naming, entity and migration conventions |
+| `.planning/indypos-overhaul/PLAN.md` | Roadmap, epics, open defects |
+| `docs/architecture/`, `docs/development/` | Design and dev-environment docs |
+| `docs/operations/` | Runbook, upgrade procedure, pilot checklist |
+| `docs/superpowers/specs/`, `docs/superpowers/plans/` | Per-feature design specs and implementation plans |
+| `.planning/indypos-overhaul/diagrams/` | Architecture and schema diagrams |
+
+**`.claude/` is gitignored and will not exist in your clone.** That is deliberate: this repository is
+public, and those files hold machine-specific paths and test credentials. `CLAUDE.md` and `PLAN.md`
+are the committed sources of truth.
+
+Real store databases under `.planning/indypos-overhaul/sqlite_database/` are also gitignored — they
+contain live sales data. Tests that need them **skip silently** when absent, including in CI.
+
+---
+
+## Domain facts that will bite you
+
+Non-obvious rules, each verified against the three real store databases. Treating any of them as a
+bug and "fixing" it causes data loss.
+
+### Legacy category ids collide across stores
+
+The same numeric id means different things in different stores:
+
+| id | GeneralHardware | MimyMart | MimyShop |
+|---|---|---|---|
+| 10 | เบ็ดเตล็ด (misc) | เบ็ดเตล็ด | **ของขวัญ (gifts)** |
+| 20 | การเกษตร (agriculture) | การเกษตร | **ขนมและเครื่องดื่ม (snacks & drinks)** |
+
+So no global id → category mapping can be correct. v4 replaces the old two-value enum with a
+**store-scoped `product_category` table** keyed `(StoreId, Code)`, holding a stable English `Code`, a
+Thai `DisplayName` and a `Kind` of `GeneralGoods` / `Hardware` / `Service`. Write the exact casing
+from `ProductCategoryCodes`; comparisons are ordinal everywhere on purpose.
+
+### `InvoiceProduct.IsTrackable` is dead data
+
+Measured across all three stores: **602,114 invoice lines, every one `IsTrackable = 1`, not a single
+`0`** — including 73,798 lines sold from products that *are* non-trackable. The legacy write path
+omits the column, so SQLite applies its `DEFAULT 1`.
+
+Read the flag from **`InventoryProduct`**, never the invoice line. Only 29 products across the three
+stores are non-trackable, and that column *is* maintained.
+
+### Legacy payment type ids
+
+`PaymentType` is identical in all three stores. Ids 4 (`ม.33`) and 6 (`ผ่อนชำระ`) were never used.
+
+| id | Thai | Means |
+|---|---|---|
+| 1 | เงินสด | Cash |
+| 2 | ลงบัญชี | PayLater (store credit) |
+| 3 | บัตรสวัสดิการแห่งรัฐ | WelfareCard (government campaign) |
+| 5 | โอนเข้าบัญชี | MoneyTransfer — the **cashless** bucket (debit tap, Apple/Google Pay) |
+| 7 | คนละครึ่ง | FiftyFifty (government campaign) |
+| 8 | เราชนะ | WeWin (government campaign) |
+
+Payment methods are a **store-scoped `payment_method` catalogue table**, not an enum — government
+campaigns start and end without a redeploy. PayLater is a `GeneralHardware`-only invariant.
+
+### Schema divergence
+
+All three stores share exactly **10** tables: `InventoryProduct`, `Invoice`, `InvoiceProduct`,
+`Payment`, `PaymentType`, `ProductBarcodeCounter`, `ProductCategory`, `User`, `UserCredential`,
+`UserRole`.
+
+GeneralHardware adds three and the other two add none, so the divergence *is* the PayLater feature:
+`PayLater`, `Customers`, `Installments` (13 tables total). `Customers` and `Installments` are empty
+everywhere and out of scope.
+
+Note the source table is **`Payment`** — not `InvoicePayment`, which appears in some older test
+fixtures and exists in no real store.
+
+### Migrations are forward-only — this is a release gate
+
+An upgrade rolls back binaries and config, **not schema**. Every migration in a release must run
+against the *previous* release's binaries:
+
+- Additive only; new columns nullable or defaulted
+- No renames, no drops, no type narrowing
+- No new `NOT NULL` column without a default
+
+Breaking this makes the installer's rollback claim false. See `docs/operations/upgrade-procedure.md`.
+
+### Entity conventions
+
+New entities use `Guid Id`, plus `DateTime CreatedUtc` and `DateTime LastModifiedUtc`.
+
+---
+
+## Contributing
+
+- Branch from **`development`** (the default branch; `main` is not used)
+- Conventional commits; small, focused, logically grouped
+- `development` is protected — changes land by **pull request**
+- Run `dotnet test` **with Docker running**, and `dotnet test tests/IndyPOS.Bootstrapper.Tests`
+  separately, before opening one


### PR DESCRIPTION
## Why

`CLAUDE.md` opened with **"Always read first: `.claude/STATUS.md`"** — but `.claude/` is gitignored,
so on a fresh clone step one is a dead end for everyone except the maintainer. This adds the
committed entry point and repoints `CLAUDE.md` at it.

Session context stays local **on purpose** — this repository is public and those files hold
machine-specific paths and test credentials. The doc says so rather than leaving it to be
rediscovered.

## Scope

App knowledge only: prerequisites, build/test, how to run it, and the domain facts that cause data
loss if "fixed". No session narrative, no roadmap duplication — `PLAN.md` stays the source for that.

## Findings from writing it

Every number was **measured against this repo** rather than carried from notes, which surfaced four
things undocumented or wrong:

| Finding | Detail |
|---|---|
| **The installer is not in `IndyPOS.sln`** | Root `dotnet build`/`dotnet test` never touch `installer/IndyPOS.Bootstrapper` or its tests, so a green run says nothing about the installer. **231 tests** (223 pass, 8 skipped), invoked directly |
| **Docker-down numbers were off** | Real total is **117 failures**, and `StoreHub.IntegrationTests` is **87 of 94** — seven need no container. `CLAUDE.md` also claimed `~1ms/test`; each *suite* fails in under a second |
| **The till points at the installed port** | WinForms `BaseUrl` is `:5000`, a dev-run StoreHub listens on `:5012` — running both from source cannot connect until one changes |
| **`/health` is dev-only** | It sits inside an `IsDevelopment()` branch, which is why an installed service 404s. `/health/ready` is the correct path |

## Correction to `PLAN.md`

It said the three stores "share 11 tables". Measured by set intersection: **10**.

```
shared (10): InventoryProduct, Invoice, InvoiceProduct, Payment, PaymentType,
             ProductBarcodeCounter, ProductCategory, User, UserCredential, UserRole
GeneralHardware +3: PayLater, Customers, Installments   (13 total)
MimyMart +0        MimyShop +0
```

## Domain facts included

Only ones re-verified against the three real store databases in this session:

- **Category id collisions** — id 10 is `เบ็ดเตล็ด` in two stores but `ของขวัญ` in MimyShop; id 20 is
  `การเกษตร` vs `ขนมและเครื่องดื่ม`. Re-read from the DBs, not copied.
- **`InvoiceProduct.IsTrackable` is dead data** — 602,114 lines, all `1`; read the flag from
  `InventoryProduct`.
- **Legacy payment type ids**, including that `MoneyTransfer` (5) is the cashless bucket rather than a
  campaign.
- **Forward-only migrations as a release gate.**

## Risk

Docs only. No code, no schema, no test changes.