### PR TITLE
build: package CloudApi as a Docker image with local and Droplet compose stacks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+**/bin/
+**/obj/
+**/.vs/
+**/*.user
+.git/
+.github/
+.claude/
+.superpowers/
+.planning/
+publish/
+tests/
+installer/
+docs/
+fonts/
+deploy/cloud/.env
+**/*.md

--- a/.gitignore
+++ b/.gitignore
@@ -492,3 +492,6 @@ installer/IndyPOS.Bootstrapper/Resources/
 # v3.7.0 footprint captures (Get-V3Footprint.ps1) list real store paths.
 # This repo is public - never commit one.
 v3-footprint-*.json
+
+# Cloud deployment secrets — .env.example is the committed template
+deploy/cloud/.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,10 +214,10 @@ dotnet run --project src/IndyPOS.AppHost --launch-profile https
 # Dashboard: https://localhost:17222
 ```
 
-Solution suites total **637** with Docker running and the real store databases present (636 pass,
-1 skipped) — measured 2026-08-19. Per suite: Domain 36 · Vault 17 · MigrationTool 134 (133 pass,
-1 skip) · StoreHub.IntegrationTests 104 · Application 299 · Windows.Forms 47. Without the real
-store databases the suite discovers **617** (DERIVED as 637 − 20, not measured) — a skipped
+Solution suites total **648** with Docker running and the real store databases present (647 pass,
+1 skipped) — measured 2026-08-20. Per suite: Domain 36 · Vault 17 · MigrationTool 134 (133 pass,
+1 skip) · StoreHub.IntegrationTests 104 · Application 310 · Windows.Forms 47. Without the real
+store databases the suite discovers **628** (DERIVED as 648 − 20, not measured) — a skipped
 `[Theory]` is one entry, not one per row. See [`ONBOARDING.md`](ONBOARDING.md) for the per-suite
 breakdown, the dev-vs-installed port split, and the `/health` vs `/health/ready` trap.
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -106,12 +106,12 @@ reports `Skipped: 1` and writes nothing — which looks like success while leavi
 ### Expected counts
 
 Solution suites (`dotnet test` at the root), Docker running **and** the real store databases present
-— **637 total** (636 pass, 1 skipped) — measured 2026-08-19. Without those databases the total is
-**617** (**derived** as 637 − 20, not measured), still all green:
+— **648 total** (647 pass, 1 skipped) — measured 2026-08-20. Without those databases the total is
+**628** (**derived** as 648 − 20, not measured), still all green:
 
 | Suite | Tests |
 |---|---|
-| `IndyPOS.Application.Tests` | 299 |
+| `IndyPOS.Application.Tests` | 310 |
 | `IndyPOS.StoreHub.IntegrationTests` | 104 (Docker) |
 | `IndyPOS.MigrationTool.Tests` | 134 (Docker; 1 skipped. **114** without the real store data — Trap 3, derived) |
 | `IndyPOS.Domain.Tests` | 36 |

--- a/deploy/cloud/.env.example
+++ b/deploy/cloud/.env.example
@@ -1,0 +1,19 @@
+# Copy to .env and fill in real values:  cp .env.example .env
+# .env is gitignored. This repository is public — never commit a real secret.
+
+# Production even for the local stack: it is the path that actually ships, so it is the path worth
+# verifying. The cost is no Scalar/OpenAPI UI locally.
+ASPNETCORE_ENVIRONMENT=Production
+
+# Signs the tokens guarding /admin/*. The host refuses to start on the built-in default.
+#   openssl rand -base64 64
+LocalToken__SecretKey=replace-me-not-a-real-secret-0000000000000000000000000000
+
+# Base64 of a PEM RSA private key, 2048 bits or more. Generate with scripts/generate-rsa-key.ps1.
+# Left empty, OpenIddict falls back to ephemeral dev certificates and every restart invalidates
+# every issued token — acceptable locally, never in production.
+INDYPOS_RSA_SIGNING_KEY=
+
+# The managed PostgreSQL cluster. Note the hyphen in the key: it must match
+# AddNpgsqlDbContext<CloudDbContext>("cloud-db"). compose.yaml overrides this for the local stack.
+ConnectionStrings__cloud-db=

--- a/deploy/cloud/.env.example
+++ b/deploy/cloud/.env.example
@@ -5,9 +5,14 @@
 # verifying. The cost is no Scalar/OpenAPI UI locally.
 ASPNETCORE_ENVIRONMENT=Production
 
-# Signs the tokens guarding /admin/*. The host refuses to start on the built-in default.
+# Signs the tokens guarding /admin/*. The host refuses to start until this is a real key -- left
+# blank on purpose, unlike the rest of this template: a filled-in-looking placeholder here would be
+# a usable secret published in a public repo. Generate one with:
 #   openssl rand -base64 64
-LocalToken__SecretKey=replace-me-not-a-real-secret-0000000000000000000000000000
+# (compose.yaml supplies its own local-dev-only value for `docker compose up`, so this being blank
+# does not stop the local stack from starting -- it only matters once you fill in .env for the
+# Droplet.)
+LocalToken__SecretKey=
 
 # Base64 of a PEM RSA private key, 2048 bits or more. Generate with scripts/generate-rsa-key.ps1.
 # Left empty, OpenIddict falls back to ephemeral dev certificates and every restart invalidates

--- a/deploy/cloud/compose.prod.yaml
+++ b/deploy/cloud/compose.prod.yaml
@@ -1,0 +1,42 @@
+# Droplet deployment unit. On the box:
+#   docker compose -f compose.prod.yaml up -d --build
+# Requires a .env alongside this file (see .env.example). Never commit that file.
+name: indypos-cloud
+
+x-cloudapi: &cloudapi
+  build:
+    context: ../..
+    dockerfile: src/IndyPOS.CloudApi/Dockerfile
+  image: indypos-cloudapi:prod
+  env_file: .env
+  logging:
+    driver: json-file
+    options:
+      # The Droplet has a 50 GB disk. An uncapped container log is a slow outage.
+      max-size: "10m"
+      max-file: "5"
+
+services:
+  # One-shot. Must exit 0 before the API is allowed to start.
+  cloud-api-migrate:
+    <<: *cloudapi
+    container_name: indypos-cloud-api-migrate
+    command: ["migrate"]
+    restart: "no"
+
+  cloud-api:
+    <<: *cloudapi
+    container_name: indypos-cloud-api
+    restart: unless-stopped
+    # TLS TERMINATOR SEAM -----------------------------------------------------------------
+    # Bound to loopback on purpose: nothing here terminates TLS, and no domain is registered
+    # yet. The infrastructure guide's firewall opens 443 publicly and 22 to trusted IPs only.
+    # A terminator must: listen on 443 with a certificate for the API's domain, forward to
+    # this container's 8080, and set X-Forwarded-Proto / X-Forwarded-For. When a domain
+    # exists, add a Caddy service on an internal network and drop this ports mapping.
+    # -------------------------------------------------------------------------------------
+    ports:
+      - "127.0.0.1:8080:8080"
+    depends_on:
+      cloud-api-migrate:
+        condition: service_completed_successfully

--- a/deploy/cloud/compose.yaml
+++ b/deploy/cloud/compose.yaml
@@ -11,6 +11,10 @@ x-cloudapi: &cloudapi
   env_file: .env.example
   environment:
     ConnectionStrings__cloud-db: "Host=postgres;Port=5432;Database=indypos_cloud;Username=cloud_app;Password=cloud_dev_password"
+    # Local-development-only value so this stack is self-contained without editing .env.example.
+    # environment: overrides env_file, so this wins over the (intentionally blank) template value.
+    # Never reuse this value anywhere real -- it is published in a public repository.
+    LocalToken__SecretKey: "indypos-cloudapi-local-compose-dev-secret-key-do-not-reuse-2026"
 
 services:
   postgres:

--- a/deploy/cloud/compose.yaml
+++ b/deploy/cloud/compose.yaml
@@ -1,0 +1,55 @@
+# Local full stack. Run from this directory:
+#   docker compose up --build
+# Postgres is published on 5433 because the StoreHub dev stack at the repo root already holds 5432.
+name: indypos-cloud
+
+x-cloudapi: &cloudapi
+  build:
+    context: ../..
+    dockerfile: src/IndyPOS.CloudApi/Dockerfile
+  image: indypos-cloudapi:local
+  env_file: .env.example
+  environment:
+    ConnectionStrings__cloud-db: "Host=postgres;Port=5432;Database=indypos_cloud;Username=cloud_app;Password=cloud_dev_password"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: indypos-cloud-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: cloud_app
+      POSTGRES_PASSWORD: cloud_dev_password
+      POSTGRES_DB: indypos_cloud
+    ports:
+      - "5433:5432"
+    volumes:
+      - cloud_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cloud_app -d indypos_cloud"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # One-shot. Applies EF migrations and exits; the API is not allowed to start until it exits 0.
+  cloud-api-migrate:
+    <<: *cloudapi
+    container_name: indypos-cloud-api-migrate
+    command: ["migrate"]
+    restart: "no"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  cloud-api:
+    <<: *cloudapi
+    container_name: indypos-cloud-api
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    depends_on:
+      cloud-api-migrate:
+        condition: service_completed_successfully
+
+volumes:
+  cloud_postgres_data:

--- a/docs/operations/cloud-deployment.md
+++ b/docs/operations/cloud-deployment.md
@@ -33,21 +33,35 @@ The migrate one-shot runs first and must exit 0; the API will not start otherwis
 - `/health/live` — process up. This is what the container's `HEALTHCHECK` probes. Served by
   `MapHealthChecks` (`ServiceDefaults/Extensions.cs`), predicate `"live"`, and it is the only
   endpoint of the two that is actually reachable as designed.
-- `/health/ready` — **mapped twice** and effectively broken. `MapDefaultEndpoints()` registers
-  `MapHealthChecks("/health/ready", …)` filtered to checks tagged `"ready"`; `Program.cs` separately
-  registers `MapGet("/health/ready", …)` that does a real `CanConnectAsync()` against the database.
-  Verified against a running container: **no `AmbiguousMatchException`.** ASP.NET Core's routing
-  prefers the endpoint carrying explicit `HttpMethodMetadata` (the `MapGet`, GET-only) over the one
-  with none (`MapHealthChecks` maps via a generic `Map`, no method constraint), so the `Program.cs`
-  handler silently wins every request — confirmed by the response body
+- `/health/ready` — **mapped twice in CloudApi, and the second registration is dead code.**
+  `MapDefaultEndpoints()` (`ServiceDefaults/Extensions.cs`) registers
+  `MapHealthChecks("/health/ready", …)` filtered to checks tagged `"ready"`; `CloudApi/Program.cs`
+  separately registers `MapGet("/health/ready", …)` that does a real `CanConnectAsync()` against the
+  database. Verified against a running container: **no `AmbiguousMatchException`.** ASP.NET Core's
+  routing prefers the endpoint carrying explicit `HttpMethodMetadata` (the `MapGet`, GET-only) over
+  the one with none (`MapHealthChecks` maps via a generic `Map`, no method constraint), so the
+  `Program.cs` handler silently wins every request — confirmed by the response body
   (`{"status":"healthy","database":"connected"}`, not the plain-text `Healthy` that `/health/live`
   returns) and by the server log, which reads `Executing endpoint 'HTTP: GET /health/ready'` rather
-  than `'Health checks'`. The `MapHealthChecks` registration behind it is dead code.
-  Separately: even if it were reached, it would report a false "ready" — `AddDefaultHealthChecks`
-  registers only a `self` check tagged `"live"`; **no check anywhere is tagged `"ready"`**, so the
-  predicate matches zero checks and the health-check middleware's convention is to report `Healthy`
-  on an empty check set. Do not rely on `/health/ready` for anything until this is resolved as its
-  own defect — packaging is not the place to fix it.
+  than `'Health checks'`.
+
+  **This is a CloudApi-only observation.** CloudApi's `AddServiceDefaults()` registers no check
+  tagged `"ready"` — `AddDefaultHealthChecks` only ever registers a `self` check tagged `"live"`, and
+  nothing in `CloudApi/Program.cs` adds a `"ready"`-tagged one — so even the dead `MapHealthChecks`
+  registration would have reported a false "ready" (an empty check set reports `Healthy` by
+  middleware convention) had it ever been reached. That is why the container's `HEALTHCHECK` probes
+  `/health/live` instead. Do not rely on CloudApi's `/health/ready` for anything until this is
+  resolved as its own defect — packaging is not the place to fix it.
+
+  **⚠️ This does NOT generalize to StoreHub — do not "clean up" its `/health/ready` as dead code.**
+  `src/IndyPOS.StoreHub/Program.cs` (around line 79) registers a real check:
+  `AddDbContextCheck<StoreHubDbContext>("storehub-db", tags: ["ready"])`, so StoreHub's
+  `MapHealthChecks("/health/ready", …)` mapping is genuine and does exercise the database. It is also
+  **load-bearing for the installer**: `installer/IndyPOS.Bootstrapper/Installers/HealthProbe.cs`
+  polls it to decide whether an upgrade (or a post-rollback restart) actually came back up, and
+  `src/IndyPOS.Infrastructure/Services/StoreHub/StoreHubHttpClient.cs`'s `IsHealthyAsync` polls the
+  same endpoint at runtime. Removing or "fixing" StoreHub's `/health/ready` on the strength of the
+  CloudApi finding above would break the installer's rollback gate.
 
 ## TLS
 
@@ -58,14 +72,39 @@ the API to `127.0.0.1:8080`. See the marked seam in that file for what a termina
 OpenIddict's token endpoint (and every other OpenIddict endpoint — `/oauth/token`,
 `/.well-known/openid-configuration`, `/.well-known/jwks`) rejects plain HTTP with `400` and
 `error_uri: https://documentation.openiddict.com/errors/ID2083`, because
