### PR TITLE
fix(payment): scale the payment buttons with the display

### DIFF
--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -450,18 +450,42 @@ pixel-identical on the shipped 195x129 button and on one where clipping is impos
 174x100, unchanged in a 400px-wide button, so it is not cropped either. The original alarm was
 arithmetic on *declared* asset sizes, which include 8px of transparent margin each side.
 
-🚨 **But "no clipping" holds only at 100%, and independent review found a real defect above it.**
-From **144.8% scaling** — so Windows' standard 150% — the caption wraps to two lines and is painted
-**on top of the card artwork**: white Thai text over pale blue. Only `WelfareCard` is affected, being
-the longest caption. Height budget: 100px icon + caption ink = 115px at 100% (fits in 129), **154px
-at 150%**, 174px at 200%.
+🚨 **"No clipping" held only at 100%, and independent review found a real defect above it —
+now fixed (2026-08-19).** From **144.8% scaling** — Windows' standard 150% — the caption wrapped to
+two lines and was painted **on top of the card artwork**: white Thai text over pale blue. Only
+`WelfareCard`, the longest caption. Height budget: 100px icon + caption ink = 115px at 100% (fits in
+129), **154px at 150%**, 174px at 200%.
 
 **Cause.** `AcceptPaymentForm` is `AutoScaleMode.Font` with `AutoScaleDimensions = (6,13)`, but
-`CreatePaymentMethodButton` hardcodes `Size(195,129)` and `Location(10 + col*201, 16 + row*135)` in
+`CreatePaymentMethodButton` hardcoded `Size(195,129)` and `Location(10 + col*201, 16 + row*135)` in
 device pixels, and `BuildPaymentMethodButtons` runs from the async load path — *after*
