### PR TITLE
Discharge the payment-button smoke (at 100% scaling), unblock the v3.7.0-coexistence check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -488,3 +488,7 @@ fabric.properties
 
 # Installer payloads — embedded at build time by build-installer.ps1
 installer/IndyPOS.Bootstrapper/Resources/
+
+# v3.7.0 footprint captures (Get-V3Footprint.ps1) list real store paths.
+# This repo is public - never commit one.
+v3-footprint-*.json

--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -443,8 +443,20 @@ Per store: fresh v4 install (`--silent --store-id <ID> --store-type <T>`), then 
 v4 installs **alongside** v3.7.0 — detection classifies a v3-only machine as `Fresh`
 (pinned by `Detect_OnAMachineRunningOnlyV3_ShouldReturnFresh`).
 
-Owed before the first store: PR #52's visual smoke (payment-button caption clipping on
-`บัตรสวัสดิการแห่งรัฐ`), and one v3.7.0-coexistence check against a real v3 footprint.
+✅ **PR #52's visual smoke is discharged (2026-08-19) — there was no clipping.** Rendered against
+the real `AcceptPaymentForm.CreatePaymentMethodButton`, the caption `บัตรสวัสดิการแห่งรัฐ` is
+pixel-identical on the shipped 195x129 button and on a 195x260 button where clipping is impossible
+(11px of ink, 5px of gap below). The welfare-card icon declares 190px but inks 174px, unchanged in a
+400px-wide button, so it is not cropped either. The alarm was arithmetic on declared asset sizes,
+which include transparent margin — `MeasureText` height (21px) is ascent+descent+leading, not ink.
+
+What *is* tight is pinned by `PaymentMethodButtonCaptionTests`: beneath a 100px icon there is room
+for exactly **one** 21px line, with zero slack, and today's longest caption is 130px of a usable
+187px. A future campaign with a longer name, or a taller bundled icon, breaks it — and now fails a
+test rather than reaching a till. The captions are read from `PaymentMethodSeeder.Defaults`, so a new
+campaign is covered the moment it is added.
+
+Still owed before the first store: one v3.7.0-coexistence check against a real v3 footprint.
 
 ---
 

--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -456,7 +456,19 @@ for exactly **one** 21px line, with zero slack, and today's longest caption is 1
 test rather than reaching a till. The captions are read from `PaymentMethodSeeder.Defaults`, so a new
 campaign is covered the moment it is added.
 