-`DisableTransportSecurityRequirement()` is never called. TLS is terminated upstream of this
-container (see the seam above), so a client talking to the container directly over its published
-8080 cannot obtain a token — it must go through the terminator once one exists. This was verified
-against the containerized API with a real RSA signing key configured (`INDYPOS_RSA_SIGNING_KEY`),
-ruling out the ephemeral-development-certificate fallback as the cause. Do **not** work around this
-by calling `DisableTransportSecurityRequirement()`, adding forwarded-headers middleware, or
-generating a certificate inside the container — enabling plain-HTTP token issuance is a
-security-design decision for the repository owner, not a packaging fix.
+`DisableTransportSecurityRequirement()` is never called. This was verified against the containerized
+API with a real RSA signing key configured (`INDYPOS_RSA_SIGNING_KEY`), ruling out the
+ephemeral-development-certificate fallback as the cause.
+
+**Putting a TLS terminator in front does NOT resolve this by itself.** OpenIddict decides whether the
+request "is HTTPS" from `HttpContext.Request.IsHttps`, which reflects the connection the *container*
+sees — not the connection the client made to the terminator. With TLS terminated upstream and no
+forwarded-headers handling in this app, the container still sees a plain `http` request from the
+terminator and still rejects it with ID2083. Resolving this needs one of two things, **and the choice
+is deliberately deferred to the repository owner as a security decision, not made here**:
+
+- Call `DisableTransportSecurityRequirement()` — accepts plain HTTP into the container outright, or
+- Configure `UseForwardedHeaders()` so the app trusts the terminator's `X-Forwarded-Proto` header,
+  which requires the terminator to be configured to set that header and the app to trust it only
+  from the terminator's address.
+
+Do **not** add either mechanism to this repository's C# yet, and do not work around ID2083 by
+generating a certificate inside the container — a terminator is necessary infrastructure either way,
+but is not sufficient on its own, and picking between the two options above is left to the repository
+owner.
+
+**Known limitation — store-to-cloud authentication does not work end to end yet, independent of the
+TLS issue above.** Store registration (`RegisterStoreHandler`) writes OAuth2 client credentials —
+a generated `ClientId` and a BCrypt-hashed `ClientSecret` — to this application's own `StoreConfigs`
+table, and `TokenController`'s `/oauth/token` handler verifies an incoming `client_id`/`client_secret`
+against that same table. But `AddOpenIddictServer` configures OpenIddict's core store
+(`OpenIddictExtensions.cs`) to use EF Core against `CloudDbContext`, which gives OpenIddict its own
+`OpenIddictApplications` table — and OpenIddict's server pipeline validates the incoming `client_id`
+against *that* table before the request ever reaches `TokenController`. Nothing in `src/` ever
+creates a row in `OpenIddictApplications`, so every token request is rejected with
+`401 invalid_client` regardless of whether the store registered successfully against `StoreConfigs`.
+Closing this belongs to Epic I task I4 (SyncWorker against the real CloudApi); until then, treat
+store-to-cloud authentication as not working end to end.
 
 ## Schema changes
 
