### PR TITLE
fix: refuse to start on the default JWT secret outside development

### DIFF
--- a/src/IndyPOS.Application/Common/Models/LocalTokenOptions.cs
+++ b/src/IndyPOS.Application/Common/Models/LocalTokenOptions.cs
@@ -9,9 +9,23 @@ public class LocalTokenOptions
     public const string SectionName = "LocalToken";
 
     /// <summary>
+    /// The key this class falls back to when no LocalToken section is configured. It is published in
+    /// a public repository, so it is a placeholder for local development only — never a usable
+    /// secret. <see cref="LocalTokenOptionsValidator"/> refuses to start a host that still has it.
+    /// </summary>
+    public const string BuiltInDefaultSecretKey = "IndyPOS-StoreHub-Local-Auth-Secret-Key-2026";
+
+    /// <summary>
     /// Secret key for signing tokens. Must be at least 32 characters.
     /// </summary>
-    public string SecretKey { get; set; } = "IndyPOS-StoreHub-Local-Auth-Secret-Key-2026";
+    public string SecretKey { get; set; } = BuiltInDefaultSecretKey;
+
+    /// <summary>
+    /// True when this instance carries no usable secret — either the built-in default or nothing at
+    /// all. Both cases mean "the operator has not supplied a key".
+    /// </summary>
+    public bool UsesBuiltInDefaultSecretKey =>
+        string.IsNullOrWhiteSpace(SecretKey) || SecretKey == BuiltInDefaultSecretKey;
 
     /// <summary>
     /// Token issuer.

--- a/src/IndyPOS.Application/Common/Models/LocalTokenOptionsValidator.cs
+++ b/src/IndyPOS.Application/Common/Models/LocalTokenOptionsValidator.cs
@@ -1,0 +1,37 @@
+namespace IndyPOS.Application.Common.Models;
+
+/// <summary>
+/// Startup guard for the shared JWT signing key. Both API hosts fall back to
+/// <see cref="LocalTokenOptions.BuiltInDefaultSecretKey"/> when no LocalToken section is configured,
+/// and that literal is published in a public repository — so outside development, running on it
+/// would let anyone mint a token for the capability-protected admin endpoints.
+/// </summary>
+public static class LocalTokenOptionsValidator
+{
+    /// <summary>
+    /// Throws unless the host has been given a real signing key. Development is the only exemption:
+    /// every other environment name — Production, Testing, Staging, or a typo — must supply one, so
+    /// a mistyped ASPNETCORE_ENVIRONMENT cannot silently disable the guard.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The key is missing or is still the built-in default, and this is not development.
+    /// </exception>
+    public static void EnsureProductionSafe(LocalTokenOptions options, bool isDevelopment)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (isDevelopment || !options.UsesBuiltInDefaultSecretKey)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"{LocalTokenOptions.SectionName}:SecretKey is not configured, or is still the built-in " +
+            "default that ships in this public repository. It signs the tokens that guard the admin " +
+            "endpoints, so the host will not start outside Development without a real one. Set the " +
+            $"environment variable {LocalTokenOptions.SectionName}__SecretKey, or the " +
+            $"{LocalTokenOptions.SectionName}:SecretKey entry in appsettings.json — on an installed " +
+            "till the installer's DatabaseSetup step writes a DPAPI-protected key there.");
+    }
+}