-`PerformAutoScale`. So the panel scales, the 12pt font scales, and the buttons never do. **Fix:**
-scale those literals by `CurrentAutoScaleDimensions / AutoScaleDimensions`, or build through a
-layout panel. **Not fixed yet — check what scaling the tills actually run at before the cutover.**
+`PerformAutoScale`. The panel scaled, the 12pt font scaled, the buttons never did.
+
+**Fix.** The factory now takes a `scale`, and every literal goes through it.
+`BuildPaymentMethodButtons` derives it as `PaymentTypePanel.LogicalToDeviceUnits(96) / 96f`, which
+is 1.0 at 100% so the shipped geometry is untouched. Measured on real renders, caption ink vs icon
+ink isolated by layout-preserving diffs:
+
+| scaling | before (icon / caption rows) | after |
+|---|---|---|
+| 100% | 6..105 / 108..122 — clear | unchanged, 195x129 |
+| 125% | 6..105 / **105**..122 — touching | 11..110 / 119..136 clear |
+| 150% | 6..105 / **69**..122 — over the artwork | 19..118 / 127..148 clear |
+| 200% | 6..105 / **47**..120 — over the artwork | 31..130 / 143..171 clear |
+
+`PaymentMethodButtonScalingTests` pins it at 100/125/150/175/200%, taking the factor as a parameter
+so it runs identically on any machine (12pt@144dpi and 18pt@96dpi share a `LOGFONT.lfHeight`, so
+raising the point size is an exact stand-in). Verified to fail against the pre-fix behaviour: 6 red
+at 125% and above, 100% still green.
+
+⚠️ **Known limits of the fix.** The icons are *not* scaled — a 100px bitmap in a 292px button at
+150% simply looks smaller; nothing overlaps. And the factor is DPI-based while the form autoscales
+on **font** metrics; those track together for normal display scaling but would diverge if a till
+ran a custom system font size. Neither is the reported defect, both are cheap to revisit.
+
+⚠️ **Same latent pattern lives in `ChangePasswordForm`**, which also builds sized controls in code.
+Not touched here. There is no other DPI handling anywhere in the WinForms project — this is the
+first.
 
 ⚠️ The measurement that first cleared this was **also** wrong in a way worth remembering: the ink
 detector walked up from the bottom until a blank row, which finds only the *last* line — so it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,10 +214,10 @@ dotnet run --project src/IndyPOS.AppHost --launch-profile https
 # Dashboard: https://localhost:17222
 ```
 
-Solution suites total **627** with Docker running and the real store databases present (626 pass,
+Solution suites total **637** with Docker running and the real store databases present (636 pass,
 1 skipped) — measured 2026-08-19. Per suite: Domain 36 · Vault 17 · MigrationTool 134 (133 pass,
-1 skip) · StoreHub.IntegrationTests 104 · Application 299 · Windows.Forms 37. Without the real
-store databases the suite discovers **607** (DERIVED as 627 − 20, not measured) — a skipped
+1 skip) · StoreHub.IntegrationTests 104 · Application 299 · Windows.Forms 47. Without the real
+store databases the suite discovers **617** (DERIVED as 637 − 20, not measured) — a skipped
 `[Theory]` is one entry, not one per row. See [`ONBOARDING.md`](ONBOARDING.md) for the per-suite
 breakdown, the dev-vs-installed port split, and the `/health` vs `/health/ready` trap.
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -106,8 +106,8 @@ reports `Skipped: 1` and writes nothing — which looks like success while leavi
 ### Expected counts
 
 Solution suites (`dotnet test` at the root), Docker running **and** the real store databases present
-— **627 total** (626 pass, 1 skipped) — measured 2026-08-19. Without those databases the total is
-**607** (**derived** as 627 − 20, not measured), still all green:
+— **637 total** (636 pass, 1 skipped) — measured 2026-08-19. Without those databases the total is
+**617** (**derived** as 637 − 20, not measured), still all green:
 
 | Suite | Tests |
 |---|---|
@@ -115,7 +115,7 @@ Solution suites (`dotnet test` at the root), Docker running **and** the real sto
 | `IndyPOS.StoreHub.IntegrationTests` | 104 (Docker) |
 | `IndyPOS.MigrationTool.Tests` | 134 (Docker; 1 skipped. **114** without the real store data — Trap 3, derived) |
 | `IndyPOS.Domain.Tests` | 36 |
-| `IndyPOS.Windows.Forms.Tests` | 37 |
+| `IndyPOS.Windows.Forms.Tests` | 47 |
 | `IndyPOS.Vault.Tests` | 17 |
 
 Outside the solution: `IndyPOS.Bootstrapper.Tests` — **231** (223 pass, 8 skipped).

--- a/src/IndyPOS.Windows.Forms/UI/Payment/AcceptPaymentForm.cs
+++ b/src/IndyPOS.Windows.Forms/UI/Payment/AcceptPaymentForm.cs
@@ -104,9 +104,15 @@ namespace IndyPOS.Windows.Forms.UI.Payment
 
             var orderedMethods = _offerableMethods.OrderBy(m => m.DisplayOrder).ToList();
 
+            // These buttons are built here, long after PerformAutoScale has sized the designer's
+            // controls, so nothing scales them for us. The caption font is point-sized and does
+            // grow with the display, which is what made the caption land on the card artwork above
+            // ~145% scaling. LogicalToDeviceUnits is the same 96dpi-relative factor WinForms uses.
+            var scale = PaymentTypePanel.LogicalToDeviceUnits(DesignDpi) / (float)DesignDpi;
+
             for (var index = 0; index < orderedMethods.Count; index++)
             {
-                var button = CreatePaymentMethodButton(orderedMethods[index], index);
+                var button = CreatePaymentMethodButton(orderedMethods[index], index, scale);
 
                 button.Click += PaymentMethodButton_Click;
 
@@ -120,18 +126,27 @@ namespace IndyPOS.Windows.Forms.UI.Payment
         private static readonly Font PaymentMethodButtonFont =
             new("Leelawadee UI", 12F, FontStyle.Regular, GraphicsUnit.Point);
 
-        private static Button CreatePaymentMethodButton(PaymentMethodDto method, int index)
+        /// <summary>The dpi the literals below were laid out against.</summary>
+        private const int DesignDpi = 96;
+
+        /// <param name="scale">
+        /// 1.0 at 100% display scaling. Every literal here is in design pixels and must go through
+        /// this, or the button stays put while its point-sized caption grows.
+        /// </param>
+        private static Button CreatePaymentMethodButton(PaymentMethodDto method, int index, float scale)
         {
             const int columnCount = 2;
             var column = index % columnCount;
             var row = index / columnCount;
 
+            int Scaled(int designPixels) => (int)Math.Round(designPixels * scale);
+
             var button = new Button
             {
                 Tag = method.Code,
                 Text = method.DisplayName,
-                Size = new Size(195, 129),
-                Location = new Point(10 + column * 201, 16 + row * 135),
+                Size = new Size(Scaled(195), Scaled(129)),
+                Location = new Point(Scaled(10 + column * 201), Scaled(16 + row * 135)),
                 BackColor = Color.FromArgb(80, 80, 80),
                 ForeColor = Color.White,
                 FlatStyle = FlatStyle.Flat,

--- a/tests/IndyPOS.Windows.Forms.Tests/UI/Payment/PaymentMethodButtonCaptionTests.cs
+++ b/tests/IndyPOS.Windows.Forms.Tests/UI/Payment/PaymentMethodButtonCaptionTests.cs
@@ -115,7 +115,8 @@ public class PaymentMethodButtonCaptionTests
 
         var method = new PaymentMethodDto(code, caption, PaymentMethodKind.Standard, true, 1);
 
-        return (Button)factory.Invoke(null, [method, 0])!;
+        // 1.0f = 100% display scaling; PaymentMethodButtonScalingTests covers the rest.
+        return (Button)factory.Invoke(null, [method, 0, 1.0f])!;
     }
 
     /// <summary>The seeded method carrying the tallest bundled icon — the worst case for height.</summary>

--- a/tests/IndyPOS.Windows.Forms.Tests/UI/Payment/PaymentMethodButtonScalingTests.cs
+++ b/tests/IndyPOS.Windows.Forms.Tests/UI/Payment/PaymentMethodButtonScalingTests.cs
@@ -1,0 +1,115 @@
+using System.Drawing;
+using System.Reflection;
+using System.Windows.Forms;
+using FluentAssertions;
+using IndyPOS.Application.UseCases.StoreHub.PaymentMethods;
+using IndyPOS.Domain.Enums;
+using Xunit;
+
+namespace IndyPOS.Windows.Forms.Tests.UI.Payment;
+
+/// <summary>
+/// The payment buttons are built in code with pixel literals, from the async load path — so after
+/// <c>PerformAutoScale</c> has already run. The 12pt caption font is point-sized and therefore
+/// renders larger as display scaling rises, while the button did not, so from about 145% the
+/// caption wrapped to two lines and was painted on top of the card artwork.
+/// <para>
+/// Scaling is passed in rather than read from the environment, so these run identically on any
+/// machine. The equivalence is exact: 12pt at 144dpi and 18pt at 96dpi produce the same
+/// <c>LOGFONT.lfHeight</c>, so raising the point size stands in for raising the scale factor.
+/// </para>
+/// </summary>
+public class PaymentMethodButtonScalingTests
+{
+    /// <summary>Matches VerticalChrome in <see cref="PaymentMethodButtonCaptionTests"/>.</summary>
+    private const int VerticalChrome = 8;
+
+    private const float DesignFontPointSize = 12F;
+
+    [Theory]
+    [InlineData(1.00f)]
+    [InlineData(1.25f)]
+    [InlineData(1.50f)]
+    [InlineData(1.75f)]
+    [InlineData(2.00f)]
+    public void CreatePaymentMethodButton_AtEveryDisplayScaling_ShouldLeaveRoomForTheCaption(float scale)
+    {
+        using var button = CreateButton(scale);
+        using var scaledFont = ScaledFont(scale);
+
+        var roomForCaption = button.Height - TallestIconHeight() - VerticalChrome;
+        var lineHeight = TextRenderer.MeasureText(Caption, scaledFont).Height;
+
+        roomForCaption.Should()
+                      .BeGreaterThanOrEqualTo(lineHeight,
+                          $"at {scale:P0} scaling the caption renders {lineHeight}px tall, and a " +
+                          "button that does not scale with it paints the caption over the icon");
+    }
+
+    [Theory]
+    [InlineData(1.00f)]
+    [InlineData(1.50f)]
+    [InlineData(2.00f)]
+    public void CreatePaymentMethodButton_AtEveryDisplayScaling_ShouldKeepTheCaptionOnOneLine(float scale)
+    {
+        using var button = CreateButton(scale);
+        using var scaledFont = ScaledFont(scale);
+
+        var width = TextRenderer.MeasureText(Caption, scaledFont).Width;
+
+        width.Should()
+             .BeLessThanOrEqualTo(button.Width - VerticalChrome,
+                 $"at {scale:P0} scaling the caption is {width}px wide; a button that does not " +
+                 "scale with it wraps the caption onto a second line it has no room for");
+    }
+
+    [Fact]
+    public void CreatePaymentMethodButton_AtDesignScaling_ShouldKeepTheShippedGeometry()
+    {
+        using var button = CreateButton(1.0f);
+
+        button.Size.Should().Be(new Size(195, 129), "scaling must be a no-op at 100%");
+        button.Location.Should().Be(new Point(10, 16));
+    }
+
+    [Fact]
+    public void CreatePaymentMethodButton_WhenScaled_ShouldScaleTheGridSpacingToo()
+    {
+        using var first = CreateButton(2.0f, index: 0);
+        using var second = CreateButton(2.0f, index: 1);
+        using var third = CreateButton(2.0f, index: 2);
+
+        (second.Location.X - first.Location.X).Should()
+            .BeGreaterThanOrEqualTo(first.Width, "columns must not overlap once the buttons grow");
+
+        (third.Location.Y - first.Location.Y).Should()
+            .BeGreaterThanOrEqualTo(first.Height, "rows must not overlap once the buttons grow");
+    }
+
+    private const string Caption = "บัตรสวัสดิการแห่งรัฐ";
+
+    private static Font ScaledFont(float scale) =>
+        new("Leelawadee UI", DesignFontPointSize * scale, FontStyle.Regular, GraphicsUnit.Point);
+
+    private static int TallestIconHeight()
+    {
+        var field = typeof(global::IndyPOS.Windows.Forms.UI.MainForm).Assembly
+                        .GetType("IndyPOS.Windows.Forms.UI.Payment.PaymentMethodIcons")!
+                        .GetField("IconsByCode", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        return ((Dictionary<string, Image>)field.GetValue(null)!).Values.Max(image => image.Height);
+    }
+
+    private static Button CreateButton(float scale, int index = 0)
+    {
+        var factory = typeof(global::IndyPOS.Windows.Forms.UI.MainForm).Assembly
+                          .GetType("IndyPOS.Windows.Forms.UI.Payment.AcceptPaymentForm")!
+                          .GetMethod("CreatePaymentMethodButton", BindingFlags.NonPublic | BindingFlags.Static)
+                      ?? throw new InvalidOperationException(
+                          "AcceptPaymentForm.CreatePaymentMethodButton is gone — this guard is measuring nothing.");
+
+        var method = new PaymentMethodDto("WelfareCard", Caption, PaymentMethodKind.GovernmentCampaign, true, 3);
+
+        return (Button)factory.Invoke(null, [method, index, scale])!;
+    }
+}


### PR DESCRIPTION
Fixes the DPI defect that PR #80's independent review turned up.

## The defect

Above **~145% display scaling** — so Windows' standard 150% — the `บัตรสวัสดิการแห่งรัฐ` caption
wrapped to two lines and was painted **on top of the card artwork**: white Thai text over pale blue.
Only `WelfareCard`, being the longest caption.

## Root cause

`AcceptPaymentForm` is `AutoScaleMode.Font` with `AutoScaleDimensions = (6,13)`, but
`CreatePaymentMethodButton` hardcoded `Size(195,129)` and `Location(10 + col*201, 16 + row*135)` in
**device pixels**, and `BuildPaymentMethodButtons` runs from the async load path — *after*
`PerformAutoScale`.

So the panel scaled, the point-sized 12pt caption font scaled, and the buttons never did:

```
height budget = 100px icon + caption ink
  100%  115px  fits in 129
  150%  154px  over by 25   <- wraps onto the artwork
  200%  174px  over by 45