@@ -77,3 +116,24 @@ dotnet ef migrations add <Name> --project src/IndyPOS.CloudApi --output-dir Infr
 ```
 
 Never hand-write one.
+
+## Operational notes
+
+**Stale Aspire dev volume won't gain new tables.** `src/IndyPOS.AppHost/Program.cs` mounts the
+`cloud-db` Postgres with `WithDataVolume("indypos-postgres-data")`, and CloudApi's dev startup path
+provisions the schema with `EnsureCreatedAsync()` (`Program.cs`), which is a no-op once the database
+already has any tables. So an Aspire dev `cloud-db` volume created before the OpenIddict entities
+existed will NOT gain the four new `OpenIddict*` tables on a later run, and `/oauth/token` (and
+anything else touching those tables) will keep failing with a 500 there until the volume is dropped.
+To fix it: stop the AppHost, then remove the named volume (`docker volume rm indypos-postgres-data`,
+or find its actual name with `docker volume ls` if Aspire suffixed it) and restart the AppHost so the
+container is recreated empty and `EnsureCreatedAsync()` builds the full schema fresh.
+
+**A migrate failure on the managed cluster does not self-heal.** `compose.prod.yaml`'s
+`cloud-api-migrate` one-shot has `restart: "no"` and nothing gates it on the external managed
+database actually being reachable first. If the managed cluster is briefly unavailable when
+`docker compose -f compose.prod.yaml up -d` runs, the migrate one-shot exits non-zero, and the
+`cloud-api` service — which depends on `cloud-api-migrate` completing successfully — never starts.
+Compose does not retry this on its own. Once the database is confirmed reachable again, re-run
+`docker compose -f compose.prod.yaml up -d` from the Droplet to retry the migration and bring the
+API up.

--- a/docs/operations/cloud-deployment.md
+++ b/docs/operations/cloud-deployment.md
@@ -1,0 +1,79 @@
+# CloudApi deployment
+
+Covers the container and the two compose stacks in `deploy/cloud/`. Provisioning the Droplet and the
+managed database is Epic I tasks I1–I3; the full operations guide is task I8.
+
+## Run it locally
+
+```bash
+cd deploy/cloud
+docker compose up --build
+```
+
+Brings up PostgreSQL on 5433 (5432 belongs to the StoreHub dev stack at the repo root), applies EF
+migrations in a one-shot container, then starts the API on <http://localhost:8080>.
+
+The stack runs as `Production` on purpose — that is the path that ships. There is no Scalar/OpenAPI
+UI as a result; for that, use the Aspire dev loop instead.
+
+## Run it on the Droplet
+
+1. Copy the repository to the box, or build the image elsewhere and push it to a registry.
+2. `cp deploy/cloud/.env.example deploy/cloud/.env` and fill in every value.
+   - `ConnectionStrings__cloud-db` — the managed cluster's string. The hyphen matters.
+   - `LocalToken__SecretKey` — `openssl rand -base64 64`. The API refuses to start without it.
+   - `INDYPOS_RSA_SIGNING_KEY` — from `scripts/generate-rsa-key.ps1`. Without it, every restart
+     invalidates every issued token.
+3. `cd deploy/cloud && docker compose -f compose.prod.yaml up -d --build`
+
+The migrate one-shot runs first and must exit 0; the API will not start otherwise.
+
+## Health
+
+- `/health/live` — process up. This is what the container's `HEALTHCHECK` probes. Served by
+  `MapHealthChecks` (`ServiceDefaults/Extensions.cs`), predicate `"live"`, and it is the only
+  endpoint of the two that is actually reachable as designed.
+- `/health/ready` — **mapped twice** and effectively broken. `MapDefaultEndpoints()` registers
+  `MapHealthChecks("/health/ready", …)` filtered to checks tagged `"ready"`; `Program.cs` separately
+  registers `MapGet("/health/ready", …)` that does a real `CanConnectAsync()` against the database.
+  Verified against a running container: **no `AmbiguousMatchException`.** ASP.NET Core's routing
+  prefers the endpoint carrying explicit `HttpMethodMetadata` (the `MapGet`, GET-only) over the one
+  with none (`MapHealthChecks` maps via a generic `Map`, no method constraint), so the `Program.cs`
+  handler silently wins every request — confirmed by the response body
+  (`{"status":"healthy","database":"connected"}`, not the plain-text `Healthy` that `/health/live`
+  returns) and by the server log, which reads `Executing endpoint 'HTTP: GET /health/ready'` rather
+  than `'Health checks'`. The `MapHealthChecks` registration behind it is dead code.
+  Separately: even if it were reached, it would report a false "ready" — `AddDefaultHealthChecks`
+  registers only a `self` check tagged `"live"`; **no check anywhere is tagged `"ready"`**, so the
+  predicate matches zero checks and the health-check middleware's convention is to report `Healthy`
+  on an empty check set. Do not rely on `/health/ready` for anything until this is resolved as its
+  own defect — packaging is not the place to fix it.
+
+## TLS
+
+Nothing in these files terminates TLS, and no domain is registered yet, so `compose.prod.yaml` binds
+the API to `127.0.0.1:8080`. See the marked seam in that file for what a terminator must do.
+
+**Known limitation — the token endpoint needs HTTPS, and the container only serves HTTP.**
+OpenIddict's token endpoint (and every other OpenIddict endpoint — `/oauth/token`,
+`/.well-known/openid-configuration`, `/.well-known/jwks`) rejects plain HTTP with `400` and
+`error_uri: https://documentation.openiddict.com/errors/ID2083`, because
+`DisableTransportSecurityRequirement()` is never called. TLS is terminated upstream of this
+container (see the seam above), so a client talking to the container directly over its published
+8080 cannot obtain a token — it must go through the terminator once one exists. This was verified
+against the containerized API with a real RSA signing key configured (`INDYPOS_RSA_SIGNING_KEY`),
+ruling out the ephemeral-development-certificate fallback as the cause. Do **not** work around this
+by calling `DisableTransportSecurityRequirement()`, adding forwarded-headers middleware, or
+generating a certificate inside the container — enabling plain-HTTP token issuance is a
+security-design decision for the repository owner, not a packaging fix.
+
+## Schema changes
+
+Forward-only, same gate as StoreHub: additive, nullable or defaulted, no renames or drops. See
+`docs/operations/upgrade-procedure.md`. Generate migrations with:
+
+```bash
+dotnet ef migrations add <Name> --project src/IndyPOS.CloudApi --output-dir Infrastructure/Migrations
+```
+
+Never hand-write one.

