### PR TITLE
fix(migration): isolate phase failures so one bad phase cannot discard the run (defect 12)

### DIFF
--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -17,7 +17,7 @@ history intact — not cloud infrastructure.
 | # | Epic | Status | Why this order |
 |---|------|--------|----------------|
 | 1 | **Product categories + MimyShop** | ✅ **SHIPPED 2026-07-31 (PR #55)** | The migration needs a category model to map into. Blocked 2 |
-| 2 | **SQLite → PostgreSQL migration hardening** | 🚧 **IN PROGRESS** — test harness landed; defects 2, 3, 10 fixed, 4/5/6/7/8/11 pinned, 9 open | 3 divergent legacy schemas. The risky half of the rollout |
+| 2 | **SQLite → PostgreSQL migration hardening** | 🚧 **IN PROGRESS** — test harness landed; defects 2, 3, 10, 12 fixed; 4/5/6/7/8/11/13 pinned; 9 open | 3 divergent legacy schemas. The risky half of the rollout |
 | 3 | **Store rollout** (fresh v4 install + migrate, per store) | ⏳ Blocked by 2 | Where the business value lands: stores off a 3.7.0-era system |
 | 4 | **Epic I: Cloud infrastructure** | 🔴 Not started | Additive. No longer on the critical path — see "Legacy history" below |
 | 5 | **Epic MCP: agent-facing API** | 🔴 Not started | Depends on 4 |
@@ -152,7 +152,7 @@ Legacy payment id 6 `ผ่อนชำระ` is dead with them.
 | 9 | `LegacyIdHelper` is dead code that maps the same legacy id to the same Guid **in every store** | Latent cross-store collision once Epic I syncs three shops into one cloud. Delete it | ❌ **new** — not pinned (dead code; deletion, not behaviour) |
 | 10 | `MigratePayLaterAsync` **creates a second `Payment`** for money `MigrateInvoicesAsync` has already migrated. `PayLater.PaymentId` is an FK to `Payment.PaymentId` — 5,181/5,181 match, all `PaymentTypeId=2` | **฿836,013 double-counted.** Unreachable today because defect 2 crashes first, so fixing 2 alone turns a loud crash into silent revenue inflation | ✅ Fixed `cf61005` |
 | 11 | `ParseDate` calls bare `DateTime.TryParse` with **no `CultureInfo`**, and the tool runs on the store's Thai-locale till | Under `th-TH` the Buddhist calendar reads `2024` as a BE year → **1481 AD, 543 years off**. Every invoice falls outside every date-range report, so a migrated store shows **zero** sales history | ❌ **new 2026-08-03** — **pinned** `c1a3ac8` |
-| 12 | **A phase-level throw still discards the whole run.** The `sqlite_master` probe and the `PayLater` SELECT sit *outside* any `try`, `MigrateAllAsync` does not wrap its four phase calls, and `SaveChangesAsync` runs after the last phase | Defects 2 and 3 were fixed at the symptom (right columns, a table probe) but **the amplifier remains**: the next column-level drift — a store whose `PayLater` lacks `PaidAmount`, say — again throws before any save, so an entire migration is discarded instead of one phase failing | ❌ **new 2026-08-04** — not pinned; needs its own fix spec |
+| 12 | **A phase-level throw still discards the whole run.** The `sqlite_master` probe and the `PayLater` SELECT sit *outside* any `try`, `MigrateAllAsync` does not wrap its four phase calls, and `SaveChangesAsync` runs after the last phase | Defects 2 and 3 were fixed at the symptom (right columns, a table probe) but **the amplifier remains**: the next column-level drift — a store whose `PayLater` lacks `PaidAmount`, say — again throws before any save, so an entire migration is discarded instead of one phase failing | ✅ Fixed `b28cb08` |
 | 13 | **An invoice line whose product no longer exists is silently dropped.** `MigrateInvoicesAsync` `continue`s when `ProductIdMap` has no entry for the line's `InventoryProductId` | **1,980 real GeneralHardware lines** reference a deleted product, so those invoices migrate with fewer lines than they had — an invoice's lines can sum to less than its own `TotalAmount`, with only a log warning. `ProductName` is already a historical snapshot on `InvoiceLine`, so the line could be preserved without the product | ❌ **new 2026-08-04** — **pinned** `3c73f11` (`MigrateInvoiceLines_WithADeletedProduct_CurrentlySkipsTheLine`) |
 
 > **"Pinned" means there is an executable test asserting today's WRONG behaviour**, naming the defect
@@ -168,6 +168,13 @@ Legacy payment id 6 `ผ่อนชำระ` is dead with them.
 > alone would have converted a loud crash into silent revenue inflation. A test now runs the shipped
 > migrator to completion against both real store shapes and asserts rows are persisted.
 > The analysis below stands as the record of why count-based verification never caught any of it.
+>
+> **The structural cause was fixed separately, as defect 12 (`b28cb08`).** Those two fixes corrected
+> the *symptom* — the wrong column names and the missing table probe. What made a single wrong column
+> name mean "no store can migrate at all" was the paragraph below: a phase-level throw escaping past
+> `SaveChangesAsync`. Each phase is now isolated, so one run reports every schema problem, while the
+> save stays gated on there being no phase failure — atomicity preserved deliberately rather than by
+> an escaping exception.
 >
 > The `PayLater` SELECT run against each real `Store.db`:
 >
@@ -443,12 +450,12 @@ Stubs returning empty collections; address during MAUI migration:
 | IndyPOS.Bootstrapper.Tests | 223 pass / 8 skip (admin-required) |
 | IndyPOS.Application.Tests | 294 |
 | IndyPOS.StoreHub.IntegrationTests | 94 (real PostgreSQL; 87 need Docker) |
-| IndyPOS.MigrationTool.Tests | 74 pass / 1 skip (75) — 31 need Docker, 24 need the gitignored real store `.db` files, 19 pure units, 1 manual extractor. **55 discovered** without those `.db` files, still all green |
+| IndyPOS.MigrationTool.Tests | 85 pass / 1 skip (86) — 36 need Docker, 24 need the gitignored real store `.db` files, 25 pure units, 1 manual extractor. **66 discovered** without those `.db` files, still all green |
 | ~~IndyPOS.Migration.Tests~~ | **deleted 2026-08-03** — validated a schema no store has |
 | IndyPOS.Domain.Tests | 36 |
 | IndyPOS.Windows.Forms.Tests | 19 |
 | IndyPOS.Vault.Tests | 17 |
-| Solution total | **535** (534 pass / 1 skip) with Docker running and real store `.db` files present; **515** without them |
+| Solution total | **546** (545 pass / 1 skip) with Docker running and real store `.db` files present; **526** without them |
 | Release build | 0 errors |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,10 +147,10 @@ dotnet build
 
 # Docker must be RUNNING for two suites - they spin up a real Postgres container.
 # With Docker down they fail fast (each suite in under a second), which reads like a
-# code regression but is not. Expect 118 failures with Docker stopped, all here.
-# (118 is DERIVED as 87 + 31, not measured - both suites were last run with Docker up.)
+# code regression but is not. Expect 123 failures with Docker stopped, all here.
+# (123 is DERIVED as 87 + 36, not measured - both suites were last run with Docker up.)
 #   tests/IndyPOS.StoreHub.IntegrationTests   (87 of 94; 7 need no container)
-#   tests/IndyPOS.MigrationTool.Tests         (31 of 75; 19 pure units, 24 need the
+#   tests/IndyPOS.MigrationTool.Tests         (36 of 86; 25 pure units, 24 need the
 #                                              gitignored real store .db files, 1 manual tool)
 
 # The installer is NOT in IndyPOS.sln, so the two commands above never touch it.
@@ -162,8 +162,8 @@ dotnet run --project src/IndyPOS.AppHost --launch-profile https
 # Dashboard: https://localhost:17222
 ```
 
-Solution suites total **535** with Docker running and the real store databases present (534 pass,
-1 skipped). Without those databases the suite discovers **515**, still all green — a skipped
+Solution suites total **546** with Docker running and the real store databases present (545 pass,
+1 skipped). Without those databases the suite discovers **526**, still all green — a skipped
 `[Theory]` is one entry, not one per row. See [`ONBOARDING.md`](ONBOARDING.md) for the per-suite
 breakdown, the dev-vs-installed port split, and the `/health` vs `/health/ready` trap.
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -51,12 +51,12 @@ dotnet test
 They spin up a real PostgreSQL container via Testcontainers. With Docker stopped they fail **fast**
 (each suite in under a second), which reads exactly like a code regression but is not.
 
-Expect **118 failures** with Docker stopped, all from these two suites. That figure is **derived**
-(87 + 31 by construction), not measured — the suites were last run with Docker up:
+Expect **123 failures** with Docker stopped, all from these two suites. That figure is **derived**
+(87 + 36 by construction), not measured — the suites were last run with Docker up:
 
 | Suite | Total | Fails without Docker |
 |---|---|---|
-| `IndyPOS.MigrationTool.Tests` | 75 | **31** (of the other 44, see Trap 3) |
+| `IndyPOS.MigrationTool.Tests` | 86 | **36** (of the other 50, see Trap 3) |
 | `IndyPOS.StoreHub.IntegrationTests` | 94 | **87** (7 need no container) |
 
 **Start Docker and re-run before investigating any of these.**
@@ -82,12 +82,12 @@ returned early instead, so 8 tests reported *Passed* on every machine but one, i
 tests also used one-directional `Should().Contain(...)` column checks, which a table with extra
 columns satisfies — so they could not have detected a dropped column even when they did run.
 
-So `IndyPOS.MigrationTool.Tests`'s 75 break down as: **31** need Docker, **24** need those real
-databases, **19** are pure units needing neither, and **1** is the manual schema extractor (Trap 3b).
+So `IndyPOS.MigrationTool.Tests`'s 86 break down as: **36** need Docker, **24** need those real
+databases, **25** are pure units needing neither, and **1** is the manual schema extractor (Trap 3b).
 
 **The total itself changes.** A skipped `[Theory]` is one skipped entry, not one per data row, so the
 21-case artefact comparison collapses to a single entry. On a fresh clone the suite therefore
-discovers **55**, not 75: 50 pass, **5 skipped**, 0 failed. Nothing turns red.
+discovers **66**, not 86: 61 pass, **5 skipped**, 0 failed. Nothing turns red.
 
 ### ⚠️ Trap 3b — regenerating the schema artefacts needs an environment variable
 
@@ -105,13 +105,13 @@ reports `Skipped: 1` and writes nothing — which looks like success while leavi
 ### Expected counts
 
 Solution suites (`dotnet test` at the root), Docker running **and** the real store databases present
-— **535 total** (534 pass, 1 skipped). Without those databases the total is **515**, still all green:
+— **546 total** (545 pass, 1 skipped). Without those databases the total is **526**, still all green:
 
 | Suite | Tests |
 |---|---|
 | `IndyPOS.Application.Tests` | 294 |
 | `IndyPOS.StoreHub.IntegrationTests` | 94 (Docker) |
-| `IndyPOS.MigrationTool.Tests` | 75 (Docker; 1 skipped. **55** without the real store data — Trap 3) |
+| `IndyPOS.MigrationTool.Tests` | 86 (Docker; 1 skipped. **66** without the real store data — Trap 3) |
 | `IndyPOS.Domain.Tests` | 36 |
 | `IndyPOS.Windows.Forms.Tests` | 19 |
 | `IndyPOS.Vault.Tests` | 17 |

--- a/docs/superpowers/plans/2026-08-04-migration-phase-isolation.md
+++ b/docs/superpowers/plans/2026-08-04-migration-phase-isolation.md
@@ -1,0 +1,766 @@
+# Migration Phase Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A phase-level failure in the migrator records a diagnosis and lets the remaining phases run, instead of throwing out of `MigrateAllAsync` and silently discarding an entire in-memory migration.
+
+**Architecture:** Three layers, in dependency order. `MigrationResult` gains a phase-failure list, a three-state `Outcome`, and a per-phase cap on error strings. `SqliteMigrationService` routes its four phase calls through a `RunPhaseAsync` wrapper and gates `SaveChangesAsync` on there being no phase failure — so atomicity is preserved deliberately rather than by an escaping exception. `Program.cs` then reports the three outcomes distinctly, because "completed with errors" applied to a run that wrote nothing would tell the operator their store is mostly migrated.
+
+**Tech Stack:** C# .NET 10, xUnit 2.9.3, FluentAssertions 8.3.0, Dapper, System.Data.SQLite, Testcontainers.PostgreSql (Docker required for Task 2 and 3 tests).
+
+**Spec:** `docs/superpowers/specs/2026-08-04-migration-phase-isolation-design.md`
+**Defect:** 12 in `.planning/indypos-overhaul/PLAN.md`
+**Branch:** `fix/migration-phase-isolation`, off `development` at `2901d1b` (PR #61 merged).
+
+## Global Constraints
+
+- **Atomicity must not change.** One `SaveChangesAsync` for the whole run. A phase failure persists **nothing**. Never make a phase commit independently — a store with products and half its sales history that reports success is worse than the crash being replaced.
+- **`IsSuccess` must account for phase failures.** `Program.cs:163` is `context.ExitCode = result.IsSuccess ? 0 : 1`. If `IsSuccess` ignores phase failures, a migration that wrote nothing exits **0** and announces success.
+- **`Failed` counts stay exact.** Only human-readable error *strings* are capped. No number in the report may become an approximation.
+- **`OperationCanceledException` is rethrown**, never recorded as a phase failure. A cancelled run is an operator decision, not a schema defect.
+- **Existing tests are the regression net.** All 75 in `tests/IndyPOS.MigrationTool.Tests` must stay green. Do not weaken an existing assertion to accommodate a change.
+- **Pinning tests exist in this suite** and assert today's *wrong* behaviour on purpose. Do not "fix" one because it looks inverted — read its comment.
+- Docker must be running for Task 2 and Task 3 tests. Task 1's tests are pure units and need neither Docker nor the real store databases.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/IndyPOS.MigrationTool/MigrationResult.cs` (modify) | The result contract: phase failures, `Outcome`, bounded error strings | 1 |
+| `tests/IndyPOS.MigrationTool.Tests/MigrationResultTests.cs` (create) | Pure unit tests for that contract | 1 |
+| `src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs` (modify) | `RunPhaseAsync`, the four wrapped calls, the save gate, `AddError` call sites | 2, 3 |
+| `tests/IndyPOS.MigrationTool.Tests/MigrationPhaseIsolationTests.cs` (create) | Integration tests driving real column drift | 2, 3 |
+| `src/IndyPOS.MigrationTool/Program.cs` (modify) | Three distinct operator-facing outcomes | 3 |
+
+---
+
+## Task 1: The result contract
+
+**Files:**
+- Modify: `src/IndyPOS.MigrationTool/MigrationResult.cs`
+- Create: `tests/IndyPOS.MigrationTool.Tests/MigrationResultTests.cs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces, all used by Tasks 2 and 3:
+  - `sealed record MigrationPhaseFailure(string Phase, string Message)`
+  - `enum MigrationOutcome { Success, CompletedWithErrors, Aborted }`
+  - `MigrationResult.PhaseFailures` → `List<MigrationPhaseFailure>`
+  - `MigrationResult.Outcome` → `MigrationOutcome`
+  - `MigrationResult.IsSuccess` → `bool` (now `Outcome == MigrationOutcome.Success`)
+  - `MigrationResult.Errors` → `IReadOnlyList<string>` (was `List<string>`)
+  - `void MigrationResult.AddError(string phase, string message)`
+  - `void MigrationResult.AddPhaseFailure(string phase, string message)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/IndyPOS.MigrationTool.Tests/MigrationResultTests.cs`:
+
+```csharp
+namespace IndyPOS.MigrationTool.Tests;
+
+/// <summary>
+/// Pure unit tests. No Docker, no database, no real store data.
+/// </summary>
+public class MigrationResultTests
+{
+    [Fact]
+    public void Outcome_WithAPhaseFailure_IsAbortedAndIsSuccessIsFalse()
+    {
+        // THE load-bearing test of defect 12's fix. Program.cs derives its exit code from IsSuccess.
+        // Before this fix a phase failure threw, so the operator got a red message and exit 1. Now it
+        // returns normally -- so if IsSuccess ignored PhaseFailures, a migration that wrote NOTHING
+        // would exit 0 and announce success. That would be worse than the defect being fixed.
+        var result = new MigrationResult();
+        result.Users.Migrated = 12;
+
+        result.AddPhaseFailure("PayLater", "SQL logic error: no such column: PaidAmount");
+
+        result.Outcome.Should().Be(MigrationOutcome.Aborted);
+        result.IsSuccess.Should().BeFalse("nothing was persisted, so the exit code must be non-zero");
+        result.PhaseFailures.Should().ContainSingle()
+              .Which.Should().BeEquivalentTo(
+                  new MigrationPhaseFailure("PayLater", "SQL logic error: no such column: PaidAmount"));
+    }
+
+    [Fact]
+    public void Outcome_WithOnlyRowFailures_IsCompletedWithErrors()
+    {
+        // Distinct from Aborted: these rows were refused but the run still committed, so data WAS
+        // written. Conflating the two would tell an operator their store is mostly migrated when
+        // nothing at all was written.
+        var result = new MigrationResult();
+        result.Invoices.Migrated = 500;
+        result.Payments.Failed = 1;
+
+        result.Outcome.Should().Be(MigrationOutcome.CompletedWithErrors);
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Outcome_WithNothingFailed_IsSuccess()
+    {
+        var result = new MigrationResult();
+        result.Users.Migrated = 3;
+        result.Products.Skipped = 2;
+
+        result.Outcome.Should().Be(MigrationOutcome.Success);
+        result.IsSuccess.Should().BeTrue("skipped rows are not failures");
+    }
+
+    [Fact]
+    public void AddError_PastTheCap_BoundsTheStringsAndSaysHowManyWereDropped()
+    {
+        // An upstream phase failure makes every downstream row miss its lookup: up to 325,780
+        // near-identical strings on real GeneralHardware data, burying the one line that explains
+        // the cause.
+        var result = new MigrationResult();
+
+        for (var i = 1; i <= 250; i++)
+        {
+            result.AddError("Invoices", $"Invoice {i}: product not found");
+        }
+
+        result.Errors.Should().HaveCount(101, "100 real errors plus one suppression note");
+        result.Errors.Last().Should().Be("Invoices: 150 further error(s) suppressed.");
+    }
+
+    [Fact]
+    public void AddError_CapsEachPhaseIndependently()
+    {
+        var result = new MigrationResult();
+
+        for (var i = 1; i <= 150; i++)
+        {
+            result.AddError("Invoices", $"Invoice {i}: product not found");
+            result.AddError("PayLater", $"PayLater {i}: no migrated payment");
+        }
+
+        result.Errors.Should().HaveCount(202, "each phase gets its own 100 plus its own note");
+        result.Errors.Should().Contain("Invoices: 50 further error(s) suppressed.");
+        result.Errors.Should().Contain("PayLater: 50 further error(s) suppressed.");
+    }
+
+    [Fact]
+    public void AddError_UnderTheCap_KeepsEveryMessageVerbatim()
+    {
+        var result = new MigrationResult();
+
+        result.AddError("PayLater", "PayLater 999: no migrated payment for legacy PaymentId 999");
+
+        result.Errors.Should().ContainSingle()
+              .Which.Should().Be("PayLater 999: no migrated payment for legacy PaymentId 999");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.MigrationTool.Tests --filter "MigrationResultTests"`
+Expected: **compile errors** — `MigrationOutcome`, `AddPhaseFailure`, `AddError` and `PhaseFailures` do not exist yet. A compile failure is the correct "red" here.
+
+- [ ] **Step 3: Implement the contract**
+
+In `src/IndyPOS.MigrationTool/MigrationResult.cs`, add above `public class MigrationResult`:
+
+```csharp
+/// <summary>
+/// A phase that failed as a whole -- its query threw, so none of its rows were examined. Distinct
+/// from a per-row failure: a phase failure means NOTHING is persisted for the entire run.
+/// </summary>
+public sealed record MigrationPhaseFailure(string Phase, string Message);
+
+/// <summary>
+/// The three outcomes an operator must be able to tell apart. Collapsing <see cref="Aborted"/> into
+/// <see cref="CompletedWithErrors"/> would report a run that wrote nothing as a partial success.
+/// </summary>
+public enum MigrationOutcome
+{
+    /// <summary>Everything migrated, and it was committed.</summary>
+    Success,
+
+    /// <summary>Committed, but individual rows were refused. Data WAS written.</summary>
+    CompletedWithErrors,
+
+    /// <summary>A phase failed wholesale, so NOTHING was written.</summary>
+    Aborted
+}
+```
+
+Then replace the `Errors` and `IsSuccess` members of `MigrationResult` with:
+
+```csharp
+    /// <summary>Per phase, because a cascade from one failure must not bury every other phase.</summary>
+    private const int MaxErrorsPerPhase = 100;
+
+    private readonly List<string> _errors = [];
+    private readonly Dictionary<string, int> _errorCountByPhase = [];
+    private readonly Dictionary<string, int> _suppressionNoteIndexByPhase = [];
+
+    /// <summary>Read-only so every write goes through <see cref="AddError"/> and stays bounded.</summary>
+    public IReadOnlyList<string> Errors => _errors;
+
+    /// <summary>Phases that failed as a whole. Non-empty means nothing was persisted.</summary>
+    public List<MigrationPhaseFailure> PhaseFailures { get; } = [];
+
+    public MigrationOutcome Outcome =>
+        PhaseFailures.Count > 0 ? MigrationOutcome.Aborted :
+        AnyRowFailed ? MigrationOutcome.CompletedWithErrors :
+        MigrationOutcome.Success;
+
+    /// <remarks>
+    /// Defect 12: this MUST count phase failures. Program.cs turns it into the process exit code, so
+    /// a phase failure that left IsSuccess true would exit 0 on a run that wrote nothing.
+    /// </remarks>
+    public bool IsSuccess => Outcome == MigrationOutcome.Success;
+
+    private bool AnyRowFailed => Users.Failed > 0 || Products.Failed > 0 ||
+                                 Invoices.Failed > 0 || Payments.Failed > 0 ||
+                                 PayLater.Failed > 0;
+
+    /// <summary>
+    /// Records a per-row error, capped per phase. The <see cref="EntityMigrationResult.Failed"/>
+    /// counts stay exact -- only these strings are capped, because an upstream phase failure makes
+    /// every downstream row miss its lookup (up to 325,780 on real data).
+    /// </summary>
+    public void AddError(string phase, string message)
+    {
+        var alreadyRecorded = _errorCountByPhase.GetValueOrDefault(phase);
+        _errorCountByPhase[phase] = alreadyRecorded + 1;
+
+        if (alreadyRecorded < MaxErrorsPerPhase)
+        {
+            _errors.Add(message);
+            return;
+        }
+
+        var note = $"{phase}: {alreadyRecorded + 1 - MaxErrorsPerPhase} further error(s) suppressed.";
+
+        if (_suppressionNoteIndexByPhase.TryGetValue(phase, out var index))
+        {
+            _errors[index] = note;
+            return;
+        }
+
+        _errors.Add(note);
+        _suppressionNoteIndexByPhase[phase] = _errors.Count - 1;
+    }
+
+    public void AddPhaseFailure(string phase, string message) =>
+        PhaseFailures.Add(new MigrationPhaseFailure(phase, message));
+```
+
+Leave `Users`, `Products`, `Invoices`, `Payments`, `PayLater`, `TotalMigrated` and the four ID maps exactly as they are.
+
+- [ ] **Step 4: Fix the now-broken writers so the solution compiles**
+
+`Errors` is read-only now, so the six `_result.Errors.Add(...)` calls in
+`src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs` will not compile. Convert each to
+`AddError` with its phase name (this is the call-site migration the cap needs):
+
+| Line (approx) | Was | Becomes |
+|---|---|---|
+| 127 | `_result.Errors.Add($"User {user.UserId}: {ex.Message}");` | `_result.AddError("Users", $"User {user.UserId}: {ex.Message}");` |
+| 205 | `_result.Errors.Add($"Product {product.Barcode}: {ex.Message}");` | `_result.AddError("Products", $"Product {product.Barcode}: {ex.Message}");` |
+| 301 | `_result.Errors.Add(` (payment-method refusal) | `_result.AddError("Invoices",` — keep the message text byte-identical |
+| 338 | `_result.Errors.Add($"Invoice {invoice.InvoiceId}: {ex.Message}");` | `_result.AddError("Invoices", $"Invoice {invoice.InvoiceId}: {ex.Message}");` |
+| 390 | `_result.Errors.Add(` (PayLater map miss) | `_result.AddError("PayLater",` — keep the message text byte-identical |
+| 425 | `_result.Errors.Add($"PayLater {payLater.PaymentId}: {ex.Message}");` | `_result.AddError("PayLater", $"PayLater {payLater.PaymentId}: {ex.Message}");` |
+
+⚠️ **Do not reword any message.** Existing tests assert on their content — e.g.
+`result.Errors.Should().ContainSingle().Which.Should().Contain("999")` and
+`.Contain("PaymentTypeId 6")`. Only the call changes, never the string.
+
+`MigrationVerifier.cs` also writes to a `result.Errors`, but that is `VerificationResult` — a
+different class. Do **not** touch it.
+
+- [ ] **Step 5: Run the new tests and the whole suite**
+
+Run: `dotnet test tests/IndyPOS.MigrationTool.Tests --filter "MigrationResultTests"`
+Expected: **6 passed.**
+
+Run: `dotnet test tests/IndyPOS.MigrationTool.Tests`
+Expected: **80 passed, 1 skipped, 81 total, 0 failed.** (The branch point is 74 passed + 1 skipped =
+75; these 6 new tests are all passing additions.) State the numbers you actually observe. If any
+pre-existing test now fails, STOP — a message was reworded, or `IsSuccess` changed meaning for a case
+that is not a phase failure.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/IndyPOS.MigrationTool/MigrationResult.cs \
+        src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs \
+        tests/IndyPOS.MigrationTool.Tests/MigrationResultTests.cs
+git commit -m "feat(migration): add phase failures and bounded errors to MigrationResult
+
+Defect 12, part 1 of 3. The result type could not express 'a whole phase
+failed', because such a failure threw out of MigrateAllAsync and no result
+was ever returned.
+
+Adds PhaseFailures, a three-state Outcome, and AddError with a per-phase cap
+of 100 strings. Failed COUNTS stay exact -- only the strings are capped,
+because an upstream phase failure makes every downstream row miss its lookup
+(up to 325,780 near-identical messages on real data, burying the cause).
+
+IsSuccess now derives from Outcome, so it counts phase failures. That line is
+load-bearing: Program.cs turns IsSuccess into the process exit code, so
+without it a run that wrote nothing would exit 0 and report success.
+
+Errors becomes IReadOnlyList so every write goes through the cap; the six
+call sites move to AddError with their phase names and byte-identical
+message text."
+```
+
+---
+
+## Task 2: Phase isolation and the save gate
+
+**Files:**
+- Modify: `src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs:26-62`
+- Create: `tests/IndyPOS.MigrationTool.Tests/MigrationPhaseIsolationTests.cs`
+
+**Interfaces:**
+- Consumes: everything Task 1 produced. Also `MigrationScenario.RunAsync(store, postgres, dryRun)` from `PayLaterMigrationTests.cs`, `LegacyStoreDatabase.CreateAsync(LegacyStoreShape)`, `LegacyStoreDataBuilder`, `PostgresFixture`.
+- Produces: `private Task RunPhaseAsync(string phase, Func<Task> migratePhase)`. Nothing outside the class uses it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/IndyPOS.MigrationTool.Tests/MigrationPhaseIsolationTests.cs`:
+
+```csharp
+using Dapper;
+using IndyPOS.MigrationTool.Tests.Fixtures;
+using IndyPOS.MigrationTool.Tests.Tools;
+using Microsoft.EntityFrameworkCore;
+
+namespace IndyPOS.MigrationTool.Tests;
+
+/// <summary>
+/// Defect 12. A phase-level throw used to escape MigrateAllAsync entirely, and because
+/// SaveChangesAsync runs after the last phase, an entire in-memory migration was discarded with only
+/// a stack trace to show for it.
+///
+/// The drift is induced the way it will really happen -- a real artefact schema with a column
+/// removed -- because that is exactly what defects 2 and 3 were.
+/// </summary>
+[Collection("Postgres")]
+public class MigrationPhaseIsolationTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+
+    public MigrationPhaseIsolationTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync() => _postgres.ResetDatabaseAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// A healthy credit sale: user, product, invoice, line, type-2 payment, PayLater extension.
+    /// Every phase has something to do, so "an earlier phase succeeded" is a real claim.
+    /// </summary>
+    private static async Task SeedOneOfEverythingAsync(LegacyStoreDatabase store)
+    {
+        var builder = new LegacyStoreDataBuilder(store);
+        await builder.AddPaymentTypeLookupAsync();
+        await builder.AddUserAsync(1, "cashier", "Somchai", "Jaidee", 1, "2024-03-15 09:00:00");
+        await builder.AddProductAsync(
+            productId: 10, barcode: "8850001000010", description: "Cement 50kg",
+            unitPrice: 700m, quantityInStock: 20, category: 50, isTrackable: true,
+            dateCreated: "2024-03-15 09:00:00");
+        await builder.AddInvoiceAsync(1, userId: 1, total: 700m, dateCreated: "2024-03-15 14:30:00");
+        await builder.AddInvoiceLineAsync(
+            invoiceProductId: 1, invoiceId: 1, productId: 10, barcode: "8850001000010",
+            description: "Cement 50kg", quantity: 1, unitPrice: 700m, originalUnitPrice: 700m);
+        await builder.AddPaymentAsync(
+            paymentId: 500, invoiceId: 1, paymentTypeId: 2, amount: 700m,
+            dateCreated: "2024-03-15 14:30:00", note: "Somchai");
+        await builder.AddPayLaterAsync(
+            paymentId: 500, invoiceId: 1, description: "Somchai", payLaterAmount: 700m,
+            paidAmount: 0m, isCompleted: false, dateCreated: "2024-03-15 14:30:00");
+    }
+
+    /// <summary>
+    /// Drops a column the migrator's SELECT names by hand, which is what column drift looks like.
+    /// PaidAmount is a plain NUMERIC with no index, no UNIQUE and no PK role, so SQLite permits it.
+    /// </summary>
+    private static Task DropPayLaterPaidAmountAsync(LegacyStoreDatabase store) =>
+        store.Connection.ExecuteAsync("ALTER TABLE PayLater DROP COLUMN PaidAmount;");
+
+    [Fact]
+    public async Task MigrateAllAsync_WhenAPhaseFails_DoesNotThrowAndNamesThePhase()
+    {
+        await using var store = await LegacyStoreDatabase.CreateAsync(LegacyStoreShape.GeneralHardware);
+        await SeedOneOfEverythingAsync(store);
+        await DropPayLaterPaidAmountAsync(store);
+
+        var result = await MigrationScenario.RunAsync(store, _postgres);
+
+        result.PhaseFailures.Should().ContainSingle(
+            "the PayLater SELECT names PaidAmount, so it throws -- and that must be caught");
+        var failure = result.PhaseFailures.Single();
+        failure.Phase.Should().Be("PayLater");
+        failure.Message.Should().Contain("PaidAmount",
+            "the operator needs the actual cause, not just the phase name");
+    }
+
+    [Fact]
+    public async Task MigrateAllAsync_WhenAPhaseFails_ReportsFailureSoTheExitCodeIsNonZero()
+    {
+        // Program.cs:163 is `context.ExitCode = result.IsSuccess ? 0 : 1`. Before this fix the phase
+        // threw and was caught there, so the operator got exit 1. Now it returns normally -- so
+        // IsSuccess is the ONLY thing standing between a store that migrated nothing and a green
+        // "success" on the console.
+        await using var store = await LegacyStoreDatabase.CreateAsync(LegacyStoreShape.GeneralHardware);
+        await SeedOneOfEverythingAsync(store);
+        await DropPayLaterPaidAmountAsync(store);
+
+        var result = await MigrationScenario.RunAsync(store, _postgres);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Outcome.Should().Be(MigrationOutcome.Aborted);
+    }
+
+    [Fact]
+    public async Task MigrateAllAsync_WhenAPhaseFails_PersistsNothingFromEarlierPhases()
+    {
+        // The property that keeps defect 12 merely expensive rather than catastrophic. Users,
+        // products and invoices all migrated successfully IN MEMORY before PayLater threw. None of
+        // it may reach PostgreSQL: a store holding products and part of its sales history, reported
+        // as a success, is worse than no migration at all.
+        await using var store = await LegacyStoreDatabase.CreateAsync(LegacyStoreShape.GeneralHardware);
+        await SeedOneOfEverythingAsync(store);
+        await DropPayLaterPaidAmountAsync(store);
+
+        var result = await MigrationScenario.RunAsync(store, _postgres);
+
+        result.Users.Migrated.Should().Be(1, "the Users phase itself succeeded");
+        result.Products.Migrated.Should().Be(1);
+        result.Invoices.Migrated.Should().Be(1);
+
+        await using var db = _postgres.CreateDbContext();
+        (await db.StoreUsers.CountAsync()).Should().Be(0, "no phase may be committed when another failed");
+        (await db.Products.CountAsync()).Should().Be(0);
+        (await db.Invoices.CountAsync()).Should().Be(0);
+        (await db.Payments.CountAsync()).Should().Be(0);
+        (await db.PayLaters.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MigrateAllAsync_WhenAnEarlyPhaseFails_StillAttemptsTheLaterOnes()
+    {
+        // The whole point of isolating the diagnosis: one attempt reports every schema problem.
+        // Re-running against a real shop costs a visit with the till switched off, so learning about
+        // one broken phase per run is expensive.
+        // Manufacturer is named explicitly in the Products SELECT and is a plain nullable TEXT with
+        // no index, so dropping it makes that phase -- and only that phase -- throw.
+        await using var store = await LegacyStoreDatabase.CreateAsync(LegacyStoreShape.GeneralHardware);
+        await SeedOneOfEverythingAsync(store);
+        await store.Connection.ExecuteAsync("ALTER TABLE InventoryProduct DROP COLUMN Manufacturer;");
+
+        var result = await MigrationScenario.RunAsync(store, _postgres);
+
+        result.PhaseFailures.Should().ContainSingle().Which.Phase.Should().Be("Products");
+        result.Users.Migrated.Should().Be(1, "the phase before the failure still ran");
+        result.Invoices.Migrated.Should().Be(1, "the phase AFTER the failure still ran");
+        result.PayLater.Migrated.Should().Be(1, "and so did the last one");
+        result.IsSuccess.Should().BeFalse("a phase still failed, so nothing was written");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/IndyPOS.MigrationTool.Tests --filter "MigrationPhaseIsolationTests"`
+Expected: **4 failed.** The first three fail because the SQLite exception escapes `MigrateAllAsync`
+(the test reports the raised `SQLiteException`, not an assertion failure) — which is precisely defect
+12. Confirm the failure message mentions `PaidAmount` or `Manufacturer`; if instead you see
+`ALTER TABLE ... DROP COLUMN` rejected by SQLite, apply the spec's §5 fallback (drop and recreate the
+table from the artefact DDL without that column) before continuing.
+
+- [ ] **Step 3: Implement the wrapper and the save gate**
+
+In `src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs`, replace the four phase calls and
+the save block (currently lines 47-56) with:
+
+```csharp
+        // Order matters: Users → Products → Invoices (with lines/payments) → PayLater
+        // Defect 12: each phase is isolated so ONE run reports every schema problem. Re-running
+        // against a real shop costs a visit with the till switched off.
+        await RunPhaseAsync("Users", () => MigrateUsersAsync(sqliteConnection, context, ct));
+        await RunPhaseAsync("Products", () => MigrateProductsAsync(sqliteConnection, context, ct));
+        await RunPhaseAsync("Invoices", () => MigrateInvoicesAsync(sqliteConnection, context, ct));
+        await RunPhaseAsync("PayLater", () => MigratePayLaterAsync(sqliteConnection, context, ct));
+
+        // Isolating the diagnosis must NOT isolate the transaction. If any phase failed the run is
+        // not trustworthy, so nothing is written -- the same outcome as before, reached deliberately
+        // instead of by an exception escaping past this line. A half-migrated store that reported
+        // success would be far worse than the crash this replaces.
+        if (!_options.DryRun && _result.PhaseFailures.Count == 0)
+        {
+            await context.SaveChangesAsync(ct);
+        }
+```
+
+Then add this private method next to the phase methods:
+
+```csharp
+    /// <summary>
+    /// Runs one migration phase, turning a phase-level throw into a recorded failure so the remaining
+    /// phases still run and report their own state.
+    /// </summary>
+    /// <remarks>
+    /// Nothing is swallowed: a recorded failure makes <see cref="MigrationResult.IsSuccess"/> false,
+    /// which is the process exit code, prints an ABORTED banner, and suppresses the save.
+    /// </remarks>
+    private async Task RunPhaseAsync(string phase, Func<Task> migratePhase)
+    {
+        try
+        {
+            await migratePhase();
+        }
+        catch (OperationCanceledException)
+        {
+            // An operator cancelling is not a defect in the store's schema.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Migration phase {Phase} failed. Nothing will be persisted for this run.", phase);
+            _result.AddPhaseFailure(phase, ex.Message);
+        }
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/IndyPOS.MigrationTool.Tests --filter "MigrationPhaseIsolationTests"`
+Expected: **4 passed.**
+
+- [ ] **Step 5: Prove the tests are not vacuous**
+
+Two probes, each reverted immediately afterwards. Confirm `git diff -- src/` is empty before moving on.
+
+1. Make `RunPhaseAsync` rethrow: add `throw;` as the last line of the `catch (Exception ex)` block.
+   Run the class: the first three tests **must fail** with the escaping `SQLiteException`. Revert.
+2. Make the save gate ignore phase failures: change the condition to `if (!_options.DryRun)`.
+   Run the class: `MigrateAllAsync_WhenAPhaseFails_PersistsNothingFromEarlierPhases` **must fail**,
+   reporting non-zero counts — i.e. the half-migrated store the Global Constraints forbid. Revert.
+
+If either probe leaves the tests green, the test is not testing what it claims. Stop and report.
+
+- [ ] **Step 6: Run the whole suite**
+
+Run: `dotnet test tests/IndyPOS.MigrationTool.Tests`
+Expected: **85 total** (81 after Task 1, plus 4), 1 skipped, 0 failed. In particular
+`MigrateAllAsync_InDryRun_ShouldWriteNothing` and the defect 2/3 completion tests must still pass,
+proving a healthy run is unaffected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs \
+        tests/IndyPOS.MigrationTool.Tests/MigrationPhaseIsolationTests.cs
+git commit -m "fix(migration): isolate phase failures without breaking atomicity
+
+Defect 12, part 2 of 3. The four phase calls sat in no try, and
+SaveChangesAsync runs after the last of them, so a schema-level throw escaped
+MigrateAllAsync and discarded an entire in-memory migration. That is what
+defects 2 and 3 did to every real store; fixing their column names left the
+amplifier in place for the next drift.
+
+Each phase now runs through RunPhaseAsync, which records a phase failure
+instead of throwing, so all four are attempted and ONE run reports every
+schema problem. Re-running against a real shop costs a visit with the till
+switched off.
+
+Atomicity is deliberately preserved: the save is gated on there being no
+phase failure, so nothing is written -- the same outcome as before, reached
+on purpose rather than by an escaping exception. Letting phases commit
+independently was considered and rejected in the spec: a store holding
+products and half its sales history, reporting success, is the same class of
+harm as defect 10.
+
+OperationCanceledException is rethrown; a cancelled run is an operator
+decision, not a schema defect.
+
+Tests induce the drift the way it will really happen -- ALTER TABLE DROP
+COLUMN on a real artefact schema -- and both directions are proven
+non-vacuous: making RunPhaseAsync rethrow fails three of them, and ungating
+the save fails the no-partial-write test."
+```
+
+---
+
+## Task 3: Tell the operator the truth
+
+**Files:**
+- Modify: `src/IndyPOS.MigrationTool/Program.cs:301-316`
+- Modify: `tests/IndyPOS.MigrationTool.Tests/MigrationPhaseIsolationTests.cs` (add one test)
+
+**Interfaces:**
+- Consumes: `MigrationResult.Outcome`, `MigrationOutcome`, `MigrationResult.PhaseFailures` from Task 1; the wrapper from Task 2.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+The console rendering itself is `AnsiConsole` output and not worth a capture harness — Task 1 already
+unit-tests the `Outcome` decision that drives it. What is untested is that a real cascade stays
+bounded while the counts stay exact. Append to `MigrationPhaseIsolationTests.cs`:
+
+```csharp
+    [Fact]
+    public async Task MigrateAllAsync_WithMoreRowErrorsThanTheCap_BoundsTheStringsButNotTheCounts()
+    {
+        // Drives the cap through the real service. This run has NO phase failure -- it reaches the cap
+        // with ordinary per-row refusals, which is the cheapest way to exercise it. The cascade the cap
+        // exists for (a failed Products phase making every invoice line miss its lookup, up to 325,780
+        // near-identical strings on real data) is the same code path with a bigger multiplier.
+        await using var store = await LegacyStoreDatabase.CreateAsync(LegacyStoreShape.GeneralHardware);
+        var builder = new LegacyStoreDataBuilder(store);
+        await builder.AddPaymentTypeLookupAsync();
+        await builder.AddUserAsync(1, "cashier", "Somchai", "Jaidee", 1, "2024-03-15 09:00:00");
+        await builder.AddProductAsync(
+            productId: 10, barcode: "8850001000010", description: "Cement 50kg",
+            unitPrice: 1m, quantityInStock: 5, category: 50, isTrackable: true,
+            dateCreated: "2024-03-15 09:00:00");
+
+        // 150 invoices, each paid by a legacy type with no catalogue code, so each records one
+        // per-row error in the Invoices phase -- 150 > the cap of 100.
+        for (var i = 1; i <= 150; i++)
+        {
+            await builder.AddInvoiceAsync(i, userId: 1, total: 1m, dateCreated: "2024-03-15 14:30:00");
+            await builder.AddPaymentAsync(
+                paymentId: 500 + i, invoiceId: i, paymentTypeId: 6, amount: 1m,
+                dateCreated: "2024-03-15 14:30:00");
+        }
+
+        var result = await MigrationScenario.RunAsync(store, _postgres);
+
+        result.Payments.Failed.Should().Be(150, "the COUNT must stay exact");
+        result.Errors.Should().HaveCount(101, "100 strings plus one suppression note");
+        result.Errors.Last().Should().Be("Invoices: 50 further error(s) suppressed.");
+    }
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `dotnet test tests/IndyPOS.MigrationTool.Tests --filter "BoundsTheStringsButNotTheCounts"`
+Expected: **PASS** — Task 1 already implemented the cap and moved the call sites. This test exists to
+prove the cap works through the real service rather than only in a unit test. If it fails with 150
+errors instead of 101, a call site at line 301 or 338 was left on the old `Errors.Add`.
+
+- [ ] **Step 3: Split the console output into three outcomes**
+
+In `src/IndyPOS.MigrationTool/Program.cs`, replace the `if (result.IsSuccess) { ... } else { ... }`
+block at lines 301-316 with:
+
+```csharp
+    switch (result.Outcome)
+    {
+        case MigrationOutcome.Success:
+            AnsiConsole.MarkupLine("\n[green]✓ Migration completed successfully![/]");
+            break;
+
+        case MigrationOutcome.Aborted:
+            // Distinct from "completed with errors" on purpose: NOTHING was written. Saying
+            // "completed" here would tell the operator their store is mostly migrated.
+            AnsiConsole.MarkupLine("\n[red]✗ Migration ABORTED - nothing was written.[/]");
+            AnsiConsole.MarkupLine("[red]  The whole run was discarded because a phase failed:[/]");
+            foreach (var failure in result.PhaseFailures)
+            {
+                AnsiConsole.MarkupLine($"  [red]•[/] [bold]{failure.Phase}[/]: {failure.Message}");
+            }
+            AnsiConsole.MarkupLine(
+                "[grey]  Fix the cause and re-run. The database is untouched.[/]");
+            break;
+
+        default:
+            AnsiConsole.MarkupLine("\n[red]✗ Migration completed with errors[/]");
+            foreach (var error in result.Errors.Take(10))
+            {
+                AnsiConsole.MarkupLine($"  [red]•[/] {error}");
+            }
+            if (result.Errors.Count > 10)
+            {
+                AnsiConsole.MarkupLine($"  [grey]... and {result.Errors.Count - 10} more errors[/]");
+            }
+            break;
+    }
+```
+
+`Program.cs:163` (`context.ExitCode = result.IsSuccess ? 0 : 1`) needs **no change** — Task 1 made
+`IsSuccess` account for phase failures, so an aborted run already exits 1.
+
+- [ ] **Step 4: Verify the whole solution builds and passes**
+
+Run: `dotnet build`
+Expected: 0 errors.
+
+Run: `dotnet test tests/IndyPOS.MigrationTool.Tests`
+Expected: **86 total**, 1 skipped, 0 failed.
+
+Run: `dotnet test IndyPOS.sln`
+Expected: all six suites green. Record the totals.
+
+- [ ] **Step 5: Update the defect table**
+
+In `.planning/indypos-overhaul/PLAN.md`, change defect 12's Status cell from
+`❌ **new 2026-08-04** — not pinned; needs its own fix spec` to `✅ Fixed <sha of Task 2's commit>`.
+
+Also update the "RESOLVED 2026-08-04" banner note above the table: it currently credits `926a245`
+and `cf61005` with fixing the crash. Add that the *structural* cause — a phase throw discarding the
+whole run — was fixed separately as defect 12, with this plan's sha.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/IndyPOS.MigrationTool/Program.cs \
+        tests/IndyPOS.MigrationTool.Tests/MigrationPhaseIsolationTests.cs \
+        .planning/indypos-overhaul/PLAN.md
+git commit -m "feat(migration): report an aborted run distinctly from a partial one
+
+Defect 12, part 3 of 3. DisplayResults had two branches, so a run that wrote
+NOTHING was announced as 'Migration completed with errors' -- which invites
+the operator to believe the store is mostly migrated and go looking for the
+few bad rows.
+
+Three outcomes now: completed, completed-with-errors (data WAS written), and
+ABORTED - nothing was written, listing each failed phase and its cause and
+stating that the database is untouched.
+
+The exit code needed no change: IsSuccess already counts phase failures.
+
+Adds the cascade test that proves the per-phase cap works through the real
+service -- 150 refused payments produce an exact Failed count of 150 but only
+101 strings -- and marks defect 12 fixed in PLAN.md."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** §1 defect → Task 2. §2 atomicity constraint → Global Constraints + Task 2 Step 3
+save gate + Task 2 Step 5 probe 2 + test 3. §3.1 phase isolation → Task 2. §3.2 save gate and the
+`IsSuccess` warning → Task 1 (`Outcome`/`IsSuccess`) and Task 2, pinned by Task 1's first test and
+Task 2's second. §3.3 bounded errors → Task 1 Steps 3-4, Task 3 Step 1. §3.4 console → Task 3 Step 3.
+§4 out of scope → nothing in any task touches `Database.MigrateAsync`, per-row logic beyond the
+`AddError` call sites, or resumability. §5 tests → Tasks 1-3, all five spec tests present
+(spec test 5 appears as Task 1's cap tests plus Task 3's end-to-end cascade test). §6 risks → each
+has a named mitigation: exit code (Task 1 test 1, Task 2 test 2), nothing swallowed (Task 2 Step 3
+`<remarks>`), cancellation (Task 2 Step 3), cap hiding errors (Task 1 Step 3 suppression note).
+
+**Placeholder scan.** No TBD/TODO. Every code step contains the actual code. The one conditional
+instruction (Task 2 Step 2's SQLite fallback) names the exact alternative and the trigger for it.
+
+**Type consistency.** `AddError(string phase, string message)`, `AddPhaseFailure(string phase, string message)`,
+`MigrationPhaseFailure(string Phase, string Message)`, `MigrationOutcome { Success, CompletedWithErrors, Aborted }`,
+`PhaseFailures`, `Outcome`, `IsSuccess`, `Errors` as `IReadOnlyList<string>`, and
+`RunPhaseAsync(string phase, Func<Task> migratePhase)` are spelled identically in every task that
+uses them. Phase name strings — `"Users"`, `"Products"`, `"Invoices"`, `"PayLater"` — match between
+Task 1 Step 4's call-site table, Task 2 Step 3's wrapper calls, and every assertion.
+
+**Count arithmetic.** 75 at branch point → 81 after Task 1 (+6) → 85 after Task 2 (+4) → 86 after
+Task 3 (+1). One of these is the always-skipped extractor, so expect "N−1 passed, 1 skipped".

--- a/docs/superpowers/specs/2026-08-04-migration-phase-isolation-design.md
+++ b/docs/superpowers/specs/2026-08-04-migration-phase-isolation-design.md
@@ -1,0 +1,207 @@
+# Migration phase isolation — design
+
+**Date:** 2026-08-04
+**Defect:** 12 (`.planning/indypos-overhaul/PLAN.md`)
+**Depends on:** PR #61 (`feat/epic2-migration-coverage`). The tests need `LegacyStoreDatabase` and
+`LegacyStoreDataBuilder`, which land in that PR, so this work **stacks on that branch** and its PR
+must merge after #61.
+
+---
+
+## 1. The defect
+
+`MigrateAllAsync` calls four phases and then saves once:
+
+```csharp
+await MigrateUsersAsync(...);      // line 48
+await MigrateProductsAsync(...);
+await MigrateInvoicesAsync(...);
+await MigratePayLaterAsync(...);   // line 51
+
+if (!_options.DryRun)
+{
+    await context.SaveChangesAsync(ct);   // line 55
+}
+```
+
+None of the four calls is wrapped in a `try`. Inside each phase, the per-row loop has a `try`, but the
+`SELECT` that feeds it does not — nor does the `sqlite_master` probe. So a schema-level problem throws
+out of the phase, out of `MigrateAllAsync`, and past line 55.
+
+The tool therefore does the entire migration **in memory** and then discards all of it.
+
+This is exactly what defects 2 and 3 did on every real store: `no such column: PayLaterId` on
+GeneralHardware, `no such table: PayLater` on MimyMart and MimyShop. Those two are fixed, but **only
+at the symptom**. The structure that turned a single wrong column name into "no store can migrate at
+all" is untouched, and it will do the same thing to the next drift — a store whose `PayLater` lacks
+`PaidAmount`, a renamed `InvoiceProduct` column, anything.
+
+### Why this is worth fixing on its own
+
+The failure is silent in the way that matters: the operator sees a stack trace, not a diagnosis, and
+learns nothing about the *other* three phases. Fixing one drift, re-running, and hitting the next is
+an expensive loop when each cycle is a scheduled visit to a working shop whose till is offline.
+
+---
+
+## 2. What must NOT change
+
+**The migration is atomic today, and it stays atomic.** All four phases stage into one `DbContext`
+and a single `SaveChangesAsync` commits them in one transaction. A phase failure means nothing
+persists.
+
+That property is the reason this defect is merely expensive rather than catastrophic, and the obvious
+reading of "isolate the phases so one failure doesn't kill the run" would destroy it. If phases were
+allowed to commit independently, a store could end up with products and half its sales history — and
+report success. Under-counted revenue that reconciles against nothing is the same class of harm as
+defect 10's double-count, and the third instance of this pattern in this epic:
+
+| Defect | The tempting fix | What it would actually cause |
+|---|---|---|
+| 2 | Correct the column names | Silent ฿836k revenue inflation (defect 10 becomes reachable) |
+| 6 | Recompute the discount from the line | A plausible number derived from dead data |
+| **12** | **Let each phase commit on its own** | **A half-migrated store reporting success** |
+
+So: **isolate the diagnosis, not the transaction.**
+
+---
+
+## 3. Design
+
+### 3.1 Phase isolation
+
+Each phase call goes through one wrapper:
+
+```csharp
+await RunPhaseAsync("Users",    () => MigrateUsersAsync(sqlite, context, ct));
+await RunPhaseAsync("Products", () => MigrateProductsAsync(sqlite, context, ct));
+await RunPhaseAsync("Invoices", () => MigrateInvoicesAsync(sqlite, context, ct));
+await RunPhaseAsync("PayLater", () => MigratePayLaterAsync(sqlite, context, ct));
+```
+
+`RunPhaseAsync` catches any exception escaping the phase, logs it, and appends a
+`MigrationPhaseFailure(phase, message)` to the result. It does not rethrow — with one exception:
+`OperationCanceledException` is rethrown, because a cancelled run is an operator decision, not a
+defect in the store's schema, and recording it as a phase failure would misreport it.
+
+**All four phases are always attempted**, even after one fails. That is the point: one run reports
+every schema problem, instead of one per round trip. A phase whose upstream dependency failed will
+produce useless per-row misses — §3.3 keeps that from drowning the signal.
+
+### 3.2 The save gate
+
+```csharp
+if (!_options.DryRun && _result.PhaseFailures.Count == 0)
+{
+    await context.SaveChangesAsync(ct);
+}
+```
+
+Nothing is written when any phase failed — the same outcome as today, reached deliberately instead of
+by an escaping exception.
+
+`MigrationResult` gains:
+
+```csharp
+public List<MigrationPhaseFailure> PhaseFailures { get; } = [];
+
+public bool IsSuccess => PhaseFailures.Count == 0 &&
+                         Users.Failed == 0 && Products.Failed == 0 &&
+                         Invoices.Failed == 0 && Payments.Failed == 0 &&
+                         PayLater.Failed == 0;
+```
+
+> ⚠️ **`IsSuccess` including `PhaseFailures` is the load-bearing line of this whole change.**
+> `Program.cs:163` is `context.ExitCode = result.IsSuccess ? 0 : 1`. Today a phase failure throws and
+> is caught at `Program.cs:165`, so the operator gets a red message and a non-zero exit. After this
+> change it returns normally — so if `IsSuccess` ignored `PhaseFailures`, a migration that wrote
+> **nothing** would exit **0** and announce success. That would be a far worse defect than the one
+> being fixed. It gets its own test (§5, test 2).
+
+### 3.3 Bounded error strings
+
+`MigrationResult.Errors` is unbounded today. When a phase fails, every downstream row misses its
+lookup: on real GeneralHardware data a failed Products phase means up to **325,780** near-identical
+strings (~32 MB), burying the one line that explains the cause.
+
+Add to `MigrationResult`:
+
+```csharp
+public void AddError(string phase, string message)
+```
+
+It appends up to `MaxErrorsPerPhase` (100) strings per phase; on the first one past the cap it appends
+a single `"<Phase>: N further errors suppressed"` note, updated as more arrive.
+
+**`Failed` counts stay exact.** Only the human-readable strings are capped, so no number in the report
+becomes an approximation. The existing `_result.Errors.Add(...)` call sites move to `AddError`.
+
+### 3.4 Console output
+
+`DisplayResults` currently has two branches, success and `"✗ Migration completed with errors"`. After
+this change that message would be shown for a run that wrote nothing — inviting the operator to
+believe the store is mostly migrated. Three branches:
+
+| Condition | Message |
+|---|---|
+| `PhaseFailures.Count > 0` | `✗ Migration ABORTED — nothing was written` + each phase failure |
+| `!IsSuccess` | `✗ Migration completed with errors` (unchanged; data **was** written) |
+| otherwise | `✓ Migration completed successfully!` |
+
+The middle branch keeps its current meaning: per-row failures with a successful commit.
+
+---
+
+## 4. Out of scope
+
+- **`context.Database.MigrateAsync`** (line 42). Failing to reach PostgreSQL is a genuine exception,
+  already caught in `Program.cs`. Wrapping it would convert an infrastructure failure into a
+  data-shaped one.
+- **Per-row handling inside the four phases.** Untouched apart from the `AddError` call sites.
+- **Resumability.** The ID maps are in-memory, so a partial migration cannot be resumed. Out of scope,
+  and §2 is the reason it is not needed.
+- **Defects 4, 5, 6, 7, 8, 11, 13.** Each has its own pinning test and its own fix.
+
+---
+
+## 5. Tests
+
+Named for the defect, in `tests/IndyPOS.MigrationTool.Tests`.
+
+The drift is induced the way it will actually happen — a real artefact schema with a column removed —
+rather than by a mock:
+
+```csharp
+await store.Connection.ExecuteAsync("ALTER TABLE PayLater DROP COLUMN PaidAmount;");
+```
+
+`DROP COLUMN` needs SQLite 3.35+. If the bundled engine in `System.Data.SQLite` 1.0.119 rejects it,
+the fallback is to `DROP TABLE PayLater` and recreate it without that column from the artefact's own
+DDL — same observable drift, no reliance on a newer engine. Confirm which applies in step 1 of the
+plan rather than assuming.
+
+| # | Test | Asserts |
+|---|---|---|
+| 1 | `MigrateAllAsync_WhenAPhaseFails_DoesNotThrowAndNamesThePhase` | Returns rather than throws; `PhaseFailures` contains one entry naming `PayLater` and the SQLite message |
+| 2 | `MigrateAllAsync_WhenAPhaseFails_ReportsFailureSoTheExitCodeIsNonZero` | **`IsSuccess` is false.** The §3.2 warning, pinned |
+| 3 | `MigrateAllAsync_WhenAPhaseFails_PersistsNothingFromEarlierPhases` | Users and Products succeeded in memory, yet `StoreUsers`, `Products`, `Invoices` are all **empty** — atomicity held |
+| 4 | `MigrateAllAsync_WhenAnEarlyPhaseFails_StillAttemptsTheLaterOnes` | Drift is induced in the **Products** phase; the run still reaches PayLater, evidenced by `PhaseFailures` naming Products while `result.PayLater.Total` shows its rows were examined. Proves one run surfaces problems in more than one phase |
+| 5 | `AddError_PastTheCap_BoundsTheStringsButNotTheCounts` | Error strings stop at the cap with a suppression note; `Failed` stays exact |
+
+Non-vacuity: each of tests 1-3 must fail if `RunPhaseAsync` rethrows, and test 2 must fail if
+`IsSuccess` omits `PhaseFailures`. Verified by temporarily reverting each, per the harness convention.
+
+The existing 75 tests are the regression net — in particular
+`MigrateAllAsync_InDryRun_ShouldWriteNothing` and the defect 2/3 completion tests, which must stay
+green, proving a healthy run is unaffected.
+
+---
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| A phase failure exits 0 and reports success | §3.2 warning; test 2 exists solely for this |
+| Swallowing a bug that should crash loudly | Nothing is swallowed: the run returns `IsSuccess == false`, exits 1, prints ABORTED, and persists nothing. The exception's message is carried into `PhaseFailures` |
+| `catch (Exception)` hiding a `CancellationToken` cancellation | Rethrow `OperationCanceledException` — a cancelled run is not a phase failure |
+| The cap hiding a real error | Only strings are capped, never counts; the suppression note states how many were dropped |

--- a/docs/superpowers/specs/2026-08-04-migration-phase-isolation-design.md
+++ b/docs/superpowers/specs/2026-08-04-migration-phase-isolation-design.md
@@ -2,9 +2,10 @@
 
 **Date:** 2026-08-04
 **Defect:** 12 (`.planning/indypos-overhaul/PLAN.md`)
-**Depends on:** PR #61 (`feat/epic2-migration-coverage`). The tests need `LegacyStoreDatabase` and
-`LegacyStoreDataBuilder`, which land in that PR, so this work **stacks on that branch** and its PR
-must merge after #61.
+**Depended on:** PR #61 (`feat/epic2-migration-coverage`), **merged 2026-08-04** as `2901d1b`. The
+tests need `LegacyStoreDatabase` and `LegacyStoreDataBuilder`, which came from that PR. This work
+therefore branches cleanly off `development` (`fix/migration-phase-isolation`) rather than stacking.
+Verified on the new base before planning: 74 pass / 1 skip / 0 fail.
 
 ---
 
@@ -175,10 +176,12 @@ rather than by a mock:
 await store.Connection.ExecuteAsync("ALTER TABLE PayLater DROP COLUMN PaidAmount;");
 ```
 
-`DROP COLUMN` needs SQLite 3.35+. If the bundled engine in `System.Data.SQLite` 1.0.119 rejects it,
-the fallback is to `DROP TABLE PayLater` and recreate it without that column from the artefact's own
-DDL — same observable drift, no reliance on a newer engine. Confirm which applies in step 1 of the
-plan rather than assuming.
+`DROP COLUMN` needs SQLite 3.35+, and SQLite refuses it for a column that is a PK, UNIQUE, indexed,
+or named in a CHECK / view / trigger. Checked against the committed artefact: `PaidAmount` is a plain
+`NUMERIC NOT NULL DEFAULT 0`, the PK is `PaymentId`, and the table carries no indexes — so none of
+those restrictions apply. If the bundled engine rejects it anyway, the fallback is to `DROP TABLE
+PayLater` and recreate it without that column from the artefact's own DDL: same observable drift, no
+reliance on a newer engine. Test 1 surfaces this immediately in its Arrange step.
 
 | # | Test | Asserts |
 |---|---|---|

--- a/src/IndyPOS.MigrationTool/MigrationResult.cs
+++ b/src/IndyPOS.MigrationTool/MigrationResult.cs
@@ -1,5 +1,27 @@
 namespace IndyPOS.MigrationTool;
 
+/// <summary>
+/// A phase that failed as a whole -- its query threw, so none of its rows were examined. Distinct
+/// from a per-row failure: a phase failure means NOTHING is persisted for the entire run.
+/// </summary>
+public sealed record MigrationPhaseFailure(string Phase, string Message);
+
+/// <summary>
+/// The three outcomes an operator must be able to tell apart. Collapsing <see cref="Aborted"/> into
+/// <see cref="CompletedWithErrors"/> would report a run that wrote nothing as a partial success.
+/// </summary>
+public enum MigrationOutcome
+{
+    /// <summary>Everything migrated, and it was committed.</summary>
+    Success,
+
+    /// <summary>Committed, but individual rows were refused. Data WAS written.</summary>
+    CompletedWithErrors,
+
+    /// <summary>A phase failed wholesale, so NOTHING was written.</summary>
+    Aborted
+}
+
 public class MigrationResult
 {
     public EntityMigrationResult Users { get; set; } = new();
@@ -8,13 +30,64 @@ public class MigrationResult
     public EntityMigrationResult Payments { get; set; } = new();
     public EntityMigrationResult PayLater { get; set; } = new();
 
-    public List<string> Errors { get; } = [];
+    /// <summary>Per phase, because a cascade from one failure must not bury every other phase.</summary>
+    private const int MaxErrorsPerPhase = 100;
 
-    public bool IsSuccess => Users.Failed == 0 &&
-                             Products.Failed == 0 &&
-                             Invoices.Failed == 0 &&
-                             Payments.Failed == 0 &&
-                             PayLater.Failed == 0;
+    private readonly List<string> _errors = [];
+    private readonly Dictionary<string, int> _errorCountByPhase = [];
+    private readonly Dictionary<string, int> _suppressionNoteIndexByPhase = [];
+
+    /// <summary>Read-only so every write goes through <see cref="AddError"/> and stays bounded.</summary>
+    public IReadOnlyList<string> Errors => _errors;
+
+    /// <summary>Phases that failed as a whole. Non-empty means nothing was persisted.</summary>
+    public List<MigrationPhaseFailure> PhaseFailures { get; } = [];
+
+    public MigrationOutcome Outcome =>
+        PhaseFailures.Count > 0 ? MigrationOutcome.Aborted :
+        AnyRowFailed ? MigrationOutcome.CompletedWithErrors :
+        MigrationOutcome.Success;
+
+    /// <remarks>
+    /// Defect 12: this MUST count phase failures. Program.cs turns it into the process exit code, so
+    /// a phase failure that left IsSuccess true would exit 0 on a run that wrote nothing.
+    /// </remarks>
+    public bool IsSuccess => Outcome == MigrationOutcome.Success;
+
+    private bool AnyRowFailed => Users.Failed > 0 || Products.Failed > 0 ||
+                                 Invoices.Failed > 0 || Payments.Failed > 0 ||
+                                 PayLater.Failed > 0;
+
+    /// <summary>
+    /// Records a per-row error, capped per phase. The <see cref="EntityMigrationResult.Failed"/>
+    /// counts stay exact -- only these strings are capped, because an upstream phase failure makes
+    /// every downstream row miss its lookup (up to 325,780 on real data).
+    /// </summary>
+    public void AddError(string phase, string message)
+    {
+        var alreadyRecorded = _errorCountByPhase.GetValueOrDefault(phase);
+        _errorCountByPhase[phase] = alreadyRecorded + 1;
+
+        if (alreadyRecorded < MaxErrorsPerPhase)
+        {
+            _errors.Add(message);
+            return;
+        }
+
+        var note = $"{phase}: {alreadyRecorded + 1 - MaxErrorsPerPhase} further error(s) suppressed.";
+
+        if (_suppressionNoteIndexByPhase.TryGetValue(phase, out var index))
+        {
+            _errors[index] = note;
+            return;
+        }
+
+        _errors.Add(note);
+        _suppressionNoteIndexByPhase[phase] = _errors.Count - 1;
+    }
+
+    public void AddPhaseFailure(string phase, string message) =>
+        PhaseFailures.Add(new MigrationPhaseFailure(phase, message));
 
     public int TotalMigrated => Users.Migrated + Products.Migrated +
                                 Invoices.Migrated + Payments.Migrated +

--- a/src/IndyPOS.MigrationTool/Program.cs
+++ b/src/IndyPOS.MigrationTool/Program.cs
@@ -265,9 +265,20 @@ static void DisplayVerificationResults(VerificationResult result)
 // Helper methods
 static void DisplayResults(MigrationResult result)
 {
+    // On an aborted run the "Migrated" numbers describe work that was staged in memory and thrown
+    // away. The banner below says so, but the table is printed FIRST and must not read as "these
+    // rows landed" to anyone skimming.
+    var aborted = result.Outcome == MigrationOutcome.Aborted;
+
+    if (aborted)
+    {
+        AnsiConsole.MarkupLine(
+            "[yellow]These counts are work that was staged in memory and then DISCARDED.[/]");
+    }
+
     var resultsTable = new Table();
     resultsTable.AddColumn("Entity");
-    resultsTable.AddColumn("Migrated", c => c.RightAligned());
+    resultsTable.AddColumn(aborted ? "Discarded" : "Migrated", c => c.RightAligned());
     resultsTable.AddColumn("Skipped", c => c.RightAligned());
     resultsTable.AddColumn("Failed", c => c.RightAligned());
 
@@ -311,7 +322,11 @@ static void DisplayResults(MigrationResult result)
             AnsiConsole.MarkupLine("[red]  The whole run was discarded because a phase failed:[/]");
             foreach (var failure in result.PhaseFailures)
             {
-                AnsiConsole.MarkupLine($"  [red]•[/] [bold]{failure.Phase}[/]: {failure.Message}");
+                // SQLite messages are multi-line ("SQL logic error\nno such column: X"), which would
+                // break the bullet across lines and lose the phase association.
+                var cause = string.Join(" ", failure.Message.Split(
+                    ['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+                AnsiConsole.MarkupLine($"  [red]•[/] [bold]{failure.Phase}[/]: {cause}");
             }
             AnsiConsole.MarkupLine(
                 "[grey]  Fix the cause and re-run. The database is untouched.[/]");

--- a/src/IndyPOS.MigrationTool/Program.cs
+++ b/src/IndyPOS.MigrationTool/Program.cs
@@ -298,21 +298,36 @@ static void DisplayResults(MigrationResult result)
 
     AnsiConsole.Write(resultsTable);
 
-    if (result.IsSuccess)
+    switch (result.Outcome)
     {
-        AnsiConsole.MarkupLine("\n[green]✓ Migration completed successfully![/]");
-    }
-    else
-    {
-        AnsiConsole.MarkupLine("\n[red]✗ Migration completed with errors[/]");
-        foreach (var error in result.Errors.Take(10))
-        {
-            AnsiConsole.MarkupLine($"  [red]•[/] {error}");
-        }
-        if (result.Errors.Count > 10)
-        {
-            AnsiConsole.MarkupLine($"  [grey]... and {result.Errors.Count - 10} more errors[/]");
-        }
+        case MigrationOutcome.Success:
+            AnsiConsole.MarkupLine("\n[green]✓ Migration completed successfully![/]");
+            break;
+
+        case MigrationOutcome.Aborted:
+            // Distinct from "completed with errors" on purpose: NOTHING was written. Saying
+            // "completed" here would tell the operator their store is mostly migrated.
+            AnsiConsole.MarkupLine("\n[red]✗ Migration ABORTED - nothing was written.[/]");
+            AnsiConsole.MarkupLine("[red]  The whole run was discarded because a phase failed:[/]");
+            foreach (var failure in result.PhaseFailures)
+            {
+                AnsiConsole.MarkupLine($"  [red]•[/] [bold]{failure.Phase}[/]: {failure.Message}");
+            }
+            AnsiConsole.MarkupLine(
+                "[grey]  Fix the cause and re-run. The database is untouched.[/]");
+            break;
+
+        default:
+            AnsiConsole.MarkupLine("\n[red]✗ Migration completed with errors[/]");
+            foreach (var error in result.Errors.Take(10))
+            {
+                AnsiConsole.MarkupLine($"  [red]•[/] {error}");
+            }
+            if (result.Errors.Count > 10)
+            {
+                AnsiConsole.MarkupLine($"  [grey]... and {result.Errors.Count - 10} more errors[/]");
+            }
+            break;
     }
 }
 

--- a/src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs
+++ b/src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs
@@ -124,7 +124,7 @@ public class SqliteMigrationService
             {
                 _logger.LogError(ex, "Failed to migrate user {UserId}", user.UserId);
                 _result.Users.Failed++;
-                _result.Errors.Add($"User {user.UserId}: {ex.Message}");
+                _result.AddError("Users", $"User {user.UserId}: {ex.Message}");
             }
         }
     }
@@ -202,7 +202,7 @@ public class SqliteMigrationService
             {
                 _logger.LogError(ex, "Failed to migrate product {Barcode}", product.Barcode);
                 _result.Products.Failed++;
-                _result.Errors.Add($"Product {product.Barcode}: {ex.Message}");
+                _result.AddError("Products", $"Product {product.Barcode}: {ex.Message}");
             }
         }
     }
@@ -298,7 +298,7 @@ public class SqliteMigrationService
                         // Refused, never guessed. The previous fallback wrote "Other", which
                         // is not a catalogue code, so the amount became unresolvable while
                         // the row counts still reconciled.
-                        _result.Errors.Add(
+                        _result.AddError("Invoices",
                             $"Invoice {invoice.InvoiceId} payment {payment.PaymentId}: legacy " +
                             $"PaymentTypeId {payment.PaymentTypeId} has no payment-method code. " +
                             $"Migrating it would misattribute {payment.Amount:N2}.");
@@ -335,7 +335,7 @@ public class SqliteMigrationService
             {
                 _logger.LogError(ex, "Failed to migrate invoice {InvoiceId}", invoice.InvoiceId);
                 _result.Invoices.Failed++;
-                _result.Errors.Add($"Invoice {invoice.InvoiceId}: {ex.Message}");
+                _result.AddError("Invoices", $"Invoice {invoice.InvoiceId}: {ex.Message}");
             }
         }
     }
@@ -387,7 +387,7 @@ public class SqliteMigrationService
                 // -- THB 836,013 across the 5,181 real rows.
                 if (!_result.PaymentIdMap.TryGetValue((int)payLater.PaymentId, out var paymentId))
                 {
-                    _result.Errors.Add(
+                    _result.AddError("PayLater",
                         $"PayLater {payLater.PaymentId}: no migrated payment for legacy PaymentId " +
                         $"{payLater.PaymentId}, so the debt of {payLater.PayLaterAmount:N2} cannot be " +
                         $"attached. Refusing rather than inventing a payment.");
@@ -422,7 +422,7 @@ public class SqliteMigrationService
             {
                 _logger.LogError(ex, "Failed to migrate PayLater {PaymentId}", payLater.PaymentId);
                 _result.PayLater.Failed++;
-                _result.Errors.Add($"PayLater {payLater.PaymentId}: {ex.Message}");
+                _result.AddError("PayLater", $"PayLater {payLater.PaymentId}: {ex.Message}");
             }
         }
     }

--- a/src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs
+++ b/src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs
@@ -61,8 +61,22 @@ public class SqliteMigrationService
             await context.SaveChangesAsync(ct);
         }
 
-        _logger.LogInformation("Migration completed. Migrated: {Count}, Errors: {Errors}",
-            _result.TotalMigrated, _result.Errors.Count);
+        // The log is what gets read during a support call, so it must not say "completed" for a run
+        // that wrote nothing -- the same trap the console banner exists to avoid.
+        if (_result.PhaseFailures.Count > 0)
+        {
+            _logger.LogError(
+                "Migration ABORTED. Nothing was written. {PhaseCount} phase(s) failed: {Phases}. " +
+                "{Count} row(s) were processed in memory and discarded.",
+                _result.PhaseFailures.Count,
+                string.Join(", ", _result.PhaseFailures.Select(f => f.Phase)),
+                _result.TotalMigrated);
+        }
+        else
+        {
+            _logger.LogInformation("Migration completed. Migrated: {Count}, Errors: {Errors}",
+                _result.TotalMigrated, _result.Errors.Count);
+        }
 
         return _result;
     }

--- a/src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs
+++ b/src/IndyPOS.MigrationTool/Services/SqliteMigrationService.cs
@@ -45,12 +45,18 @@ public class SqliteMigrationService
         _logger.LogInformation("Starting migration from {SqlitePath} to PostgreSQL", _options.SqlitePath);
 
         // Order matters: Users → Products → Invoices (with lines/payments) → PayLater
-        await MigrateUsersAsync(sqliteConnection, context, ct);
-        await MigrateProductsAsync(sqliteConnection, context, ct);
-        await MigrateInvoicesAsync(sqliteConnection, context, ct);
-        await MigratePayLaterAsync(sqliteConnection, context, ct);
+        // Defect 12: each phase is isolated so ONE run reports every schema problem. Re-running
+        // against a real shop costs a visit with the till switched off.
+        await RunPhaseAsync("Users", () => MigrateUsersAsync(sqliteConnection, context, ct));
+        await RunPhaseAsync("Products", () => MigrateProductsAsync(sqliteConnection, context, ct));
+        await RunPhaseAsync("Invoices", () => MigrateInvoicesAsync(sqliteConnection, context, ct));
+        await RunPhaseAsync("PayLater", () => MigratePayLaterAsync(sqliteConnection, context, ct));
 
-        if (!_options.DryRun)
+        // Isolating the diagnosis must NOT isolate the transaction. If any phase failed the run is
+        // not trustworthy, so nothing is written -- the same outcome as before, reached deliberately
+        // instead of by an exception escaping past this line. A half-migrated store that reported
+        // success would be far worse than the crash this replaces.
+        if (!_options.DryRun && _result.PhaseFailures.Count == 0)
         {
             await context.SaveChangesAsync(ct);
         }
@@ -59,6 +65,33 @@ public class SqliteMigrationService
             _result.TotalMigrated, _result.Errors.Count);
 
         return _result;
+    }
+
+    /// <summary>
+    /// Runs one migration phase, turning a phase-level throw into a recorded failure so the remaining
+    /// phases still run and report their own state.
+    /// </summary>
+    /// <remarks>
+    /// Nothing is swallowed: a recorded failure makes <see cref="MigrationResult.IsSuccess"/> false,
+    /// which is the process exit code, prints an ABORTED banner, and suppresses the save.
+    /// </remarks>
+    private async Task RunPhaseAsync(string phase, Func<Task> migratePhase)
+    {
+        try
+        {
+            await migratePhase();
+        }
+        catch (OperationCanceledException)
+        {
+            // An operator cancelling is not a defect in the store's schema.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Migration phase {Phase} failed. Nothing will be persisted for this run.", phase);
+            _result.AddPhaseFailure(phase, ex.Message);
+        }
     }
 
     private async Task MigrateUsersAsync(SQLiteConnection sqlite, StoreHubDbContext context, CancellationToken ct)

--- a/tests/IndyPOS.MigrationTool.Tests/MigrationPhaseIsolationTests.cs
+++ b/tests/IndyPOS.MigrationTool.Tests/MigrationPhaseIsolationTests.cs
@@ -1,0 +1,138 @@
+using Dapper;
+using IndyPOS.MigrationTool.Tests.Fixtures;
+using IndyPOS.MigrationTool.Tests.Tools;
+using Microsoft.EntityFrameworkCore;
+
+namespace IndyPOS.MigrationTool.Tests;
+
+/// <summary>
+/// Defect 12. A phase-level throw used to escape MigrateAllAsync entirely, and because
+/// SaveChangesAsync runs after the last phase, an entire in-memory migration was discarded with only
+/// a stack trace to show for it.
+///
+/// The drift is induced the way it will really happen -- a real artefact schema with a column
+/// removed -- because that is exactly what defects 2 and 3 were.
+/// </summary>
+[Collection("Postgres")]
+public class MigrationPhaseIsolationTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+
+    public MigrationPhaseIsolationTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync() => _postgres.ResetDatabaseAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// A healthy credit sale: user, product, invoice, line, type-2 payment, PayLater extension.
+    /// Every phase has something to do, so "an earlier phase succeeded" is a real claim.
+    /// </summary>
+    private static async Task SeedOneOfEverythingAsync(LegacyStoreDatabase store)
+    {
+        var builder = new LegacyStoreDataBuilder(store);
+        await builder.AddPaymentTypeLookupAsync();
+        await builder.AddUserAsync(1, "cashier", "Somchai", "Jaidee", 1, "2024-03-15 09:00:00");
+        await builder.AddProductAsync(
+            productId: 10, barcode: "8850001000010", description: "Cement 50kg",
+            unitPrice: 700m, quantityInStock: 20, category: 50, isTrackable: true,
+            dateCreated: "2024-03-15 09:00:00");
+        await builder.AddInvoiceAsync(1, userId: 1, total: 700m, dateCreated: "2024-03-15 14:30:00");
+        await builder.AddInvoiceLineAsync(
+            invoiceProductId: 1, invoiceId: 1, productId: 10, barcode: "8850001000010",
+            description: "Cement 50kg", quantity: 1, unitPrice: 700m, originalUnitPrice: 700m);
+        await builder.AddPaymentAsync(
+            paymentId: 500, invoiceId: 1, paymentTypeId: 2, amount: 700m,
+            dateCreated: "2024-03-15 14:30:00", note: "Somchai");
+        await builder.AddPayLaterAsync(
+            paymentId: 500, invoiceId: 1, description: "Somchai", payLaterAmount: 700m,
+            paidAmount: 0m, isCompleted: false, dateCreated: "2024-03-15 14:30:00");
+    }
+
+    /// <summary>
+    /// Drops a column the migrator's SELECT names by hand, which is what column drift looks like.
+    /// PaidAmount is a plain NUMERIC with no index, no UNIQUE and no PK role, so SQLite permits it.
+    /// </summary>
+    private static Task DropPayLaterPaidAmountAsync(LegacyStoreDatabase store) =>
+        store.Connection.ExecuteAsync("ALTER TABLE PayLater DROP COLUMN PaidAmount;");
+
+    [Fact]
+    public async Task MigrateAllAsync_WhenAPhaseFails_DoesNotThrowAndNamesThePhase()
+    {
+        await using var store = await LegacyStoreDatabase.CreateAsync(LegacyStoreShape.GeneralHardware);
+        await SeedOneOfEverythingAsync(store);
+        await DropPayLaterPaidAmountAsync(store);
+
+        var result = await MigrationScenario.RunAsync(store, _postgres);
+
+        result.PhaseFailures.Should().ContainSingle(
+            "the PayLater SELECT names PaidAmount, so it throws -- and that must be caught");
+        var failure = result.PhaseFailures.Single();
+        failure.Phase.Should().Be("PayLater");
+        failure.Message.Should().Contain("PaidAmount",
+            "the operator needs the actual cause, not just the phase name");
+    }
+
+    [Fact]
+    public async Task MigrateAllAsync_WhenAPhaseFails_ReportsFailureSoTheExitCodeIsNonZero()
+    {
+        // Program.cs:163 is `context.ExitCode = result.IsSuccess ? 0 : 1`. Before this fix the phase
+        // threw and was caught there, so the operator got exit 1. Now it returns normally -- so
+        // IsSuccess is the ONLY thing standing between a store that migrated nothing and a green
+        // "success" on the console.
+        await using var store = await LegacyStoreDatabase.CreateAsync(LegacyStoreShape.GeneralHardware);
+        await SeedOneOfEverythingAsync(store);
+        await DropPayLaterPaidAmountAsync(store);
+
+        var result = await MigrationScenario.RunAsync(store, _postgres);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Outcome.Should().Be(MigrationOutcome.Aborted);
+    }
+
+    [Fact]
+    public async Task MigrateAllAsync_WhenAPhaseFails_PersistsNothingFromEarlierPhases()
+    {
+        // The property that keeps defect 12 merely expensive rather than catastrophic. Users,
+        // products and invoices all migrated successfully IN MEMORY before PayLater threw. None of
+        // it may reach PostgreSQL: a store holding products and part of its sales history, reported
+        // as a success, is worse than no migration at all.
+        await using var store = await LegacyStoreDatabase.CreateAsync(LegacyStoreShape.GeneralHardware);
+        await SeedOneOfEverythingAsync(store);
+        await DropPayLaterPaidAmountAsync(store);
+
+        var result = await MigrationScenario.RunAsync(store, _postgres);
+
+        result.Users.Migrated.Should().Be(1, "the Users phase itself succeeded");
+        result.Products.Migrated.Should().Be(1);
+        result.Invoices.Migrated.Should().Be(1);
+
+        await using var db = _postgres.CreateDbContext();
+        (await db.StoreUsers.CountAsync()).Should().Be(0, "no phase may be committed when another failed");
+        (await db.Products.CountAsync()).Should().Be(0);
+        (await db.Invoices.CountAsync()).Should().Be(0);
+        (await db.Payments.CountAsync()).Should().Be(0);
+        (await db.PayLaters.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MigrateAllAsync_WhenAnEarlyPhaseFails_StillAttemptsTheLaterOnes()
+    {
+        // The whole point of isolating the diagnosis: one attempt reports every schema problem.
+        // Re-running against a real shop costs a visit with the till switched off, so learning about
+        // one broken phase per run is expensive.
+        // Manufacturer is named explicitly in the Products SELECT and is a plain nullable TEXT with
+        // no index, so dropping it makes that phase -- and only that phase -- throw.
+        await using var store = await LegacyStoreDatabase.CreateAsync(LegacyStoreShape.GeneralHardware);
+        await SeedOneOfEverythingAsync(store);
+        await store.Connection.ExecuteAsync("ALTER TABLE InventoryProduct DROP COLUMN Manufacturer;");
+
+        var result = await MigrationScenario.RunAsync(store, _postgres);
+
+        result.PhaseFailures.Should().ContainSingle().Which.Phase.Should().Be("Products");
+        result.Users.Migrated.Should().Be(1, "the phase before the failure still ran");
+        result.Invoices.Migrated.Should().Be(1, "the phase AFTER the failure still ran");
+        result.PayLater.Migrated.Should().Be(1, "and so did the last one");
+        result.IsSuccess.Should().BeFalse("a phase still failed, so nothing was written");
+    }
+}

--- a/tests/IndyPOS.MigrationTool.Tests/MigrationPhaseIsolationTests.cs
+++ b/tests/IndyPOS.MigrationTool.Tests/MigrationPhaseIsolationTests.cs
@@ -135,4 +135,37 @@ public class MigrationPhaseIsolationTests : IAsyncLifetime
         result.PayLater.Migrated.Should().Be(1, "and so did the last one");
         result.IsSuccess.Should().BeFalse("a phase still failed, so nothing was written");
     }
+
+    [Fact]
+    public async Task MigrateAllAsync_WithMoreRowErrorsThanTheCap_BoundsTheStringsButNotTheCounts()
+    {
+        // Drives the cap through the real service. This run has NO phase failure -- it reaches the cap
+        // with ordinary per-row refusals, which is the cheapest way to exercise it. The cascade the cap
+        // exists for (a failed Products phase making every invoice line miss its lookup, up to 325,780
+        // near-identical strings on real data) is the same code path with a bigger multiplier.
+        await using var store = await LegacyStoreDatabase.CreateAsync(LegacyStoreShape.GeneralHardware);
+        var builder = new LegacyStoreDataBuilder(store);
+        await builder.AddPaymentTypeLookupAsync();
+        await builder.AddUserAsync(1, "cashier", "Somchai", "Jaidee", 1, "2024-03-15 09:00:00");
+        await builder.AddProductAsync(
+            productId: 10, barcode: "8850001000010", description: "Cement 50kg",
+            unitPrice: 1m, quantityInStock: 5, category: 50, isTrackable: true,
+            dateCreated: "2024-03-15 09:00:00");
+
+        // 150 invoices, each paid by a legacy type with no catalogue code, so each records one
+        // per-row error in the Invoices phase -- 150 > the cap of 100.
+        for (var i = 1; i <= 150; i++)
+        {
+            await builder.AddInvoiceAsync(i, userId: 1, total: 1m, dateCreated: "2024-03-15 14:30:00");
+            await builder.AddPaymentAsync(
+                paymentId: 500 + i, invoiceId: i, paymentTypeId: 6, amount: 1m,
+                dateCreated: "2024-03-15 14:30:00");
+        }
+
+        var result = await MigrationScenario.RunAsync(store, _postgres);
+
+        result.Payments.Failed.Should().Be(150, "the COUNT must stay exact");
+        result.Errors.Should().HaveCount(101, "100 strings plus one suppression note");
+        result.Errors.Last().Should().Be("Invoices: 50 further error(s) suppressed.");
+    }
 }

--- a/tests/IndyPOS.MigrationTool.Tests/MigrationResultTests.cs
+++ b/tests/IndyPOS.MigrationTool.Tests/MigrationResultTests.cs
@@ -1,0 +1,95 @@
+namespace IndyPOS.MigrationTool.Tests;
+
+/// <summary>
+/// Pure unit tests. No Docker, no database, no real store data.
+/// </summary>
+public class MigrationResultTests
+{
+    [Fact]
+    public void Outcome_WithAPhaseFailure_IsAbortedAndIsSuccessIsFalse()
+    {
+        // THE load-bearing test of defect 12's fix. Program.cs derives its exit code from IsSuccess.
+        // Before this fix a phase failure threw, so the operator got a red message and exit 1. Now it
+        // returns normally -- so if IsSuccess ignored PhaseFailures, a migration that wrote NOTHING
+        // would exit 0 and announce success. That would be worse than the defect being fixed.
+        var result = new MigrationResult();
+        result.Users.Migrated = 12;
+
+        result.AddPhaseFailure("PayLater", "SQL logic error: no such column: PaidAmount");
+
+        result.Outcome.Should().Be(MigrationOutcome.Aborted);
+        result.IsSuccess.Should().BeFalse("nothing was persisted, so the exit code must be non-zero");
+        result.PhaseFailures.Should().ContainSingle()
+              .Which.Should().BeEquivalentTo(
+                  new MigrationPhaseFailure("PayLater", "SQL logic error: no such column: PaidAmount"));
+    }
+
+    [Fact]
+    public void Outcome_WithOnlyRowFailures_IsCompletedWithErrors()
+    {
+        // Distinct from Aborted: these rows were refused but the run still committed, so data WAS
+        // written. Conflating the two would tell an operator their store is mostly migrated when
+        // nothing at all was written.
+        var result = new MigrationResult();
+        result.Invoices.Migrated = 500;
+        result.Payments.Failed = 1;
+
+        result.Outcome.Should().Be(MigrationOutcome.CompletedWithErrors);
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Outcome_WithNothingFailed_IsSuccess()
+    {
+        var result = new MigrationResult();
+        result.Users.Migrated = 3;
+        result.Products.Skipped = 2;
+
+        result.Outcome.Should().Be(MigrationOutcome.Success);
+        result.IsSuccess.Should().BeTrue("skipped rows are not failures");
+    }
+
+    [Fact]
+    public void AddError_PastTheCap_BoundsTheStringsAndSaysHowManyWereDropped()
+    {
+        // An upstream phase failure makes every downstream row miss its lookup: up to 325,780
+        // near-identical strings on real GeneralHardware data, burying the one line that explains
+        // the cause.
+        var result = new MigrationResult();
+
+        for (var i = 1; i <= 250; i++)
+        {
+            result.AddError("Invoices", $"Invoice {i}: product not found");
+        }
+
+        result.Errors.Should().HaveCount(101, "100 real errors plus one suppression note");
+        result.Errors.Last().Should().Be("Invoices: 150 further error(s) suppressed.");
+    }
+
+    [Fact]
+    public void AddError_CapsEachPhaseIndependently()
+    {
+        var result = new MigrationResult();
+
+        for (var i = 1; i <= 150; i++)
+        {
+            result.AddError("Invoices", $"Invoice {i}: product not found");
+            result.AddError("PayLater", $"PayLater {i}: no migrated payment");
+        }
+
+        result.Errors.Should().HaveCount(202, "each phase gets its own 100 plus its own note");
+        result.Errors.Should().Contain("Invoices: 50 further error(s) suppressed.");
+        result.Errors.Should().Contain("PayLater: 50 further error(s) suppressed.");
+    }
+
+    [Fact]
+    public void AddError_UnderTheCap_KeepsEveryMessageVerbatim()
+    {
+        var result = new MigrationResult();
+
+        result.AddError("PayLater", "PayLater 999: no migrated payment for legacy PaymentId 999");
+
+        result.Errors.Should().ContainSingle()
+              .Which.Should().Be("PayLater 999: no migrated payment for legacy PaymentId 999");
+    }
+}


### PR DESCRIPTION
## What this fixes

Defect 12. Defects 2 and 3 were fixed at the **symptom** — the wrong column names and the missing
table probe. What turned a single wrong column name into *"no real store can migrate at all"* was
never touched:

```csharp
await MigrateUsersAsync(...);      // none of these four is in a try
await MigrateProductsAsync(...);
await MigrateInvoicesAsync(...);
await MigratePayLaterAsync(...);

if (!_options.DryRun)
{
    await context.SaveChangesAsync(ct);   // ...and this runs after them
}
```

A schema-level throw escaped the phase, escaped `MigrateAllAsync`, and sailed past the save. The tool
did the entire migration **in memory** and then discarded all of it, leaving a stack trace and no
diagnosis. The next column drift — a store whose `PayLater` lacks `PaidAmount`, a renamed
`InvoiceProduct` column — would have done it again.

## The design decision that mattered

**The migrator is atomic today, and it stays atomic.**

The obvious reading of "isolate the phases so one failure doesn't kill the run" would have destroyed
that. If phases committed independently, a store could end up with products and half its sales
history — and report success. Under-counted revenue that reconciles against nothing is the same class
of harm as defect 10's double-count, and the third time this epic has met the pattern where the
tempting fix is the dangerous one:

| Defect | The tempting fix | What it would have caused |
|---|---|---|
| 2 | Correct the column names | Silent ฿836k revenue inflation (defect 10 becomes reachable) |
| 6 | Recompute the discount from the line | A plausible number derived from dead data |
| **12** | **Let each phase commit on its own** | **A half-migrated store reporting success** |

So this **isolates the diagnosis, not the transaction**:

- Each phase runs through `RunPhaseAsync`, which records a `MigrationPhaseFailure` instead of
  throwing. All four are always attempted, so **one run reports every schema problem** rather than one
  per round trip — which matters when each attempt is a visit to a working shop with its till offline.
- `SaveChangesAsync` is gated on there being no phase failure. Nothing is written — the same outcome
  as before, reached deliberately instead of by an escaping exception.
- `OperationCanceledException` is rethrown. A cancelled run is an operator decision, not a schema
  defect.

## The load-bearing line

`Program.cs:163` is `context.ExitCode = result.IsSuccess ? 0 : 1`. Before this change a phase failure
*threw*, so the operator got a red message and exit 1. Now it returns normally — so an `IsSuccess`
that ignored `PhaseFailures` would make a migration that wrote **nothing** exit **0** and announce
success. That would be worse than the defect being fixed.

`IsSuccess` therefore derives from a three-state `Outcome`, and one test exists for that single line
and nothing else.

## Operator output

`DisplayResults` had two branches, so a run that wrote nothing was announced as *"Migration completed
with errors"* — inviting the operator to believe the store was mostly migrated. Now three:

| Condition | Message |
|---|---|
| a phase failed | `✗ Migration ABORTED - nothing was written.` + each phase and its cause + *"The database is untouched."* |
| per-row failures only | `✗ Migration completed with errors` (unchanged — data **was** written) |
| otherwise | `✓ Migration completed successfully!` |

## Bounded error strings

An upstream phase failure makes every downstream row miss its lookup — up to **325,780**
near-identical strings on real GeneralHardware data (~32 MB), burying the one line that explains the
cause. `AddError` caps at 100 per phase with a `"N further error(s) suppressed"` note.

**`Failed` counts stay exact.** Only the human-readable strings are capped, so no number in the report
becomes an approximation. `Errors` is now `IReadOnlyList` so every write goes through the cap.

## Tests

11 new, and the drift is induced the way it will really happen rather than with a mock:

```csharp
await store.Connection.ExecuteAsync("ALTER TABLE PayLater DROP COLUMN PaidAmount;");
```

Before the fix that reproduced defect 2's exact `SQL logic error: no such column: PaidAmount` as an
escaping `SQLiteException` — the defect, on demand.

**Both properties proven non-vacuous independently**, because they can fail separately:

- Making `RunPhaseAsync` rethrow → all four isolation tests fail.
- Ungating the save → `PersistsNothingFromEarlierPhases` fails with **1 committed `StoreUser`**: the
  half-migrated store this PR forbids, caught by the test that forbids it.

| Suite | Result |
|---|---|
| Solution (`dotnet test IndyPOS.sln`, Docker up, real store data) | **545 pass / 1 skip / 0 fail** (546) |
| `IndyPOS.MigrationTool.Tests` | **85 pass / 1 skip** (86), was 75 |

Of the 86: 36 need Docker, 24 need the gitignored real store `.db` files, 25 are pure units, 1 is the
manual extractor. A fresh clone discovers 66, all green.

## Verified by running the tool for real

The console strings have no automated test — `AnsiConsole` output isn't worth a capture harness — so
they were verified by hand instead, against a throwaway PostgreSQL container and a legacy store built
from the committed artefact with `PaidAmount` removed.

**That caught two more instances of this branch's own defect**, now fixed in `46421c5`:

- The summary **log** said `Migration completed. Migrated: 4, Errors: 0` on a run that wrote nothing
  (`Errors: 0` was even true — a phase failure is not a per-row error). The log is what gets read
  during a support call. It now reports ABORTED, the failed phases, and that the rows were discarded.
- The results **table** printed `Migrated 1/1/1/1` *above* the aborted banner, so skimming read as
  "4 rows landed". On an aborted run that column is now headed **Discarded**, preceded by an explicit
  warning line.

Also flattened the phase-failure bullet: SQLite messages are multi-line, which split the bullet and
lost the phase association.

What the two runs established:

| Run | Result |
|---|---|
| drifted store | ABORTED banner, **exit 1**, and **every table 0 rows** — atomicity holds against a real database, not only in tests |
| healthy store | `Migrated` header, success banner, exit 0, rows present |

The healthy run also re-confirmed the previous PR's fixes on real infrastructure: `paid_amount=299.00`
(defect 2 — read, not derived from `IsCompleted`, which would give 0) and payments summing to
**700.00, not 1400.00** (defect 10 — no double-count).

Spec: `docs/superpowers/specs/2026-08-04-migration-phase-isolation-design.md`
Plan: `docs/superpowers/plans/2026-08-04-migration-phase-isolation.md`

