### PR TITLE
docs: v3.7.0 is an xcopy deployment, not an install

### DIFF
--- a/.planning/indypos-overhaul/PLAN.md
+++ b/.planning/indypos-overhaul/PLAN.md
@@ -501,11 +501,35 @@ campaign is covered the moment it is added.
 **Still owed before the first store: one v3.7.0-coexistence check against a real v3 footprint** —
 now unblocked, but it needs one read-only command run at a live store.
 
-`scripts/vm-testing/` now carries `Get-V3Footprint.ps1` (capture a store's real layout, read-only)
-and `New-V3Footprint.ps1` (replay it onto the VM before installing v4). The reason to capture rather
-than rebuild: a v3.7.0 binary *is* reproducible from this repo (`9aca15c~1`, before the 4.0.0
-assembly bump — there is no tag or release, which stops at 3.6.0), but a from-source build gives a
-*fresh-install* footprint, not the layout a five-year-old till has actually accumulated.
+🔑 **v3.7.0 was never *installed*. It is an xcopy deployment** — confirmed by the owner 2026-08-19.
+No installer, no MSI, no uninstall entry, and **no versioned folder**: the binary was copied into
+place and its data lives in **non-versioned directories at the root of `C:\ProgramData\IndyPOS`** —
+`Config\StoreConfiguration.json`, `db\Store.db`, `Logs\log*.json` (that exact shape is on the dev box
+today, beside `v4\` and `v4.0.0\`).
+
+Three consequences, and they reframe this whole check:
+
+1. **There is no "install v3, then install v4" test to run.** Nothing to install. You place v3's
+   files and install v4 over them. Earlier drafts of this plan said "there is no v3.7.0 artefact to
+   install" and then corrected that to "a binary is buildable from `9aca15c~1`" — both missed the
+   point. A build would give you a *binary*, and v3 never had an installer to exercise anyway.
+2. **`verify-install.ps1` section 7's design is now explained rather than merely asserted.** It keys
+   on "top-level entries that are not `v*`" precisely because that IS v3's footprint. It is also why
+   the stale `v\d+\.\d+\.\d+` pattern was so damaging: it swallowed our own `v4` into the same bucket.
+3. **v3 and v4 share one root**, so anything that deletes broadly under `C:\ProgramData\IndyPOS`
+   would take the shop's live `Store.db` with it. `cleanup-v4.ps1`'s `Assert-V4Path` was executed
+   against that exact list on 2026-08-19: `v4` and `v4.0.0` deletable; the bare root, `db`, `Config`,
+   `Logs`, a `v4\..\db` traversal, `vendor` and a loose `.exe` all refused. **That guard holds.**
+
+`scripts/vm-testing/` carries `Get-V3Footprint.ps1` (capture a till's real layout, read-only) and
+`New-V3Footprint.ps1` (replay it onto the VM before installing v4). With no installer and no manifest
+anywhere, **a capture is the only way to know what a given till actually has** — which makes the pair
+more necessary here, not less.
+
+❓ **Open: where does the v3 binary live on a till?** It is *not* on the dev box — only v3's data is
+(`Config`, `db`, `Logs`; no `.exe` under `C:\ProgramData\IndyPOS`, none in `Program Files`, and
+`%LOCALAPPDATA%\IndyPOS` holds only an unrelated credential file). The capture answers this per store,
+which is one more reason to run it.
 
 ⚠️ **`verify-install.ps1` section 7 was also silently broken**, fixed in this branch: `SystemRoot`
 became `v{Major}` in `5ce6cea` but the script still matched `v\d+\.\d+\.\d+`, so it counted our *own*

--- a/scripts/vm-testing/Get-V3Footprint.ps1
+++ b/scripts/vm-testing/Get-V3Footprint.ps1
@@ -3,10 +3,17 @@
     Read-only capture of a v3.7.0 store's on-disk and registry footprint.
 
 .DESCRIPTION
-    Epic 3 owes one v3.7.0-coexistence check before the first cutover, and there is
-    no v3.7.0 artefact to install — GitHub releases stop at 3.6.0. So instead of
-    reconstructing v3 from a build, we capture what a live store actually has and
-    replay it onto the test VM with New-V3Footprint.ps1.
+    Epic 3 owes one v3.7.0-coexistence check before the first cutover.
+
+    v3.7.0 is an XCOPY deployment: no installer, no uninstall entry, no versioned
+    folder. The binary was copied into place and its data lives in non-versioned
+    directories at the root of C:\ProgramData\IndyPOS -- Config\, db\Store.db, Logs\.
+    So there is nothing to install to build a test machine, and no manifest to read a
+    till's layout from. Capturing what a store actually has is the only way to know,
+    and New-V3Footprint.ps1 replays it onto the test VM.
+
+    Note v3 and v4 SHARE that root: v4 lives in v4\ beside v3's folders. Anything that
+    deletes broadly under C:\ProgramData\IndyPOS would take the shop's live Store.db.
 
     STRICTLY READ-ONLY on the store machine. It records paths, sizes and timestamps.
     It never opens Store.db, never reads file CONTENTS, and never writes anywhere

--- a/scripts/vm-testing/README.md
+++ b/scripts/vm-testing/README.md
@@ -23,15 +23,26 @@ wizard step.
 
 ## v3.7.0 coexistence
 
-`Test-IndyPOSInstallation.ps1` drops the side-by-side invariants, because a clean VM
-has no v3 footprint to protect — and `verify-install.ps1`'s section 7 `Skip`s for the
-same reason. So the coexistence promise in `docs/operations/upgrade-procedure.md` has
-never actually been tested, and there is no v3.7.0 artefact to install (releases stop
-at 3.6.0).
+**v3.7.0 is an xcopy deployment.** No installer, no uninstall entry, no versioned folder:
+the binary was copied into place, and its data lives in **non-versioned directories at the
+root of `C:\ProgramData\IndyPOS`** — `Config\StoreConfiguration.json`, `db\Store.db`,
+`Logs\log*.json`. That is why `verify-install.ps1` section 7 keys on "top-level entries
+that are not `v*`": those entries *are* v3.
+
+So there is nothing to install to build a test machine, and no manifest to read a till's
+layout from — **a capture is the only way to know what a given till has.** Meanwhile a
+clean VM has no v3 footprint at all, so `Test-IndyPOSInstallation.ps1` drops the
+side-by-side invariants and section 7 `Skip`s, leaving the coexistence promise in
+`docs/operations/upgrade-procedure.md` untested.
 
 The pair of scripts above closes that: capture the layout a live store really has,
 replay it onto the VM, install v4 over it, then read section 7 of `verify-install.ps1`
 — it must now report the v3-era entries rather than skip.
+
+⚠️ **v3 and v4 share one root**, so anything deleting broadly under `C:\ProgramData\IndyPOS`
+would take the shop's live `Store.db` with it. `cleanup-v4.ps1`'s `Assert-V4Path` was
+exercised against exactly that on 2026-08-19 — `v4` and `v4.0.0` deletable; the bare root,
+`db`, `Config`, `Logs`, a `v4\..\db` traversal and a loose `.exe` all refused.
 
 ```powershell
 # 1. At a store, BEFORE v4 is installed there. Read-only.


### PR DESCRIPTION
Corrects a load-bearing assumption about v3.7.0. Docs only, plus one guard I executed to check the
consequence.

## What was wrong

The plan said *"there is no v3.7.0 artefact to install (releases stop at 3.6.0)"*, then corrected
itself to *"a binary **is** buildable from `9aca15c~1`"*. **Both missed the point.**

**v3.7.0 was never installed at all.** No installer, no uninstall entry, no versioned folder. The
binary was copied into place, and its data lives in **non-versioned directories at the root of
`C:\ProgramData\IndyPOS`**:

```
C:\ProgramData\IndyPOS\
├── Config\StoreConfiguration.json      <- v3
├── db\Store.db                         <- v3  (66.8 MB on the dev box)
├── Logs\log*.json                      <- v3
├── v4\                                 <- v4
└── v4.0.0\                             <- v4, older layout
```

That exact shape is on the dev box today.

## Why it matters

**1. There is no "install v3, then install v4" test to run.** Nothing to install. You place v3's
files and install v4 over them. A from-source build would give a *binary*, not an install to
exercise.

**2. It explains `verify-install.ps1` section 7 rather than merely asserting it.** The check keys on
*"top-level entries that are not `v*`"* because **those entries are v3**. Which is also why the stale
`v\d+\.\d+\.\d+` pattern (fixed in #80) was so damaging — it swallowed our own `v4` into the same
bucket and reported a v3 footprint on machines that had never seen v3.

**3. v3 and v4 share one root**, so anything deleting broadly under `C:\ProgramData\IndyPOS` takes
the shop's **live `Store.db`** with it. That is the highest blast radius in the whole rollout, so I
executed `cleanup-v4.ps1`'s `Assert-V4Path` against exactly that list rather than reading it:

```
  [ok ] C:\ProgramData\IndyPOS\v4              -> DELETABLE
  [ok ] C:\ProgramData\IndyPOS\v4.0.0          -> DELETABLE
  [ok ] C:\ProgramData\IndyPOS                 -> refused
  [ok ] C:\ProgramData\IndyPOS\db              -> refused
  [ok ] C:\ProgramData\IndyPOS\Config          -> refused
  [ok ] C:\ProgramData\IndyPOS\Logs            -> refused
  [ok ] C:\ProgramData\IndyPOS\v4\..\db        -> refused
  [ok ] C:\ProgramData\IndyPOS\vendor          -> refused
  [ok ] C:\ProgramData\IndyPOS\IndyPOS.exe     -> refused
```

**The guard holds.** No change needed — but it was worth proving, not assuming, now that we know
what shares that root.

## What this changes about the capture scripts

Nothing, except that they become **more** necessary. With no installer and no manifest anywhere,
a capture is the only way to know what a given till actually has.

## One open question, now recorded

**Where does the v3 binary live on a till?** It is *not* on the dev box — no `.exe` under
`C:\ProgramData\IndyPOS`, none in `Program Files`, and `%LOCALAPPDATA%\IndyPOS` holds only an
unrelated credential file. Only v3's *data* is here. `Get-V3Footprint.ps1` answers this per store,
which is one more reason to run it.

## Testing

Docs only, plus the guard exercise above. No code paths changed; `Get-V3Footprint.ps1` still parses
clean (its comment header was the only edit).