--- a/src/IndyPOS.CloudApi/Dockerfile
+++ b/src/IndyPOS.CloudApi/Dockerfile
@@ -1,0 +1,50 @@
+# Build context is the REPOSITORY ROOT, not this directory:
+#   docker build -f src/IndyPOS.CloudApi/Dockerfile -t indypos-cloudapi:local .
+# CloudApi references Application (-> Domain) and ServiceDefaults, and inherits
+# Directory.Build.props, none of which are reachable from src/IndyPOS.CloudApi/.
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Restore layer: project files only, so editing a .cs file does not re-restore.
+COPY Directory.Build.props ./
+COPY src/IndyPOS.CloudApi/IndyPOS.CloudApi.csproj src/IndyPOS.CloudApi/
+COPY src/IndyPOS.Application/IndyPOS.Application.csproj src/IndyPOS.Application/
+COPY src/IndyPOS.Domain/IndyPOS.Domain.csproj src/IndyPOS.Domain/
+COPY src/IndyPOS.ServiceDefaults/IndyPOS.ServiceDefaults.csproj src/IndyPOS.ServiceDefaults/
+RUN dotnet restore src/IndyPOS.CloudApi/IndyPOS.CloudApi.csproj
+
+COPY src/IndyPOS.CloudApi/ src/IndyPOS.CloudApi/
+COPY src/IndyPOS.Application/ src/IndyPOS.Application/
+COPY src/IndyPOS.Domain/ src/IndyPOS.Domain/
+COPY src/IndyPOS.ServiceDefaults/ src/IndyPOS.ServiceDefaults/
+RUN dotnet publish src/IndyPOS.CloudApi/IndyPOS.CloudApi.csproj \
+      -c Release -o /app/publish --no-restore
+
+# Debian, not Alpine: this system converts timestamps to and from Asia/Bangkok and handles Thai
+# product names, and the Alpine images ship neither ICU nor tzdata without extra packages.
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+
+# curl is the probe binary for HEALTHCHECK and for compose's service_healthy condition. The aspnet
+# image ships neither curl nor wget, which is also why the chiseled variants are unusable here.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=build /app/publish ./
+
+ENV ASPNETCORE_HTTP_PORTS=8080
+EXPOSE 8080
+
+# Non-root. The aspnet images define APP_UID for exactly this.
+USER $APP_UID
+
+# /health/live, not /health/ready: it is the cheap probe by design, and it is mapped exactly once
+# (see defect I0-C in the spec).
+HEALTHCHECK --interval=15s --timeout=3s --start-period=20s --retries=3 \
+  CMD curl -fsS http://localhost:8080/health/live || exit 1
+
+# Entrypoint without the command, so "migrate" can be passed as an argument by the compose one-shot
+# rather than needing a second image.
+ENTRYPOINT ["dotnet", "IndyPOS.CloudApi.dll"]