```

## The fix

The factory takes a `scale` and every literal goes through it. `BuildPaymentMethodButtons` derives
it as `PaymentTypePanel.LogicalToDeviceUnits(96) / 96f`, which is exactly **1.0 at 100%**, so the
shipped geometry is unchanged there — pinned by a test.

## Verification

Measured on real renders, with caption ink and icon ink isolated by **layout-preserving diffs**
(render twice changing only `ForeColor`, or swapping the icon for a same-size transparent bitmap)
rather than a colour threshold — because a threshold detector walking up from the bottom is exactly
what missed this defect the first time.

| scaling | before (icon rows / caption rows) | after |
|---|---|---|
| 100% | 6..105 / 108..122 — clear | unchanged, 195×129 |
| 125% | 6..105 / **105**..122 — touching | 11..110 / 119..136 clear |
| 150% | 6..105 / **69**..122 — over the artwork | 19..118 / 127..148 clear |
| 175% | 6..105 / **59**..122 — over the artwork | 25..124 / 135..160 clear |
| 200% | 6..105 / **47**..120 — over the artwork | 31..130 / 143..171 clear |

Caption pixel counts are identical before and after at every scaling (776 / 1060 / 1481 / 1932 /
2297) — the text renders the same, it simply has room now.

### The guards

`PaymentMethodButtonScalingTests` pins 100 / 125 / 150 / 175 / 200%. It takes the factor as a
**parameter**, so it runs identically on any machine and needs no high-DPI environment: 12pt@144dpi
and 18pt@96dpi share a `LOGFONT.lfHeight`, so raising the point size is an exact stand-in for
raising the scale.

Verified to fail against the pre-fix behaviour — I reverted `Scaled` to the identity and re-ran:

```
Expected roomForCaption to be >= 28 because at 125% scaling the caption renders 28px tall ... but found 21
Expected roomForCaption to be >= 32 because at 150% scaling the caption renders 32px tall ... but found 21
Expected roomForCaption to be >= 45 because at 200% scaling the caption renders 45px tall ... but found 21
Expected width to be <= 187 because at 150% scaling the caption is 195px wide ... but found 195
Failed! - Failed: 6, Passed: 41
```

6 red at 125% and above; **100% stayed green**, which is right — there is no defect at 100%.

## Deliberately not addressed

- **The icons are not scaled.** A 100px bitmap in a 292px button at 150% just looks smaller; nothing
  overlaps. Scaling them means caching resized copies (the icons are shared statics), which is a
  bigger change than the defect warrants.
- **The factor is DPI-based while the form autoscales on font metrics.** Identical for normal
  display scaling; they would diverge only under a custom system font size.
- **`ChangePasswordForm` has the same latent pattern** and is left alone. There is no other DPI
  handling anywhere in the WinForms project — this is the first.

## Testing

Docker up, real store databases present — **637 total, 636 pass, 1 skip, 0 fail**.

| Suite | Result |
|---|---|
| Domain | 36 ✅ |
| Vault | 17 ✅ |
| Application | 299 ✅ |
| Windows.Forms | **47** ✅ (was 37) |
| MigrationTool | 134 ✅ (133 pass, 1 skip) |
| StoreHub.IntegrationTests | 104 ✅ |

`CLAUDE.md` and `ONBOARDING.md` counts refreshed to match.