--- a/src/IndyPOS.CloudApi/Program.cs
+++ b/src/IndyPOS.CloudApi/Program.cs
@@ -61,6 +61,10 @@ builder.Services.AddAuthentication(OpenIddictValidationAspNetCoreDefaults.Authen
 var localTokenOptions = builder.Configuration.GetSection(LocalTokenOptions.SectionName).Get<LocalTokenOptions>()
     ?? new LocalTokenOptions();
 
+LocalTokenOptionsValidator.EnsureProductionSafe(
+    localTokenOptions,
+    builder.Environment.IsDevelopment());
+
 builder.Services.AddAuthentication()
     .AddJwtBearer("StoreHubJwt", options =>
     {

--- a/src/IndyPOS.StoreHub/Program.cs
+++ b/src/IndyPOS.StoreHub/Program.cs
@@ -130,6 +130,10 @@ builder.Services.AddTransient<ICommandHandler<RecordPayLaterPaymentCommand, PayL
 var tokenOptions = builder.Configuration.GetSection(LocalTokenOptions.SectionName).Get<LocalTokenOptions>()
     ?? new LocalTokenOptions();
 
+LocalTokenOptionsValidator.EnsureProductionSafe(
+    tokenOptions,
+    builder.Environment.IsDevelopment());
+
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
        .AddJwtBearer(options =>
        {

--- a/tests/IndyPOS.Application.Tests/Models/LocalTokenOptionsTests.cs
+++ b/tests/IndyPOS.Application.Tests/Models/LocalTokenOptionsTests.cs
@@ -1,0 +1,52 @@
+namespace IndyPOS.Application.Tests.Models;
+
+using FluentAssertions;
+using IndyPOS.Application.Common.Models;
+using Xunit;
+
+public class LocalTokenOptionsTests
+{
+    [Fact]
+    public void UsesBuiltInDefaultSecretKey_WithUntouchedOptions_ShouldReturnTrue()
+    {
+        var options = new LocalTokenOptions();
+
+        options.UsesBuiltInDefaultSecretKey
+               .Should()
+               .BeTrue("a freshly constructed instance still carries the repo's published key");
+    }
+
+    [Fact]
+    public void UsesBuiltInDefaultSecretKey_WithConfiguredKey_ShouldReturnFalse()
+    {
+        var options = new LocalTokenOptions
+        {
+            SecretKey = "eEq0T1u+PzvR7mQ3nS9xW2yB5cF8hJ1kL4oN6pA0dG=="
+        };
+
+        options.UsesBuiltInDefaultSecretKey
+               .Should()
+               .BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void UsesBuiltInDefaultSecretKey_WithMissingKey_ShouldReturnTrue(string? secretKey)
+    {
+        var options = new LocalTokenOptions { SecretKey = secretKey! };
+
+        options.UsesBuiltInDefaultSecretKey
+               .Should()
+               .BeTrue("an unset key is no safer than the default one");
+    }
+
+    [Fact]
+    public void BuiltInDefaultSecretKey_ShouldBeTheValueThePropertyInitialiserUses()
+    {
+        new LocalTokenOptions().SecretKey
+                               .Should()
+                               .Be(LocalTokenOptions.BuiltInDefaultSecretKey);
+    }
+}

--- a/tests/IndyPOS.Application.Tests/Models/LocalTokenOptionsValidatorTests.cs
+++ b/tests/IndyPOS.Application.Tests/Models/LocalTokenOptionsValidatorTests.cs
@@ -1,0 +1,68 @@
+namespace IndyPOS.Application.Tests.Models;
+
+using System;
+using FluentAssertions;
+using IndyPOS.Application.Common.Models;
+using Xunit;
+
+public class LocalTokenOptionsValidatorTests
+{
+    private static LocalTokenOptions ConfiguredOptions() => new()
+    {
+        SecretKey = "eEq0T1u+PzvR7mQ3nS9xW2yB5cF8hJ1kL4oN6pA0dG=="
+    };
+
+    [Fact]
+    public void EnsureProductionSafe_WithDefaultKeyOutsideDevelopment_ShouldThrow()
+    {
+        var act = () => LocalTokenOptionsValidator.EnsureProductionSafe(
+            new LocalTokenOptions(),
+            isDevelopment: false);
+
+        act.Should()
+           .Throw<InvalidOperationException>()
+           .WithMessage("*LocalToken__SecretKey*");
+    }
+
+    [Fact]
+    public void EnsureProductionSafe_WithDefaultKeyInDevelopment_ShouldNotThrow()
+    {
+        var act = () => LocalTokenOptionsValidator.EnsureProductionSafe(
+            new LocalTokenOptions(),
+            isDevelopment: true);
+
+        act.Should()
+           .NotThrow("the Aspire dev loop must keep starting without configuration");
+    }
+
+    [Fact]
+    public void EnsureProductionSafe_WithConfiguredKeyOutsideDevelopment_ShouldNotThrow()
+    {
+        var act = () => LocalTokenOptionsValidator.EnsureProductionSafe(
+            ConfiguredOptions(),
+            isDevelopment: false);
+
+        act.Should()
+           .NotThrow();
+    }
+
+    [Fact]
+    public void EnsureProductionSafe_WithBlankKeyOutsideDevelopment_ShouldThrow()
+    {
+        var act = () => LocalTokenOptionsValidator.EnsureProductionSafe(
+            new LocalTokenOptions { SecretKey = "  " },
+            isDevelopment: false);
+
+        act.Should()
+           .Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void EnsureProductionSafe_WithNullOptions_ShouldThrowArgumentNullException()
+    {
+        var act = () => LocalTokenOptionsValidator.EnsureProductionSafe(null!, isDevelopment: false);
+
+        act.Should()
+           .Throw<ArgumentNullException>();
+    }
+}

--- a/tests/IndyPOS.StoreHub.IntegrationTests/StoreHubWebApplicationFactory.cs
+++ b/tests/IndyPOS.StoreHub.IntegrationTests/StoreHubWebApplicationFactory.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Security.Cryptography;
 using IndyPOS.Application.Common.Interfaces;
 using IndyPOS.Domain.Enums;
 using IndyPOS.Domain.ValueObjects;
@@ -32,6 +34,14 @@ public class StoreHubWebApplicationFactory : WebApplicationFactory<Program>, IAs
     {
         // Set environment to Testing and provide connection string
         builder.UseSetting("ConnectionStrings:storehub-db", _postgresContainer.GetConnectionString());
+
+        // The host refuses to start outside Development on the built-in default signing key.
+        // Tests obtain their tokens from the login endpoint, which signs server-side, so a random
+        // per-run key is invisible to them.
+        builder.UseSetting(
+            "LocalToken:SecretKey",
+            Convert.ToBase64String(RandomNumberGenerator.GetBytes(64)));
+
         builder.UseEnvironment("Testing");
 
         builder.ConfigureTestServices(services =>


### PR DESCRIPTION
### The defect

`LocalTokenOptions.SecretKey` defaults to `IndyPOS-StoreHub-Local-Auth-Secret-Key-2026` — a literal committed to this **public** repository. That key validates the `StoreHubJwt` scheme, which is the sole guard on `POST /admin/stores/register` and all of `/admin/users`. Both hosts fall back to it whenever no `LocalToken` section is configured, and **CloudApi ships no `appsettings.json` at all**, so for CloudApi the fallback was the normal path, not an edge case.

Anyone holding this repo could mint a token that registers stores and creates users.

### The fix

Fail closed at startup: outside Development, refuse to start when the key is missing or still the built-in default. **Development is the only exemption** — `Testing`, `Staging`, and any typo all require a real key, because guarding on `IsProduction()` alone would let a mistyped `ASPNETCORE_ENVIRONMENT` serve admin auth with a published key.

`EnsureProductionSafe` takes a `bool`, not an `IHostEnvironment`, so `IndyPOS.Application` takes no hosting dependency.

### Why this does not break a single till

Verified against the installer rather than assumed:

- `DatabaseSetup.GenerateJwtSecret()` fills 64 random bytes per install, DPAPI-protects them into StoreHub's `appsettings.json`, and ACLs the file.
- On a **fresh install**, that write happens *before* database provisioning.
- On an **in-place upgrade**, `ConfigSnapshot.Restore()` runs *before* the migrate step — the class exists precisely because package extraction overwrites the file.
- `reset-admin` works from any working directory because `ContentRootPath` is anchored to the exe.
- WinForms never calls the validator; Aspire runs as Development.

Where the guard *does* fire, firing is correct: it means the install left no real key behind.

### Test-fixture change

`StoreHubWebApplicationFactory` hosts as `Testing`, not Development, so the guard applies to the whole StoreHub integration suite. It now injects a random per-run key in `ConfigureWebHost`. Tests take their tokens from the login endpoint, which signs server-side, so the value is invisible to them.

### Verification

- 11 new tests; suite **637 → 648** (647 pass, 1 skip)
- StoreHub integration suite unchanged at **104/104**
- Ran StoreHub for real outside Development with no key and read the refusal; confirmed the Development path still starts clean

Stacked on the Nokpirab bump.