### PR DESCRIPTION
The packaging itself — task I0's actual deliverable.

### What ships

- **`src/IndyPOS.CloudApi/Dockerfile`** — multi-stage, non-root (uid 1654), HTTP only on 8080, no in-container TLS, `ENTRYPOINT` with no `CMD` so `migrate` passes as an argument. 376 MB. Build context is the repo root because the project graph reaches Application → Domain and ServiceDefaults and inherits `Directory.Build.props`.
- **`.dockerignore`** — without it the context included the `bin/Debug` trees.
- **`deploy/cloud/compose.yaml`** — postgres → migrate one-shot → API, the API gated on `service_completed_successfully`. Verified: the one-shot exits 0 before the API starts, and the container reports `healthy`.
- **`deploy/cloud/compose.prod.yaml`** — the Droplet unit. No database service (managed cluster), loopback-bound, capped logs, and a marked TLS-terminator seam.
- **`deploy/cloud/.env.example`** and **`docs/operations/cloud-deployment.md`**.

### Decisions worth knowing

**Debian, not Alpine or chiseled.** This system converts timestamps to and from Asia/Bangkok and handles Thai product names; Alpine ships neither ICU nor tzdata without extra packages, and chiseled has no shell for a probe. `curl` is installed solely so `HEALTHCHECK` and `service_healthy` have a probe binary.

