### PR TITLE
chore: bump Nokpirab to 1.1.0

### DIFF
--- a/src/IndyPOS.Application/IndyPOS.Application.csproj
+++ b/src/IndyPOS.Application/IndyPOS.Application.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Nokpirab" Version="1.0.0" />
+    <PackageReference Include="Nokpirab" Version="1.1.0" />
     <PackageReference Include="Prism.Core" Version="9.0.537" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
     <PackageReference Include="Throw" Version="1.4.0" />


### PR DESCRIPTION
Moves `IndyPOS.Application`'s `Nokpirab` pin from 1.0.0 to 1.1.0.

Isolated in its own PR on purpose: `Nokpirab` supplies the `ICommandHandler` / `IQueryHandler` abstractions that every use case, both API hosts and the WinForms client compile against, so a breaking change would surface solution-wide rather than in one place. Keeping it alone means the blast radius is legible and the packaging PRs further up the stack are not the thing that appears to have broken the build.

### Verification

Full suite before **and** after, Docker running with the real store databases present:

- **637 total / 636 pass / 1 skip** → **637 total / 636 pass / 1 skip** (no delta)
- Installer suite, which `IndyPOS.sln` excludes: **231 / 223 pass / 8 skip**

No breaking API change; no call-site fixes were needed.

Stacked on #84.
