### PR TITLE
docs(operations): add a way to verify the forward-only release gate, and run it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,10 @@ must therefore be runnable against the *previous* release's binaries:
   and the till could not complete a sale.
 
 A migration that breaks this makes the installer's rollback claim false.
-See `docs/operations/upgrade-procedure.md`.
+See `docs/operations/upgrade-procedure.md`, which now carries a **recipe for verifying the gate** —
+apply the release's schema, then write a complete sale using only the columns that existed before it.
+Verified for the 2026-08-17 release's three migrations; before that it had only ever been reasoned
+about.
 
 ### Method Chaining Style
 ```csharp

--- a/docs/operations/upgrade-procedure.md
+++ b/docs/operations/upgrade-procedure.md
@@ -242,8 +242,42 @@ C:\ProgramData\IndyPOS\v4\backups\<yyyyMMdd-HHmmss>\
 
 ---
 
+## Verifying the forward-only gate before a release
+
+Point 5 above is a **promise to the store**: a failed upgrade leaves them working. It rests entirely
+on every migration in the release being runnable against the *previous* release's binaries, and until
+2026-08-17 that had only ever been reasoned about, never tested.
+
+It is cheap to test, and worth doing for any release that adds a migration:
+
+```powershell
+# 1. A throwaway PostgreSQL with THIS release's schema. Any migration run applies it.
+docker run -d --name gate -e POSTGRES_PASSWORD=pass -e POSTGRES_DB=storehub -p 55510:5432 postgres:16-alpine
+.\IndyPOS.MigrationTool.exe --sqlite <any-legacy.db> --postgres "Host=localhost;Port=55510;..." --store-id GATE
+
+# 2. Confirm every column the release ADDED is nullable, or NOT NULL with a default.
+docker exec gate psql -U postgres -d storehub -c "
+  SELECT table_name, column_name, is_nullable, column_default
+  FROM information_schema.columns WHERE table_schema='public' ORDER BY 1,2"
+```
+
+**3. Then prove it, rather than trusting step 2.** Write the rows the way the *previous* release does —
+an `INSERT` naming only the columns that existed before, never mentioning the new ones — for
+`product`, `invoice`, `invoice_line`, `payment` and `inventory_movement`. If a complete sale can be
+written that way, the restored binaries can still trade. If any `INSERT` fails, **the rollback claim in
+point 5 is false** and the release must not ship.
+
+Result for the 2026-08-17 release (3 migrations: invoice-line detail, legacy ids, `is_trackable`):
+every pre-release `INSERT` succeeded, `product.is_trackable` defaulted to `true`, the legacy id columns
+took `NULL`, and a complete sale was written using only pre-release columns. Note that this also covers
+the two `DropIndex` calls in the legacy-ids migration — they remove EF *convention* indexes superseded
+by composite ones leading with the same column, so no access path is lost.
+
+---
+
 ## Change Log
 
 | Date | Change |
 |------|--------|
 | 2026-07-29 | Initial in-place upgrade procedure |
+| 2026-08-17 | Added the forward-only gate verification, and ran it against the release's 3 migrations |


### PR DESCRIPTION
Docs only, plus the result of actually running the check.

## The promise that had never been tested

`upgrade-procedure.md` tells the store:

> **Schema is never rolled back.** A failed upgrade restores binaries and config only, which is why
> every migration must be forward-only.

That is a promise that a failed upgrade leaves them trading. It rests entirely on every migration being
runnable against the **previous** release's binaries — and until now that had only ever been *reasoned
about*, never tested. Including the three migrations added in this release.

## Ran it

The recipe is now in `upgrade-procedure.md`, and the third step is the one that matters. Inspecting the
schema tells you what you expect; **writing a complete sale the way the previous release writes it**
proves it:

```sql
-- product: the pre-release shape. No is_trackable, no legacy_product_id.
INSERT INTO product (id, barcode, name, ..., store_id) VALUES (...);

-- invoice_line: the deliberate 7-field shape. None of defect 6's columns, no legacy id.
INSERT INTO invoice_line (id, invoice_id, product_id, product_name, quantity, unit_price, created_utc)
VALUES (...);
```

Result against this release's schema:

```
product.is_trackable defaulted to true, legacy_product_id = NULL
a complete sale written by pre-today INSERTs: 1 line, 1 payment, 1 movement
PSQL_EXIT=0
```

Every pre-release `INSERT` succeeded — product, invoice, invoice line, payment and inventory movement —
without naming a single new column. **The rollback claim holds** for all three migrations
(invoice-line detail, legacy ids, `is_trackable`).

It also settles the one thing in this release that *looks* like a gate violation: the two `DropIndex`
calls in the legacy-ids migration. They remove EF **convention** indexes superseded by composite ones
leading with the same column, so the restored binaries keep both correctness and their access path.

## Also: the installer suite

`IndyPOS.sln` excludes the installer, so nothing else today touched it — despite three schema
migrations landing. Ran it explicitly: **223 pass, 8 skipped, 231 total, exit 0**, matching the
documented figure exactly. No regression.

## Why this is worth a PR rather than a note

A verified gate is only useful if the next person can repeat it, and the tempting shortcut — reading
`information_schema` and concluding "all nullable, fine" — is exactly what would miss a `NOT NULL`
without a default, a narrowed type, or a dropped column that a query still names. The recipe says to
insert, not to inspect.