**Files live in `deploy/cloud/`, not the repo root.** Compose prefers `compose.yaml` over `docker-compose.yml`, so a root file would have **silently shadowed** the existing StoreHub dev stack — no error, just a different stack answering `docker compose up`.

**The local stack runs as `Production` on purpose**, so what gets verified locally is the path that ships. Cost: no Scalar/OpenAPI UI locally; use the Aspire loop for that.

### `/health/ready`: the open question, answered

The healthcheck probes `/health/live`. `/health/ready` was double-mapped and its behaviour had never been observed, so this was measured:

It does **not** throw `AmbiguousMatchException`. ASP.NET Core routing prefers the endpoint carrying explicit `HttpMethodMetadata`, so `CloudApi/Program.cs`'s `MapGet` wins and the `ServiceDefaults` mapping is dead — **in CloudApi only**.

⚠️ **StoreHub's `/health/ready` is real and load-bearing.** `StoreHub/Program.cs:79` registers a `ready`-tagged DB check, and the installer gates its **upgrade rollback decision** on that endpoint (`HealthProbe.cs:19`, `StoreHubHttpClient.cs:247`). It must not be "cleaned up" as dead code. An earlier draft of the runbook stated this too broadly; that is corrected here.

### 🚨 Two limitations documented rather than papered over