-Still owed before the first store: one v3.7.0-coexistence check against a real v3 footprint.
+**Still owed before the first store: one v3.7.0-coexistence check against a real v3 footprint** —
+now unblocked, but it needs one read-only command run at a live store.
+
+It could not be done before: a clean VM has no v3 footprint, so `verify-install.ps1`'s section 7
+skips, and there is no v3.7.0 artefact to install (releases stop at 3.6.0). `scripts/vm-testing/`
+now carries `Get-V3Footprint.ps1` (capture a store's real layout, read-only) and
+`New-V3Footprint.ps1` (replay it onto the VM before installing v4).
+
+⚠️ **That section was also silently broken**, fixed in this branch: `SystemRoot` became `v{Major}`
+in `5ce6cea` but the script still matched `v\d+\.\d+\.\d+`, so it counted our *own* `v4` directory
+as a v3-era entry and reported "v3.7.0-era top-level entries detected → Pass" on a machine that had
+never seen v3. It could never `Skip`, so this check would have looked discharged while testing
+nothing — and the same stale pattern made the side-by-side check fail a correct install.
 
 ---
 

--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -443,32 +443,56 @@ Per store: fresh v4 install (`--silent --store-id <ID> --store-type <T>`), then 
 v4 installs **alongside** v3.7.0 — detection classifies a v3-only machine as `Fresh`
 (pinned by `Detect_OnAMachineRunningOnlyV3_ShouldReturnFresh`).
 
-✅ **PR #52's visual smoke is discharged (2026-08-19) — there was no clipping.** Rendered against
-the real `AcceptPaymentForm.CreatePaymentMethodButton`, the caption `บัตรสวัสดิการแห่งรัฐ` is
-pixel-identical on the shipped 195x129 button and on a 195x260 button where clipping is impossible
-(11px of ink, 5px of gap below). The welfare-card icon declares 190px but inks 174px, unchanged in a
-400px-wide button, so it is not cropped either. The alarm was arithmetic on declared asset sizes,
-which include transparent margin — `MeasureText` height (21px) is ascent+descent+leading, not ink.
+✅ **PR #52's visual smoke is discharged (2026-08-19) at 100% display scaling.** Rendered against the
+real `AcceptPaymentForm.CreatePaymentMethodButton`, the caption `บัตรสวัสดิการแห่งรัฐ` is
+pixel-identical on the shipped 195x129 button and on one where clipping is impossible — ink rows
+108-122, **15px**, with rows 123-127 clear below it. The welfare-card icon declares 190x100 but inks
+174x100, unchanged in a 400px-wide button, so it is not cropped either. The original alarm was
+arithmetic on *declared* asset sizes, which include 8px of transparent margin each side.
 
-What *is* tight is pinned by `PaymentMethodButtonCaptionTests`: beneath a 100px icon there is room
-for exactly **one** 21px line, with zero slack, and today's longest caption is 130px of a usable
-187px. A future campaign with a longer name, or a taller bundled icon, breaks it — and now fails a
-test rather than reaching a till. The captions are read from `PaymentMethodSeeder.Defaults`, so a new
+🚨 **But "no clipping" holds only at 100%, and independent review found a real defect above it.**
+From **144.8% scaling** — so Windows' standard 150% — the caption wraps to two lines and is painted
+**on top of the card artwork**: white Thai text over pale blue. Only `WelfareCard` is affected, being
+the longest caption. Height budget: 100px icon + caption ink = 115px at 100% (fits in 129), **154px
+at 150%**, 174px at 200%.
+
+**Cause.** `AcceptPaymentForm` is `AutoScaleMode.Font` with `AutoScaleDimensions = (6,13)`, but
+`CreatePaymentMethodButton` hardcodes `Size(195,129)` and `Location(10 + col*201, 16 + row*135)` in
+device pixels, and `BuildPaymentMethodButtons` runs from the async load path — *after*
+`PerformAutoScale`. So the panel scales, the 12pt font scales, and the buttons never do. **Fix:**
+scale those literals by `CurrentAutoScaleDimensions / AutoScaleDimensions`, or build through a
+layout panel. **Not fixed yet — check what scaling the tills actually run at before the cutover.**
+
+⚠️ The measurement that first cleared this was **also** wrong in a way worth remembering: the ink
+detector walked up from the bottom until a blank row, which finds only the *last* line — so it
+reported a comfortable single-line caption at exactly the DPI where the caption had doubled.
+
+`PaymentMethodButtonCaptionTests` pins the 100% contract: max caption width **184px**, established
+by bisecting real renders rather than derived from chrome (`MeasureText` adds 10px of glyph-overhang
+padding that is *not* chrome, which is why "195 − border − inset" lands ~3px too lenient); and room
+for one line beneath the tallest icon, read from the real `PaymentMethodIcons` table — verified to
+fail when a 130px icon is injected. Captions come from `PaymentMethodSeeder.Defaults`, so a new
 campaign is covered the moment it is added.
 
 **Still owed before the first store: one v3.7.0-coexistence check against a real v3 footprint** —
 now unblocked, but it needs one read-only command run at a live store.
 
-It could not be done before: a clean VM has no v3 footprint, so `verify-install.ps1`'s section 7
-skips, and there is no v3.7.0 artefact to install (releases stop at 3.6.0). `scripts/vm-testing/`
-now carries `Get-V3Footprint.ps1` (capture a store's real layout, read-only) and
-`New-V3Footprint.ps1` (replay it onto the VM before installing v4).
+`scripts/vm-testing/` now carries `Get-V3Footprint.ps1` (capture a store's real layout, read-only)
+and `New-V3Footprint.ps1` (replay it onto the VM before installing v4). The reason to capture rather
+than rebuild: a v3.7.0 binary *is* reproducible from this repo (`9aca15c~1`, before the 4.0.0
+assembly bump — there is no tag or release, which stops at 3.6.0), but a from-source build gives a
+*fresh-install* footprint, not the layout a five-year-old till has actually accumulated.
 
-⚠️ **That section was also silently broken**, fixed in this branch: `SystemRoot` became `v{Major}`
-in `5ce6cea` but the script still matched `v\d+\.\d+\.\d+`, so it counted our *own* `v4` directory
-as a v3-era entry and reported "v3.7.0-era top-level entries detected → Pass" on a machine that had
-never seen v3. It could never `Skip`, so this check would have looked discharged while testing
-nothing — and the same stale pattern made the side-by-side check fail a correct install.
+⚠️ **`verify-install.ps1` section 7 was also silently broken**, fixed in this branch: `SystemRoot`
+became `v{Major}` in `5ce6cea` but the script still matched `v\d+\.\d+\.\d+`, so it counted our *own*
+`v4` directory as a v3-era entry and reported "v3.7.0-era top-level entries detected → Pass" on a
+machine that had never seen v3. The same stale pattern made the side-by-side check *fail* a correct
+install. (Pre-fix it would still have skipped on a box whose only root was a long-form `v4.0.0`.)
+
+⚠️ **Section 7 remains advisory, even fixed.** It enumerates non-versioned top-level entries for a
+human; it cannot tell v3's `Config`/`db`/`Logs` from a dev box's, since `CLAUDE.md`'s debug setup
+puts `StoreConfiguration.json` at exactly that path. It skips only on a pristine machine. Proving
+the footprint is *untouched* still needs a before/after baseline diff, which does not exist yet.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,10 +214,10 @@ dotnet run --project src/IndyPOS.AppHost --launch-profile https
 # Dashboard: https://localhost:17222
 ```
 
-Solution suites total **618** with Docker running and the real store databases present (617 pass,
-1 skipped) — measured 2026-08-17. Per suite: Domain 36 · Vault 17 · MigrationTool 134 (133 pass,
-1 skip) · StoreHub.IntegrationTests 104 · Application 299 · Windows.Forms 28. Without the real
-store databases the suite discovers **598** (DERIVED as 618 − 20, not measured) — a skipped
+Solution suites total **627** with Docker running and the real store databases present (626 pass,
+1 skipped) — measured 2026-08-19. Per suite: Domain 36 · Vault 17 · MigrationTool 134 (133 pass,
+1 skip) · StoreHub.IntegrationTests 104 · Application 299 · Windows.Forms 37. Without the real
+store databases the suite discovers **607** (DERIVED as 627 − 20, not measured) — a skipped
 `[Theory]` is one entry, not one per row. See [`ONBOARDING.md`](ONBOARDING.md) for the per-suite
 breakdown, the dev-vs-installed port split, and the `/health` vs `/health/ready` trap.
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -106,8 +106,8 @@ reports `Skipped: 1` and writes nothing — which looks like success while leavi
 ### Expected counts
 
 Solution suites (`dotnet test` at the root), Docker running **and** the real store databases present
-— **618 total** (617 pass, 1 skipped) — measured 2026-08-17. Without those databases the total is
-**598** (**derived** as 618 − 20, not measured), still all green:
+— **627 total** (626 pass, 1 skipped) — measured 2026-08-19. Without those databases the total is
+**607** (**derived** as 627 − 20, not measured), still all green:
 
 | Suite | Tests |
 |---|---|
@@ -115,7 +115,7 @@ Solution suites (`dotnet test` at the root), Docker running **and** the real sto
 | `IndyPOS.StoreHub.IntegrationTests` | 104 (Docker) |
 | `IndyPOS.MigrationTool.Tests` | 134 (Docker; 1 skipped. **114** without the real store data — Trap 3, derived) |
 | `IndyPOS.Domain.Tests` | 36 |
-| `IndyPOS.Windows.Forms.Tests` | 28 |
+| `IndyPOS.Windows.Forms.Tests` | 37 |
 | `IndyPOS.Vault.Tests` | 17 |
 
 Outside the solution: `IndyPOS.Bootstrapper.Tests` — **231** (223 pass, 8 skipped).

--- a/scripts/verify-install.ps1
+++ b/scripts/verify-install.ps1
@@ -385,10 +385,16 @@ function Test-SideBySide {
         return
     }
 
+    # SystemRoot is "v{Major}" (InstallationConfig.cs:80), so "v4" -- it stopped being
+    # "v4.0.0" in 5ce6cea so that an upgrade reuses one root across patch releases.
+    # Accept both: a box installed by an older bootstrapper still carries the long form.
+    $ourRootPattern = '^v\d+(\.\d+)*$'
+
     # v4 location confinement is already covered by Test-Filesystem;
     # don't re-fail here. Just verify the install dir is strictly a
     # v*\ subdir (defence against accidental top-level writes).
-    if ($SystemRoot -match [regex]::Escape($ProgramDataRoot) + '\\v\d+\.\d+\.\d+') {
+    if ((Split-Path $SystemRoot -Parent) -eq $ProgramDataRoot -and
+        (Split-Path $SystemRoot -Leaf) -match $ourRootPattern) {
         Pass "SystemRoot is a v*\ subdir (no top-level v4 leakage)" $SystemRoot
     } else {
         Fail "SystemRoot is NOT a v-version subdir of ProgramDataRoot" $SystemRoot
@@ -397,8 +403,11 @@ function Test-SideBySide {
     # Top-level entries other than v*\ dirs are presumed pre-existing v3 or
     # unrelated. We can't verify byte-for-byte untouchedness without a
     # baseline snapshot, so just enumerate them for the human reviewer.
+    # NOTE: matching this against the OLD 'v\d+\.\d+\.\d+' pattern counted our own
+    # "v4" directory as a v3-era entry, so this reported a v3 footprint on a box
+    # that had never seen v3 -- a false pass on the one check that was still owed.
     $topLevel = Get-ChildItem $ProgramDataRoot -ErrorAction SilentlyContinue
-    $nonVersioned = $topLevel | Where-Object { $_.Name -notmatch '^v\d+\.\d+\.\d+$' }
+    $nonVersioned = $topLevel | Where-Object { $_.Name -notmatch $ourRootPattern }
     if ($nonVersioned.Count -gt 0) {
         Pass "v3.7.0-era top-level entries detected" "$($nonVersioned.Count) found: $($nonVersioned.Name -join ', ')"
     } else {

--- a/scripts/vm-testing/Get-V3Footprint.ps1
+++ b/scripts/vm-testing/Get-V3Footprint.ps1
@@ -1,0 +1,144 @@
+<#
+.SYNOPSIS
+    Read-only capture of a v3.7.0 store's on-disk and registry footprint.
+
+.DESCRIPTION
+    Epic 3 owes one v3.7.0-coexistence check before the first cutover, and there is
+    no v3.7.0 artefact to install — GitHub releases stop at 3.6.0. So instead of
+    reconstructing v3 from a build, we capture what a live store actually has and
+    replay it onto the test VM with New-V3Footprint.ps1.
+
+    STRICTLY READ-ONLY on the store machine. It records paths, sizes and timestamps.
+    It never opens Store.db, never reads file CONTENTS, and never writes anywhere
+    except the -OutputPath you choose.
+
+    Run this on a till BEFORE v4 is installed on it. Running it after would capture
+    v4's own directories as part of the "v3" baseline.
+
+.PARAMETER OutputPath
+    Where to write the JSON capture. Defaults to the desktop.
+
+.PARAMETER StoreLabel
+    A name for the store, recorded in the capture so several can be told apart.
+
+.EXAMPLE
+    .\Get-V3Footprint.ps1 -StoreLabel GeneralHardware
+    # Writes v3-footprint-GeneralHardware.json to the desktop.
+
+.NOTES
+    IndyPOS is a PUBLIC repository. Do not commit the JSON this produces — it lists
+    real store paths. Keep captures outside the repo.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$OutputPath,
+    [Parameter(Mandatory)][string]$StoreLabel
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProgramDataRoot = "C:\ProgramData\IndyPOS"
+
+function Get-TreeEntries {
+    param([string]$Root, [int]$Depth = 3)
+
+    if (-not (Test-Path $Root)) { return @() }
+
+    # -Force so hidden/system entries are captured too; a footprint that misses them
+    # would replay as "clean" and the coexistence check would prove less than it claims.
+    Get-ChildItem -LiteralPath $Root -Recurse -Depth $Depth -Force -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            [PSCustomObject]@{
+                RelativePath  = $_.FullName.Substring($Root.Length).TrimStart('\')
+                IsDirectory   = $_.PSIsContainer
+                SizeBytes     = if ($_.PSIsContainer) { $null } else { $_.Length }
+                LastWriteUtc  = $_.LastWriteTimeUtc.ToString("o")
+                Attributes    = $_.Attributes.ToString()
+            }
+        }
+}
+
+function Get-IndyServices {
+    Get-ChildItem "HKLM:\SYSTEM\CurrentControlSet\Services" -ErrorAction SilentlyContinue |
+        Where-Object { $_.PSChildName -like "*IndyPOS*" } |
+        ForEach-Object {
+            $props = Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue
+            [PSCustomObject]@{
+                Name      = $_.PSChildName
+                ImagePath = $props.ImagePath
+                Start     = $props.Start
+            }
+        }
+}
+
+function Get-IndyUninstallEntries {
+    $roots = @(
+        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+        "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+        "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
+    )
+
+    foreach ($root in $roots) {
+        Get-ChildItem $root -ErrorAction SilentlyContinue | ForEach-Object {
+            $props = Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue
+            if ($props.DisplayName -like "*IndyPOS*") {
+                [PSCustomObject]@{
+                    Hive            = $root
+                    DisplayName     = $props.DisplayName
+                    DisplayVersion  = $props.DisplayVersion
+                    InstallLocation = $props.InstallLocation
+                }
+            }
+        }
+    }
+}
+
+$appRoots = @(
+    (Join-Path $env:LOCALAPPDATA "IndyPOS"),
+    (Join-Path $env:LOCALAPPDATA "IndyPOS.POS"),
+    (Join-Path $env:LOCALAPPDATA "IndyPOS.POS.v4"),
+    "C:\Program Files\IndyPOS",
+    "C:\Program Files (x86)\IndyPOS"
+) | Where-Object { Test-Path $_ }
+
+$capture = [PSCustomObject]@{
+    StoreLabel        = $StoreLabel
+    CapturedUtc       = (Get-Date).ToUniversalTime().ToString("o")
+    MachineName       = $env:COMPUTERNAME
+    ProgramDataRoot   = $ProgramDataRoot
+    ProgramDataExists = (Test-Path $ProgramDataRoot)
+    ProgramDataTree   = @(Get-TreeEntries -Root $ProgramDataRoot)
+    AppRoots          = @($appRoots | ForEach-Object {
+        [PSCustomObject]@{ Path = $_; Tree = @(Get-TreeEntries -Root $_ -Depth 2) }
+    })
+    Services          = @(Get-IndyServices)
+    UninstallEntries  = @(Get-IndyUninstallEntries)
+}
+
+if (-not $OutputPath) {
+    $desktop = [Environment]::GetFolderPath("Desktop")
+    $OutputPath = Join-Path $desktop "v3-footprint-$StoreLabel.json"
+}
+
+$capture | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $OutputPath -Encoding UTF8
+
+$topLevel = $capture.ProgramDataTree | Where-Object { $_.RelativePath -notmatch '\\' }
+$versioned = $topLevel | Where-Object { $_.IsDirectory -and $_.RelativePath -match '^v\d+(\.\d+)*$' }
+
+Write-Host ""
+Write-Host "Captured $StoreLabel -> $OutputPath" -ForegroundColor Green
+Write-Host "  $ProgramDataRoot exists : $($capture.ProgramDataExists)"
+Write-Host "  entries under it        : $($capture.ProgramDataTree.Count)"
+Write-Host "  top-level entries       : $($topLevel.Count)"
+Write-Host "  IndyPOS services        : $($capture.Services.Count)"
+Write-Host "  uninstall entries       : $($capture.UninstallEntries.Count)"
+
+if ($versioned.Count -gt 0) {
+    Write-Host ""
+    Write-Host "  WARNING: found v*\ directories ($($versioned.RelativePath -join ', '))." -ForegroundColor Yellow
+    Write-Host "  A v3-only till should have none. Was v4 already installed here?" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "This file lists real store paths. Do NOT commit it - IndyPOS is a public repo." -ForegroundColor Yellow

--- a/scripts/vm-testing/New-V3Footprint.ps1
+++ b/scripts/vm-testing/New-V3Footprint.ps1
@@ -13,9 +13,17 @@
     which is whether the v4 install leaves the v3 footprint alone. It is NOT a working
     v3 install and will not launch.
 
-    Services and uninstall entries are NOT replayed. A real v3.7.0 has neither a
-    Windows service nor Postgres, so recreating them would model a machine that does
-    not exist. The script warns if the capture contains any.
+    Only the C:\ProgramData\IndyPOS tree is replayed. The capture also records AppRoots
+    (%LOCALAPPDATA%\IndyPOS*, Program Files) and uninstall entries, but those are kept as
+    evidence for a human rather than recreated, because verify-install.ps1's section 7 --
+    the check this exists to feed -- only inspects ProgramDataRoot. Consequence worth
+    knowing: this setup cannot detect a v4 install that clobbered v3's program files.
+
+    Services are NOT replayed either. A real v3.7.0 has neither a Windows service nor
+    Postgres, so recreating one would model a machine that does not exist. The script
+    warns if the capture contains any.
+
+    Runs on Windows PowerShell 5.1, which is what a clean Windows snapshot ships with.
 
 .PARAMETER CapturePath
     The JSON written by Get-V3Footprint.ps1.
@@ -84,11 +92,54 @@ $sep = [char]92
 $made = [ordered]@{ Directories = 0; Files = 0 }
 $truncated = New-Object System.Collections.Generic.List[string]
 
+# Join-Path does not normalise, so a capture carrying ".." in a RelativePath would
+# resolve to a write OUTSIDE the target root -- past the safety guard entirely. A
+# genuine capture cannot produce one (RelativePath is a Substring of FullName), so
+# this only bites on an edited or corrupted JSON. Refuse it rather than trust it.
+$rootFull = [System.IO.Path]::GetFullPath($ProgramDataRoot)
+
+# ConvertFrom-Json may hand back a DateTime already (pwsh 7) or a string (older hosts).
+# Calling [datetime]::Parse on a DateTime stringifies it with the CURRENT culture and
+# re-parses it as Unspecified, which then gets the local offset applied a second time --
+# and under th-TH it reads 2026 as a Buddhist-era year, giving 1483, which is before the
+# Win32 FILETIME epoch and throws mid-replay. This is a Thai POS; assume a Thai locale.
+function ConvertTo-Utc {
+    param($Value)
+
+    if ($Value -is [datetime]) {
+        switch ($Value.Kind) {
+            ([System.DateTimeKind]::Utc)   { return $Value }
+            ([System.DateTimeKind]::Local) { return $Value.ToUniversalTime() }
+            # The capture wrote UTC ("o" format, trailing Z), so Unspecified means UTC.
+            default { return [datetime]::SpecifyKind($Value, [System.DateTimeKind]::Utc) }
+        }
+    }
+
+    return [datetime]::Parse(
+        [string]$Value,
+        [cultureinfo]::InvariantCulture,
+        [System.Globalization.DateTimeStyles]::RoundtripKind).ToUniversalTime()
+}
+
+function Resolve-Contained {
+    param([string]$Root, [string]$RootFull, [string]$RelativePath)
+
+    $candidate = [System.IO.Path]::GetFullPath((Join-Path $Root $RelativePath))
+    $prefix = if ($RootFull.EndsWith([System.IO.Path]::DirectorySeparatorChar)) { $RootFull }
+              else { $RootFull + [System.IO.Path]::DirectorySeparatorChar }
+
+    if (-not $candidate.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Capture entry escapes the target root: '$RelativePath' -> '$candidate'"
+    }
+
+    return $candidate
+}
+
 # Directories first, deepest last, so a file never precedes its parent.
 foreach ($entry in ($capture.ProgramDataTree | Where-Object { $_.IsDirectory } |
                     Sort-Object { $_.RelativePath.Split($sep).Count })) {
 
-    $target = Join-Path $ProgramDataRoot $entry.RelativePath
+    $target = Resolve-Contained -Root $ProgramDataRoot -RootFull $rootFull -RelativePath $entry.RelativePath
 
     if (-not (Test-Path -LiteralPath $target)) {
         $null = New-Item -ItemType Directory -Path $target -Force
@@ -97,7 +148,7 @@ foreach ($entry in ($capture.ProgramDataTree | Where-Object { $_.IsDirectory } |
 }
 
 foreach ($entry in ($capture.ProgramDataTree | Where-Object { -not $_.IsDirectory })) {
-    $target = Join-Path $ProgramDataRoot $entry.RelativePath
+    $target = Resolve-Contained -Root $ProgramDataRoot -RootFull $rootFull -RelativePath $entry.RelativePath
     $parent = Split-Path $target -Parent
 
     if (-not (Test-Path -LiteralPath $parent)) {
@@ -107,7 +158,9 @@ foreach ($entry in ($capture.ProgramDataTree | Where-Object { -not $_.IsDirector
 
     if (Test-Path -LiteralPath $target) { continue }
 
-    $length = [long]($entry.SizeBytes ?? 0)
+    # No ?? here: Windows PowerShell 5.1 cannot even PARSE it, and that is what a
+    # clean Windows snapshot ships with -- the whole point is to run this on the VM.
+    $length = if ($null -eq $entry.SizeBytes) { [long]0 } else { [long]$entry.SizeBytes }
 
     if ($length -gt $MaxFileBytes) {
         $truncated.Add("$($entry.RelativePath) ($length bytes -> $MaxFileBytes)")
@@ -119,7 +172,7 @@ foreach ($entry in ($capture.ProgramDataTree | Where-Object { -not $_.IsDirector
     $stream = [System.IO.File]::Create($target)
     try { $stream.SetLength($length) } finally { $stream.Dispose() }
 
-    [System.IO.File]::SetLastWriteTimeUtc($target, [datetime]::Parse($entry.LastWriteUtc).ToUniversalTime())
+    [System.IO.File]::SetLastWriteTimeUtc($target, (ConvertTo-Utc $entry.LastWriteUtc))
     $made.Files++
 }
 

--- a/scripts/vm-testing/New-V3Footprint.ps1
+++ b/scripts/vm-testing/New-V3Footprint.ps1
@@ -1,0 +1,146 @@
+<#
+.SYNOPSIS
+    Replays a captured v3.7.0 footprint onto a test machine.
+
+.DESCRIPTION
+    Consumes the JSON produced by Get-V3Footprint.ps1 and recreates the directory
+    and file layout under C:\ProgramData\IndyPOS, so v4 can be installed over a
+    realistic v3 footprint and verify-install.ps1's side-by-side section can assert
+    coexistence against something real instead of skipping.
+
+    File CONTENTS are not captured and are not reproduced — files are created at
+    their recorded length (zero-filled). That is enough for the question being asked,
+    which is whether the v4 install leaves the v3 footprint alone. It is NOT a working
+    v3 install and will not launch.
+
+    Services and uninstall entries are NOT replayed. A real v3.7.0 has neither a
+    Windows service nor Postgres, so recreating them would model a machine that does
+    not exist. The script warns if the capture contains any.
+
+.PARAMETER CapturePath
+    The JSON written by Get-V3Footprint.ps1.
+
+.PARAMETER MaxFileBytes
+    Files longer than this are created truncated, and listed at the end. Keeps a
+    multi-hundred-MB Store.db from being materialised for no benefit.
+
+.PARAMETER Force
+    Required when the target root already has a v*\ install root. See the safety guard below.
+
+.PARAMETER TargetRoot
+    Where to replay the footprint. Defaults to the real C:\ProgramData\IndyPOS.
+    Overriding it is how this script gets tested without writing to a live layout.
+
+.EXAMPLE
+    .\New-V3Footprint.ps1 -CapturePath .\v3-footprint-GeneralHardware.json
+
+.EXAMPLE
+    .\New-V3Footprint.ps1 -CapturePath .\capture.json -TargetRoot $env:TEMP\fp
+    # Dry run into a throwaway directory.
+
+.NOTES
+    SAFETY: refuses to run on a machine that already has a v*\ install root unless
+    -Force is given, so it cannot be run against a real till by accident.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$CapturePath,
+    [string]$TargetRoot = "C:\ProgramData\IndyPOS",
+    [long]$MaxFileBytes = 4MB,
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProgramDataRoot = $TargetRoot
+
+if (-not (Test-Path -LiteralPath $CapturePath)) {
+    throw "Capture not found: $CapturePath"
+}
+
+$capture = Get-Content -LiteralPath $CapturePath -Raw | ConvertFrom-Json
+
+# --- Safety guard -------------------------------------------------------------
+# A real till is exactly the machine we must never write to. The tell is an
+# existing versioned install root, so treat that as a stop unless overridden.
+$existingVersioned = @()
+if (Test-Path $ProgramDataRoot) {
+    $existingVersioned = @(Get-ChildItem $ProgramDataRoot -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match '^v\d+(\.\d+)*$' })
+}
+
+if ($existingVersioned.Count -gt 0 -and -not $Force) {
+    Write-Host ""
+    Write-Host "REFUSING to run." -ForegroundColor Red
+    Write-Host "  $ProgramDataRoot already contains: $($existingVersioned.Name -join ', ')"
+    Write-Host "  That looks like a real install, not a clean test VM."
+    Write-Host "  Re-run with -Force only if you are certain this is a throwaway machine."
+    exit 2
+}
+
+# --- Replay -------------------------------------------------------------------
+$sep = [char]92
+$made = [ordered]@{ Directories = 0; Files = 0 }
+$truncated = New-Object System.Collections.Generic.List[string]
+
+# Directories first, deepest last, so a file never precedes its parent.
+foreach ($entry in ($capture.ProgramDataTree | Where-Object { $_.IsDirectory } |
+                    Sort-Object { $_.RelativePath.Split($sep).Count })) {
+
+    $target = Join-Path $ProgramDataRoot $entry.RelativePath
+
+    if (-not (Test-Path -LiteralPath $target)) {
+        $null = New-Item -ItemType Directory -Path $target -Force
+        $made.Directories++
+    }
+}
+
+foreach ($entry in ($capture.ProgramDataTree | Where-Object { -not $_.IsDirectory })) {
+    $target = Join-Path $ProgramDataRoot $entry.RelativePath
+    $parent = Split-Path $target -Parent
+
+    if (-not (Test-Path -LiteralPath $parent)) {
+        $null = New-Item -ItemType Directory -Path $parent -Force
+        $made.Directories++
+    }
+
+    if (Test-Path -LiteralPath $target) { continue }
+
+    $length = [long]($entry.SizeBytes ?? 0)
+
+    if ($length -gt $MaxFileBytes) {
+        $truncated.Add("$($entry.RelativePath) ($length bytes -> $MaxFileBytes)")
+        $length = $MaxFileBytes
+    }
+
+    # SetLength on a new file gives a zero-filled file of the right size without
+    # allocating a buffer for it.
+    $stream = [System.IO.File]::Create($target)
+    try { $stream.SetLength($length) } finally { $stream.Dispose() }
+
+    [System.IO.File]::SetLastWriteTimeUtc($target, [datetime]::Parse($entry.LastWriteUtc).ToUniversalTime())
+    $made.Files++
+}
+
+Write-Host ""
+Write-Host "Replayed footprint '$($capture.StoreLabel)' captured $($capture.CapturedUtc)" -ForegroundColor Green
+Write-Host "  directories created : $($made.Directories)"
+Write-Host "  files created       : $($made.Files)"
+
+if ($truncated.Count -gt 0) {
+    Write-Host ""
+    Write-Host "  $($truncated.Count) file(s) created truncated (contents are not part of the capture):" -ForegroundColor Yellow
+    $truncated | ForEach-Object { Write-Host "    $_" -ForegroundColor Yellow }
+}
+
+if ($capture.Services.Count -gt 0) {
+    Write-Host ""
+    Write-Host "  NOT replayed: $($capture.Services.Count) IndyPOS service(s) in the capture" -ForegroundColor Yellow
+    Write-Host "  ($($capture.Services.Name -join ', ')). A real v3.7.0 has no Windows service," -ForegroundColor Yellow
+    Write-Host "  so the capture may have come from a machine that already had v4." -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "Next: install v4, then run scripts\verify-install.ps1 and read section 7." -ForegroundColor Cyan
+Write-Host "It must now report the v3-era entries rather than Skip." -ForegroundColor Cyan

--- a/scripts/vm-testing/README.md
+++ b/scripts/vm-testing/README.md
@@ -17,7 +17,36 @@ wizard step.
 | `VMTestConfig.psd1` | Shared config — VM name, paths, timeouts |
 | `Reset-AndInstall.ps1` | Host-side orchestrator (run this) |
 | `Test-IndyPOSInstallation.ps1` | In-VM verifier (called via PSDirect) |
+| `Get-V3Footprint.ps1` | Read-only capture of a v3.7.0 store's layout (run at a store) |
+| `New-V3Footprint.ps1` | Replays that capture onto the VM (run before installing v4) |
 | `README.md` | This file |
+
+## v3.7.0 coexistence
+
+`Test-IndyPOSInstallation.ps1` drops the side-by-side invariants, because a clean VM
+has no v3 footprint to protect — and `verify-install.ps1`'s section 7 `Skip`s for the
+same reason. So the coexistence promise in `docs/operations/upgrade-procedure.md` has
+never actually been tested, and there is no v3.7.0 artefact to install (releases stop
+at 3.6.0).
+
+The pair of scripts above closes that: capture the layout a live store really has,
+replay it onto the VM, install v4 over it, then read section 7 of `verify-install.ps1`
+— it must now report the v3-era entries rather than skip.
+
+```powershell
+# 1. At a store, BEFORE v4 is installed there. Read-only.
+.\Get-V3Footprint.ps1 -StoreLabel GeneralHardware
+
+# 2. On the test VM, from the Clean-Windows snapshot.
+.\New-V3Footprint.ps1 -CapturePath .\v3-footprint-GeneralHardware.json
+
+# 3. Install v4, then:
+..\verify-install.ps1
+```
+
+⚠️ The capture lists real store paths and **must not be committed** — this repo is public.
+`New-V3Footprint.ps1` refuses to run where a `v*\` root already exists, so it cannot be
+pointed at a real till by accident.
 
 ## Prerequisites (one-time, ~30 min)
 

--- a/tests/IndyPOS.Windows.Forms.Tests/UI/Payment/PaymentMethodButtonCaptionTests.cs
+++ b/tests/IndyPOS.Windows.Forms.Tests/UI/Payment/PaymentMethodButtonCaptionTests.cs
@@ -1,0 +1,103 @@
+using System.Reflection;
+using System.Windows.Forms;
+using FluentAssertions;
+using IndyPOS.Application.UseCases.StoreHub.PaymentMethods;
+using IndyPOS.Domain.Enums;
+using IndyPOS.Infrastructure.Persistence.StoreHub.Seeders;
+using Xunit;
+
+namespace IndyPOS.Windows.Forms.Tests.UI.Payment;
+
+/// <summary>
+/// Guards the payment buttons against a caption that no longer fits.
+/// <para>
+/// PLAN.md carried an owed visual smoke for months, suspecting <c>บัตรสวัสดิการแห่งรัฐ</c> was
+/// clipped on the 195x129 button. It is not: rendered against a 195x260 button, where clipping is
+/// impossible, the caption ink is identical (11px, 5px of gap below it) and the welfare-card icon's
+/// visible ink is 174px wide in both a 195px and a 400px button. The arithmetic that raised the
+/// alarm used declared asset sizes, which include transparent margin.
+/// </para>
+/// <para>
+/// What is genuinely tight is that only ONE line of caption fits beneath a 100px icon, and the
+/// catalogue is data-driven — a future campaign can arrive with a longer name. These tests pin the
+/// two margins that keep it readable, driven by the real factory and the real seeded catalogue so
+/// neither can drift from what a till renders.
+/// </para>
+/// </summary>
+public class PaymentMethodButtonCaptionTests
+{
+    /// <summary>1px flat border plus the 3px text inset ButtonBase applies, on both sides.</summary>
+    private const int HorizontalChrome = 8;
+
+    /// <summary>The same allowance vertically, above and below the image-plus-text stack.</summary>
+    private const int VerticalChrome = 8;
+
+    /// <summary>The tallest icon bundled for a payment method (see PaymentMethodIcons).</summary>
+    private const int TallestIconHeight = 100;
+
+    public static TheoryData<string> SeededCaptions()
+    {
+        var data = new TheoryData<string>();
+
+        foreach (var caption in ShippedCaptions())
+            data.Add(caption);
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(SeededCaptions))]
+    public void CreatePaymentMethodButton_ForEverySeededCaption_ShouldRenderOnOneLine(string caption)
+    {
+        using var button = CreateButton(caption);
+
+        var width = TextRenderer.MeasureText(caption, button.Font).Width;
+
+        width.Should()
+             .BeLessThanOrEqualTo(button.Width - HorizontalChrome,
+                 $"'{caption}' has to fit on one line — a second line does not fit under the icon");
+    }
+
+    [Fact]
+    public void CreatePaymentMethodButton_BeneathTheTallestIcon_ShouldLeaveRoomForOneLine()
+    {
+        using var button = CreateButton("บัตรสวัสดิการแห่งรัฐ");
+
+        var roomForCaption = button.Height - TallestIconHeight - VerticalChrome;
+        var lineHeight = TextRenderer.MeasureText("บัตรสวัสดิการแห่งรัฐ", button.Font).Height;
+
+        roomForCaption.Should()
+                      .BeGreaterThanOrEqualTo(lineHeight,
+                          "the caption is drawn below the icon, so shrinking the button or " +
+                          "bundling a taller icon would clip it");
+    }
+
+    private static Button CreateButton(string caption)
+    {
+        var factory = typeof(global::IndyPOS.Windows.Forms.UI.MainForm).Assembly
+                          .GetType("IndyPOS.Windows.Forms.UI.Payment.AcceptPaymentForm")!
+                          .GetMethod("CreatePaymentMethodButton", BindingFlags.NonPublic | BindingFlags.Static)
+                      ?? throw new InvalidOperationException(
+                          "AcceptPaymentForm.CreatePaymentMethodButton is gone — this guard is measuring nothing.");
+
+        var method = new PaymentMethodDto("Code", caption, PaymentMethodKind.Standard, true, 1);
+
+        return (Button)factory.Invoke(null, [method, 0])!;
+    }
+
+    /// <summary>
+    /// The captions a store actually gets, read from the seeder rather than copied, so a new
+    /// campaign is covered by this guard the moment it is added.
+    /// </summary>
+    private static IEnumerable<string> ShippedCaptions()
+    {
+        var defaults = typeof(PaymentMethodSeeder)
+                           .GetField("Defaults", BindingFlags.NonPublic | BindingFlags.Static)
+                           ?.GetValue(null) as Array
+                       ?? throw new InvalidOperationException(
+                           "PaymentMethodSeeder.Defaults is gone — this guard is measuring nothing.");
+
+        foreach (var seed in defaults)
+            yield return (string)seed.GetType().GetProperty("DisplayName")!.GetValue(seed)!;
+    }
+}

--- a/tests/IndyPOS.Windows.Forms.Tests/UI/Payment/PaymentMethodButtonCaptionTests.cs
+++ b/tests/IndyPOS.Windows.Forms.Tests/UI/Payment/PaymentMethodButtonCaptionTests.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using System.Reflection;
 using System.Windows.Forms;
 using FluentAssertions;
@@ -13,66 +14,98 @@ namespace IndyPOS.Windows.Forms.Tests.UI.Payment;
 /// <para>
 /// PLAN.md carried an owed visual smoke for months, suspecting <c>บัตรสวัสดิการแห่งรัฐ</c> was
 /// clipped on the 195x129 button. It is not: rendered against a 195x260 button, where clipping is
-/// impossible, the caption ink is identical (11px, 5px of gap below it) and the welfare-card icon's
-/// visible ink is 174px wide in both a 195px and a 400px button. The arithmetic that raised the
-/// alarm used declared asset sizes, which include transparent margin.
+/// impossible, the caption ink is identical (rows 108-122, 15px, with rows 123-127 clear below it)
+/// and the welfare-card icon's visible ink is 174px wide in both a 195px and a 400px button. The
+/// arithmetic that raised the alarm used declared asset sizes, which include transparent margin.
 /// </para>
 /// <para>
-/// What is genuinely tight is that only ONE line of caption fits beneath a 100px icon, and the
-/// catalogue is data-driven — a future campaign can arrive with a longer name. These tests pin the
-/// two margins that keep it readable, driven by the real factory and the real seeded catalogue so
-/// neither can drift from what a till renders.
+/// What is genuinely tight is that only ONE line of caption fits beneath the tallest bundled icon,
+/// and the catalogue is data-driven — a future campaign can arrive with a longer name. These tests
+/// pin the two margins that keep it readable. Everything they measure is read from shipped code:
+/// the button from the real factory, the captions from <see cref="PaymentMethodSeeder"/>, and the
+/// icon height from the real <c>PaymentMethodIcons</c> table — so bundling a taller icon or adding
+/// a longer campaign name fails here rather than reaching a till.
 /// </para>
 /// </summary>
 public class PaymentMethodButtonCaptionTests
 {
-    /// <summary>1px flat border plus the 3px text inset ButtonBase applies, on both sides.</summary>
-    private const int HorizontalChrome = 8;
+    /// <summary>
+    /// Widest caption that renders unclipped, established empirically rather than derived: a
+    /// button was rendered at 195px and again at 400px and the caption's ink pixels compared,
+    /// which puts the onset of real clipping between 184px and 189px depending on the glyphs.
+    /// 184 is the strict end of that band, so this errs toward a false alarm rather than a miss.
+    /// <para>
+    /// Do NOT re-derive this as "195 minus border and inset". `MeasureText(text, font)` adds a
+    /// fixed 10px of glyph-overhang padding that is not chrome, so that arithmetic mixes units
+    /// and lands ~3px too lenient.
+    /// </para>
+    /// </summary>
+    private const int MaxCaptionWidth = 184;
 
     /// <summary>The same allowance vertically, above and below the image-plus-text stack.</summary>
     private const int VerticalChrome = 8;
 
-    /// <summary>The tallest icon bundled for a payment method (see PaymentMethodIcons).</summary>
-    private const int TallestIconHeight = 100;
-
-    public static TheoryData<string> SeededCaptions()
+    public static TheoryData<string, string> SeededMethods()
     {
-        var data = new TheoryData<string>();
+        var data = new TheoryData<string, string>();
 
-        foreach (var caption in ShippedCaptions())
-            data.Add(caption);
+        foreach (var (code, caption) in ShippedMethods())
+            data.Add(code, caption);
 
         return data;
     }
 
     [Theory]
-    [MemberData(nameof(SeededCaptions))]
-    public void CreatePaymentMethodButton_ForEverySeededCaption_ShouldRenderOnOneLine(string caption)
+    [MemberData(nameof(SeededMethods))]
+    public void CreatePaymentMethodButton_ForEverySeededCaption_ShouldRenderOnOneLine(
+        string code, string caption)
     {
-        using var button = CreateButton(caption);
+        using var button = CreateButton(code, caption);
 
         var width = TextRenderer.MeasureText(caption, button.Font).Width;
 
         width.Should()
-             .BeLessThanOrEqualTo(button.Width - HorizontalChrome,
-                 $"'{caption}' has to fit on one line — a second line does not fit under the icon");
+             .BeLessThanOrEqualTo(MaxCaptionWidth,
+                 $"'{caption}' has to fit on one line — with an icon above it, a caption this " +
+                 "wide is hard-clipped mid-glyph rather than wrapped");
     }
 
     [Fact]
-    public void CreatePaymentMethodButton_BeneathTheTallestIcon_ShouldLeaveRoomForOneLine()
+    public void CreatePaymentMethodButton_BeneathTheTallestBundledIcon_ShouldLeaveRoomForOneLine()
     {
-        using var button = CreateButton("บัตรสวัสดิการแห่งรัฐ");
+        var tallestIcon = ShippedIconHeights().Max();
 
-        var roomForCaption = button.Height - TallestIconHeight - VerticalChrome;
-        var lineHeight = TextRenderer.MeasureText("บัตรสวัสดิการแห่งรัฐ", button.Font).Height;
+        using var button = CreateButton(TallestSeededMethod().Code, TallestSeededMethod().Caption);
+
+        var roomForCaption = button.Height - tallestIcon - VerticalChrome;
+        var lineHeight = TextRenderer.MeasureText(TallestSeededMethod().Caption, button.Font).Height;
 
         roomForCaption.Should()
                       .BeGreaterThanOrEqualTo(lineHeight,
-                          "the caption is drawn below the icon, so shrinking the button or " +
-                          "bundling a taller icon would clip it");
+                          $"the caption is drawn below the icon, and the tallest bundled icon is " +
+                          $"{tallestIcon}px — shrinking the button or bundling a taller icon clips it");
     }
 
-    private static Button CreateButton(string caption)
+    /// <summary>
+    /// The layout the margin tests assume. Without an icon actually attached and stacked above the
+    /// text, both of them would be arithmetic on constants that no longer describe the button.
+    /// </summary>
+    [Fact]
+    public void CreatePaymentMethodButton_ForASeededMethod_ShouldStackARealIconAboveTheCaption()
+    {
+        var seeded = TallestSeededMethod();
+
+        using var button = CreateButton(seeded.Code, seeded.Caption);
+
+        button.Image.Should()
+              .NotBeNull($"'{seeded.Code}' is a seeded method and must resolve a bundled icon — " +
+                         "without one these tests measure a layout the till does not use");
+
+        button.TextImageRelation.Should().Be(TextImageRelation.ImageAboveText);
+        button.Image!.Height.Should().Be(ShippedIconHeights().Max());
+    }
+
+    private static Button CreateButton(string code, string caption)
     {
         var factory = typeof(global::IndyPOS.Windows.Forms.UI.MainForm).Assembly
                           .GetType("IndyPOS.Windows.Forms.UI.Payment.AcceptPaymentForm")!
@@ -80,16 +113,51 @@ public class PaymentMethodButtonCaptionTests
                       ?? throw new InvalidOperationException(
                           "AcceptPaymentForm.CreatePaymentMethodButton is gone — this guard is measuring nothing.");
 
-        var method = new PaymentMethodDto("Code", caption, PaymentMethodKind.Standard, true, 1);
+        var method = new PaymentMethodDto(code, caption, PaymentMethodKind.Standard, true, 1);
 
         return (Button)factory.Invoke(null, [method, 0])!;
     }
 
+    /// <summary>The seeded method carrying the tallest bundled icon — the worst case for height.</summary>
+    private static (string Code, string Caption) TallestSeededMethod()
+    {
+        var icons = ShippedIcons();
+
+        var withIcons = ShippedMethods()
+                        .Where(method => icons.ContainsKey(method.Code))
+                        .OrderByDescending(method => icons[method.Code].Height)
+                        .ToList();
+
+        if (withIcons.Count == 0)
+            throw new InvalidOperationException(
+                "No seeded payment method resolves a bundled icon — this guard is measuring nothing.");
+
+        return withIcons[0];
+    }
+
+    private static IEnumerable<int> ShippedIconHeights() =>
+        ShippedIcons().Values.Select(image => image.Height);
+
     /// <summary>
-    /// The captions a store actually gets, read from the seeder rather than copied, so a new
+    /// The real icon table, so a taller asset is caught here rather than copied into a constant
+    /// that silently goes stale.
+    /// </summary>
+    private static Dictionary<string, Image> ShippedIcons()
+    {
+        var field = typeof(global::IndyPOS.Windows.Forms.UI.MainForm).Assembly
+                        .GetType("IndyPOS.Windows.Forms.UI.Payment.PaymentMethodIcons")!
+                        .GetField("IconsByCode", BindingFlags.NonPublic | BindingFlags.Static)
+                    ?? throw new InvalidOperationException(
+                        "PaymentMethodIcons.IconsByCode is gone — this guard is measuring nothing.");
+
+        return (Dictionary<string, Image>)field.GetValue(null)!;
+    }
+
+    /// <summary>
+    /// The methods a store actually gets, read from the seeder rather than copied, so a new
     /// campaign is covered by this guard the moment it is added.
     /// </summary>
-    private static IEnumerable<string> ShippedCaptions()
+    private static IEnumerable<(string Code, string Caption)> ShippedMethods()
     {
         var defaults = typeof(PaymentMethodSeeder)
                            .GetField("Defaults", BindingFlags.NonPublic | BindingFlags.Static)
@@ -98,6 +166,12 @@ public class PaymentMethodButtonCaptionTests
                            "PaymentMethodSeeder.Defaults is gone — this guard is measuring nothing.");
 
         foreach (var seed in defaults)
-            yield return (string)seed.GetType().GetProperty("DisplayName")!.GetValue(seed)!;
+        {
+            var type = seed.GetType();
+
+            yield return (
+                (string)type.GetProperty("Code")!.GetValue(seed)!,
+                (string)type.GetProperty("DisplayName")!.GetValue(seed)!);
+        }
     }
 }


### PR DESCRIPTION
Clears the first of Epic 3's two owed pre-cutover checks, unblocks the second — and, via independent
review, turns up a real UI defect that was hiding behind the first.

> **Reviewed by four independent lenses before merge.** They refuted the original headline claim,
> found a hole in the new tests, and found four defects in the new scripts. All are fixed or
> recorded below. The commit history keeps the original claims and the corrections separate.

## (a) The payment-button caption smoke

**At 100% display scaling there is no clipping.** Rendered against the real
`AcceptPaymentForm.CreatePaymentMethodButton` and compared with a button where clipping is
impossible:

| | 195×129 (shipped) | oversized (cannot clip) |
|---|---|---|
| caption ink | rows 108–122, **15px**, rows 123–127 clear | rows 142–156, **15px** |
| icon ink | **174×100** | 174×100 (in a 400px-wide button) |

Identical. The original alarm was arithmetic on **declared** asset sizes — the welfare PNG declares
190×100 but carries 8px of transparent margin each side.

### 🚨 But that verdict holds only at 100%, and there is a real defect above it

From **144.8% scaling — so Windows' standard 150% — the caption wraps to two lines and is painted on
top of the card artwork.** White Thai text over pale blue. Only `WelfareCard`; it is the longest
caption, and the one that was under suspicion all along.

**Cause.** `AcceptPaymentForm` is `AutoScaleMode.Font` with `AutoScaleDimensions = (6,13)`, but
`CreatePaymentMethodButton` hardcodes `Size(195,129)` and `Location(10 + col*201, 16 + row*135)` in
device pixels, and `BuildPaymentMethodButtons` runs from the async load path — *after*
`PerformAutoScale`. The panel scales, the 12pt font scales, the buttons never do.

```
height budget = 100px icon + caption ink
  100%  115px  fits in 129
  150%  154px  over by 25   <- wraps, overlaps the artwork
  200%  174px  over by 45
```

**Not fixed in this PR.** It is a change to shipped UI code with its own blast radius and deserves
its own focused work. Recorded in PLAN.md with the cause and the fix (scale those literals by
`CurrentAutoScaleDimensions / AutoScaleDimensions`, or build through a layout panel).
**Open question before the cutover: what scaling do the three tills actually run at?**

### The instrument was blind to it

The ink detector that produced the original clearance walked up from the bottom until a blank row —
which finds only the **last** line. At 150% it reports a comfortable single-line caption. Recorded,
because it is the same class of under-measurement that also made "11px of ink" wrong (it is 15px —
the detector cut the Thai upper vowel marks).

## (b) The guards

`PaymentMethodButtonCaptionTests` pins the 100% contract. Review found the first version measured the
one configuration where its own rule does not apply — it built the DTO with code `"Code"`, which
`PaymentMethodIcons.For` does not know, so **no icon was ever attached**. Without an icon WinForms
*wraps* the Thai caption and renders it fine; with one it *clips* mid-glyph. `TallestIconHeight` was
likewise an inert hand-copied constant: injecting a 150×130 icon changed nothing and the test still
passed.

Now the theory is driven by `(Code, DisplayName)` pairs from `PaymentMethodSeeder.Defaults`, so
buttons carry real icons, and the height bound reads the tallest image out of the real
`PaymentMethodIcons.IconsByCode`:

```
as shipped                 tallest=100px  room= 21px  => PASS
with a 130px icon bundled  tallest=130px  room= -9px  => FAIL
```

A third test pins the layout the other two assume, so this cannot silently regress to the no-icon
case. The width bound is an empirical **184px** — review showed `MeasureText` adds a fixed 10px of
glyph-overhang padding that is not chrome, so the derived 187 mixed units and passed a caption that
genuinely lost 24 ink pixels.

## (c) A verification script that could not fail

`verify-install.ps1` still matched `v\d+\.\d+\.\d+` though `SystemRoot` became `v{Major}` — plain
`v4` — in `5ce6cea`. Confirmed by **running** the patterns:

- the side-by-side check **failed a correct install**;
- the v3.7.0 footprint check counted our own `v4` directory as a v3-era entry, so it reported
  **"v3.7.0-era top-level entries detected → Pass" on a box that had never seen v3**.

```
OLD  counted as v3.7.0-era: Config, db, Logs, v4     <- v4 is ours
NEW  counted as v3.7.0-era: Config, db, Logs
```

**Honest limit, per review:** section 7 stays *advisory* even fixed. It cannot tell v3's
`Config`/`db`/`Logs` from a dev box's, since CLAUDE.md's own debug setup writes that same path. It
skips only on a pristine machine. Proving the footprint is *untouched* still needs a before/after
baseline diff, which does not exist yet.

## (d) Unblocking the v3-coexistence check

`Get-V3Footprint.ps1` (read-only capture at a store) and `New-V3Footprint.ps1` (replay onto the VM).

A v3.7.0 binary *is* reproducible from this repo — `9aca15c~1`, before the 4.0.0 assembly bump; there
is no tag or release, which stops at 3.6.0. The reason to capture from a real till is that a
from-source build gives a *fresh-install* footprint, not what a five-year-old till has accumulated.

Review found four defects here, all reproduced before fixing:

1. **Every timestamp was wrong, and `th-TH` crashed the run.** `ConvertFrom-Json` already yields a
   `DateTime`, so `[datetime]::Parse` restringified it with the current culture and applied the local
   offset twice. Under `th-TH` it read 2026 as a Buddhist year → 1483 → before the Win32 FILETIME
   epoch → threw after **one file**. On a Thai POS. Now exact to sub-second; th-TH replays all 491.
2. **`??` does not parse on Windows PowerShell 5.1** — what a clean VM snapshot ships with, i.e. the
   only host this was written for. Verified running under real 5.1: 491 files, exit 0; refusal exits 2.
3. **`..` in a capture escaped `-TargetRoot`**, past the safety guard whose whole promise is that this
   cannot touch a real till. Now refused.
4. `AppRoots` captured but never replayed — deliberate, now documented, including the consequence
   that this cannot detect a v4 install that clobbered v3's program files.

## Testing

Docker up, real store databases present — **627 total, 626 pass, 1 skip, 0 fail**.

| Suite | Result |
|---|---|
| Domain | 36 ✅ |
| Vault | 17 ✅ |
| Application | 299 ✅ |
| Windows.Forms | **37** ✅ (was 28) |
| MigrationTool | 134 ✅ (133 pass, 1 skip) |
| StoreHub.IntegrationTests | 104 ✅ |

Both `.ps1` files parse and run under Windows PowerShell 5.1 **and** pwsh 7. `CLAUDE.md` and
`ONBOARDING.md` counts refreshed to the measured 627; `.gitignore` now covers `v3-footprint-*.json`
so "never commit a capture" is mechanical.

## Still owed

One read-only command at a live store, before v4 lands there:

```powershell
.\scripts\vm-testing\Get-V3Footprint.ps1 -StoreLabel GeneralHardware
```

And a decision on the DPI defect above.
