### PR TITLE
test(sync): wait for the condition instead of sleeping 100ms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,11 +79,16 @@ sits there for many minutes is now a real problem rather than normal. The memory
 single `SaveChangesAsync` that defect 12 made deliberate — everything is held until then — so watch
 it on a low-RAM till.
 
-⚠️ **Running many Postgres containers at once makes two tests flake.** With 9 up, a full-solution run
-failed `SyncWorkerTests.SyncWorker_ShouldHandleException_WithoutCrashing` and
-`ProductsEndpointTests.CreateProduct_WithValidData_ReturnsCreatedProduct`. Both passed in isolation
-and both passed on a full re-run after stopping the spare containers. These are the names behind the
-previously unidentified `Application.Tests` flake — check `docker ps` before investigating either.
+⚠️ **Two tests flake under the CPU load of a full-solution run**, and one of them is now fixed.
+`SyncWorkerTests.SyncWorker_ShouldHandleException_WithoutCrashing` was the long-unidentified
+`Application.Tests` flake: it slept a fixed 100 ms and then asserted a background worker had polled,
+which is not guaranteed when six suites and two Testcontainers Postgres instances are competing. It
+now waits for the condition instead. **An earlier note here blamed the number of running containers —
+that was wrong**; it recurred with only one container up, and the cause was always the fixed sleep.
+
+`ProductsEndpointTests.CreateProduct_WithValidData_ReturnsCreatedProduct` has flaked once under the
+same load and is **not** fixed. It passes in isolation. Re-run before investigating it as a
+regression, and be suspicious of any other test that sleeps rather than waiting for a condition.
 
 ⚠️ **Defect 7 is open but has NO pin** — do not go looking for one. Its pin asserted that migrating a
 service line produced a stock movement; defect 14 removed that replay, so the pin was deleted rather

--- a/tests/IndyPOS.Application.Tests/StoreHub/Services/SyncWorkerTests.cs
+++ b/tests/IndyPOS.Application.Tests/StoreHub/Services/SyncWorkerTests.cs
@@ -153,22 +153,47 @@ public class SyncWorkerTests
     [Fact]
     public async Task SyncWorker_ShouldHandleException_WithoutCrashing()
     {
-        // Arrange
-        var (worker, outboxRepo, syncClient) = CreateSut();
+        // Waits for the condition rather than for a fixed 100 ms. This test used to sleep 100 ms and
+        // then assert the worker had polled at least once, which made it FLAKY: under the CPU load of
+        // a full-solution run the background worker is not always scheduled inside that window, so
+        // the count was 0 and the run failed with nothing wrong. It surfaced twice on 2026-08-17 and
+        // passed every time in isolation.
+        //
+        // Polling a SECOND time is also the stronger assertion, and the one that matches the test's
+        // name: surviving the exception means it kept going, not merely that it started.
+        // SyncWorker_ShouldMarkAsFailed_WhenSyncFails in this file already used this shape.
+        var (worker, outboxRepo, _) = CreateSut();
 
-        outboxRepo.SetupSequence(x => x.GetPendingEventsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("Database error"))
-            .ReturnsAsync(new List<OutboxEvent>());
+        var polledAfterThrowing = new TaskCompletionSource();
+        var calls = 0;
+
+        outboxRepo.Setup(x => x.GetPendingEventsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                {
+                    throw new InvalidOperationException("Database error");
+                }
+
+                polledAfterThrowing.TrySetResult();
+                return Task.FromResult<IReadOnlyList<OutboxEvent>>([]);
+            });
 
         using var cts = new CancellationTokenSource();
 
-        // Act - Should not throw
-        var workerTask = worker.StartAsync(cts.Token);
-        await Task.Delay(100);
+        // Act - should not throw
+        await worker.StartAsync(cts.Token);
+
+        var finished = await Task.WhenAny(polledAfterThrowing.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+
         cts.Cancel();
         await worker.StopAsync(CancellationToken.None);
 
-        // Assert - Worker should have survived the exception
-        outboxRepo.Verify(x => x.GetPendingEventsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.AtLeast(1));
+        // Assert
+        finished.Should().Be(polledAfterThrowing.Task,
+            "the worker must keep polling after GetPendingEventsAsync throws, not die on it");
+        outboxRepo.Verify(
+            x => x.GetPendingEventsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.AtLeast(2));
     }
 }


### PR DESCRIPTION
Independent of the defect 6 PR — both branch off `development`, and they touch different files (this
one only `SyncWorkerTests.cs`, plus one `CLAUDE.md` note).

## The flake, finally named and fixed

`SyncWorker_ShouldHandleException_WithoutCrashing` slept a fixed **100 ms** and then asserted the
background worker had polled at least once:

```csharp
var workerTask = worker.StartAsync(cts.Token);
await Task.Delay(100);
cts.Cancel();
await worker.StopAsync(CancellationToken.None);
outboxRepo.Verify(x => x.GetPendingEventsAsync(...), Times.AtLeast(1));
```

Under the CPU load of a full-solution run — six suites plus two Testcontainers Postgres instances —
the worker is not always scheduled inside that window. The count is 0 and the run fails with nothing
wrong.

**This is the `Application.Tests` flake `STATUS.md` has been asking someone to identify.** It surfaced
twice on 2026-08-17 and passed 3/3 in isolation both times.

## The fix

It now waits for the worker to poll a **second** time, via `TaskCompletionSource` + `Task.WhenAny`
with a generous ceiling.

That is also the *stronger* assertion, and the one the test's name actually claims: surviving the
exception means it **kept going**, not merely that it started once. The old `Times.AtLeast(1)` would
pass even if the worker had died on the throw, as long as it had made the throwing call.

`SyncWorker_ShouldMarkAsFailed_WhenSyncFails` in the same file already used this shape, so this makes
the file consistent rather than introducing a new pattern.

## I got the cause wrong first, and this corrects it

An earlier note I added to `CLAUDE.md` blamed the **number of running Postgres containers** ("with 9
up..."). That was wrong: it recurred with only **one** container up, and the cause was always the
fixed sleep. The note now says so.

It also flags the one I have **not** fixed:
`ProductsEndpointTests.CreateProduct_WithValidData_ReturnsCreatedProduct` flaked once under the same
load and passes in isolation. I have not diagnosed it, and I would rather it stay written down as a
known suspect than be quietly folded in here.

## Verification

Ran the SyncWorker tests 3× in isolation (green), then a **full-solution run** — the condition that
actually exposed the flake: **608 tests, 607 pass, 1 skip, 0 fail.**

Test counts are unchanged, so no docs numbers move.