**1. A containerised `/oauth/token` cannot issue tokens as shipped.** OpenIddict rejects plain HTTP with `400` / `ID2083` because `DisableTransportSecurityRequirement()` is never called. **A TLS terminator alone does not fix this** — without forwarded-headers handling the app still sees `http`. The fix is a choice between `DisableTransportSecurityRequirement()` and `UseForwardedHeaders` trusting `X-Forwarded-Proto`, and it is left to you: it is a security decision about a production auth endpoint. No workaround was smuggled in — no C# file is touched by this PR.

**2. Store registration writes to `StoreConfigs` while OpenIddict validates against `OpenIddictApplications`**, which nothing populates — so a registered store still gets `401`. Belongs to I4.

Both are in the runbook so an operator meets them in the docs, not in production.

### Also worth your attention (pre-existing, not from this PR)

`NU1903`: `Microsoft.OpenApi` 2.0.0 has a **known high-severity vulnerability** (GHSA-v5pm-xwqc-g5wc), arriving transitively via `Microsoft.AspNetCore.OpenApi` 10.0.3 — referenced by **both** CloudApi and StoreHub. Patched versions exist (2.0.1 … 2.12.0), so a direct pin clears it. Left out of scope here because it is a shared transitive bump needing its own full-suite run, and the reachable surface is near zero (`AddOpenApi`/`MapOpenApi` are Development-only). **Worth landing before this goes on a public Droplet.**

Suite unchanged at 648 (647 pass, 1 skip) — this PR touches no C#. `CLAUDE.md` and `ONBOARDING.md` counts corrected to match the stack's new total.

Top of the stack, on #87.
