### PR TITLE
fix: let a deployment declare that TLS terminates upstream

### DIFF
--- a/deploy/cloud/.env.example
+++ b/deploy/cloud/.env.example
@@ -22,3 +22,10 @@ INDYPOS_RSA_SIGNING_KEY=
 # The managed PostgreSQL cluster. Note the hyphen in the key: it must match
 # AddNpgsqlDbContext<CloudDbContext>("cloud-db"). compose.yaml overrides this for the local stack.
 ConnectionStrings__cloud-db=
+
+# NOT SET HERE, deliberately: OpenIddict__TlsTerminatedUpstream.
+# OpenIddict rejects token requests that did not arrive over HTTPS (400 / ID2083). Both compose
+# files declare that flag in their `environment:` map, which overrides env_file -- so a value set
+# here could never take effect, and putting one here would only suggest otherwise.
+# It defaults to FALSE in code, so a host running the image WITHOUT compose stays strict.
+# Change it in compose.prod.yaml if you deploy without a TLS terminator in front.

--- a/deploy/cloud/compose.prod.yaml
+++ b/deploy/cloud/compose.prod.yaml
@@ -9,6 +9,12 @@ x-cloudapi: &cloudapi
     dockerfile: src/IndyPOS.CloudApi/Dockerfile
   image: indypos-cloudapi:prod
   env_file: .env
+  environment:
+    # OpenIddict rejects token requests that did not arrive over HTTPS (ID2083). TLS terminates at
+    # the reverse proxy in front of this container, so the requirement is relaxed here. Defaults to
+    # false in code -- an unconfigured host stays strict and refuses to issue tokens over cleartext.
+    # If you run this stack WITHOUT a terminator, tokens go out in the clear.
+    OpenIddict__TlsTerminatedUpstream: "true"
   logging:
     driver: json-file
     options:

--- a/deploy/cloud/compose.yaml
+++ b/deploy/cloud/compose.yaml
@@ -15,6 +15,10 @@ x-cloudapi: &cloudapi
     # environment: overrides env_file, so this wins over the (intentionally blank) template value.
     # Never reuse this value anywhere real -- it is published in a public repository.
     LocalToken__SecretKey: "indypos-cloudapi-local-compose-dev-secret-key-do-not-reuse-2026"
+    # OpenIddict rejects token requests that did not arrive over HTTPS (ID2083). This container
+    # serves plain HTTP and expects TLS to terminate in front of it, so the requirement is relaxed
+    # here. Defaults to false in code -- an unconfigured host stays strict.
+    OpenIddict__TlsTerminatedUpstream: "true"
 
 services:
   postgres:

--- a/docs/operations/cloud-deployment.md
+++ b/docs/operations/cloud-deployment.md
@@ -68,30 +68,39 @@ The migrate one-shot runs first and must exit 0; the API will not start otherwis
 Nothing in these files terminates TLS, and no domain is registered yet, so `compose.prod.yaml` binds
 the API to `127.0.0.1:8080`. See the marked seam in that file for what a terminator must do.
 
-**Known limitation — the token endpoint needs HTTPS, and the container only serves HTTP.**
-OpenIddict's token endpoint (and every other OpenIddict endpoint — `/oauth/token`,
-`/.well-known/openid-configuration`, `/.well-known/jwks`) rejects plain HTTP with `400` and
-`error_uri: https://documentation.openiddict.com/errors/ID2083`, because
-`DisableTransportSecurityRequirement()` is never called. This was verified against the containerized
-API with a real RSA signing key configured (`INDYPOS_RSA_SIGNING_KEY`), ruling out the
-ephemeral-development-certificate fallback as the cause.
+**The token endpoint requires HTTPS, and the container serves HTTP — this is now configured, not
+broken.** OpenIddict rejects plain-HTTP token requests with `400` and
+`error_uri: https://documentation.openiddict.com/errors/ID2083`. It decides whether a request "is
+HTTPS" from `HttpContext.Request.IsHttps`, which reflects the connection the *container* sees — not
+the connection the client made to the terminator. So terminating TLS upstream does **not**, by
+itself, satisfy the check.
 
-**Putting a TLS terminator in front does NOT resolve this by itself.** OpenIddict decides whether the
-request "is HTTPS" from `HttpContext.Request.IsHttps`, which reflects the connection the *container*
-sees — not the connection the client made to the terminator. With TLS terminated upstream and no
-forwarded-headers handling in this app, the container still sees a plain `http` request from the
-terminator and still rejects it with ID2083. Resolving this needs one of two things, **and the choice
-is deliberately deferred to the repository owner as a security decision, not made here**:
+Both compose files therefore declare `OpenIddict__TlsTerminatedUpstream: "true"`, which makes
+`AddOpenIddictServer` call `DisableTransportSecurityRequirement()`
+(`src/IndyPOS.CloudApi/Infrastructure/Auth/OpenIddictExtensions.cs`).
 
-- Call `DisableTransportSecurityRequirement()` — accepts plain HTTP into the container outright, or
-- Configure `UseForwardedHeaders()` so the app trusts the terminator's `X-Forwarded-Proto` header,
-  which requires the terminator to be configured to set that header and the app to trust it only
-  from the terminator's address.
+**It defaults to `false` in code.** An unconfigured host — the image run without these compose files —
+stays strict and refuses to issue tokens over cleartext rather than doing it silently. That is the
+same fail-closed posture as the JWT signing-key guard.
 
-Do **not** add either mechanism to this repository's C# yet, and do not work around ID2083 by
-generating a certificate inside the container — a terminator is necessary infrastructure either way,
-but is not sufficient on its own, and picking between the two options above is left to the repository
-owner.
+⚠️ **Turning it on is a statement about your topology, and it is only true if you keep it true.** With
+the flag on, this container will issue access tokens to anything that can reach it over plain HTTP.
+That is safe only while the container is unreachable except through a TLS terminator —
+`compose.prod.yaml` binds it to `127.0.0.1` for exactly this reason. If you ever publish port 8080 on
+a public interface, or put the container on a shared network, set the flag back to `false` first.
+
+Verified by controlled comparison against the same image, same request, only the flag differing:
+
+| `OpenIddict__TlsTerminatedUpstream` | Response to `POST /oauth/token` over plain HTTP |
+|---|---|
+| `false` (code default) | `400 invalid_request` — "This server only accepts HTTPS requests." (ID2083) |
+| `true` (both compose files) | `401 invalid_client` (ID2052) — past the transport gate, then blocked by the separate defect below |
+
+The alternative — `UseForwardedHeaders()` trusting the terminator's `X-Forwarded-Proto` — was
+considered and rejected for now. Container bridge addresses are dynamic, so it would require clearing
+`KnownNetworks`/`KnownProxies`, i.e. trusting that header from anyone who can reach the container.
+That is the same practical exposure as the flag above, with more moving parts. It becomes the stronger
+option once a terminator exists at a known address, and is worth revisiting then.
 
 **Known limitation — store-to-cloud authentication does not work end to end yet, independent of the
 TLS issue above.** Store registration (`RegisterStoreHandler`) writes OAuth2 client credentials —

--- a/src/IndyPOS.CloudApi/Infrastructure/Auth/OpenIddictExtensions.cs
+++ b/src/IndyPOS.CloudApi/Infrastructure/Auth/OpenIddictExtensions.cs
@@ -16,6 +16,12 @@ public static class OpenIddictExtensions
     /// </summary>
     public const string RsaSigningKeyEnvVar = "INDYPOS_RSA_SIGNING_KEY";
 
+    /// <summary>
+    /// Configuration key declaring that a reverse proxy terminates TLS in front of this host, so the
+    /// container itself only ever receives plain HTTP over an internal network.
+    /// </summary>
+    public const string TlsTerminatedUpstreamKey = "OpenIddict:TlsTerminatedUpstream";
+
     public static IServiceCollection AddOpenIddictServer(
         this IServiceCollection services,
         IConfiguration configuration)
@@ -23,6 +29,11 @@ public static class OpenIddictExtensions
         // Try to load RSA key from environment variable (production)
         var rsaKeyBase64 = Environment.GetEnvironmentVariable(RsaSigningKeyEnvVar)
             ?? configuration["OpenIddict:RsaSigningKey"];
+
+        // Defaults to false: strict transport security unless a deployment explicitly declares
+        // otherwise. An unconfigured host refuses to issue tokens over cleartext rather than doing
+        // it silently.
+        var tlsTerminatedUpstream = configuration.GetValue<bool>(TlsTerminatedUpstreamKey);
 
         RsaSecurityKey? rsaSecurityKey = null;
         if (!string.IsNullOrEmpty(rsaKeyBase64))
@@ -80,6 +91,19 @@ public static class OpenIddictExtensions
                 // ASP.NET Core integration
                 options.UseAspNetCore()
                        .EnableTokenEndpointPassthrough();
+
+                // OpenIddict rejects token requests that did not arrive over HTTPS (error ID2083).
+                // In the containerised deployment TLS terminates at a reverse proxy, so this host
+                // sees plain HTTP on an internal network the public cannot reach — the store-to-cloud
+                // leg is still HTTPS, because StoreHub's CloudApi:BaseUrl points at the proxy.
+                //
+                // This stays OFF by default. Turning it on without a terminator in front means
+                // tokens are issued over cleartext.
+                if (tlsTerminatedUpstream)
+                {
+                    options.UseAspNetCore()
+                           .DisableTransportSecurityRequirement();
+                }
             })
             .AddValidation(options =>
             {


### PR DESCRIPTION
Resolves the TLS limitation that #88 documented. **Item 1 of the three decisions #88 left open.**

### The problem

OpenIddict rejects token requests that did not arrive over HTTPS (`400` / `ID2083`), and it decides that from `HttpContext.Request.IsHttps` — the connection the **container** sees, not the one the client made to the terminator. The container serves plain HTTP on 8080 by design, so a containerised `/oauth/token` could not issue tokens at all.

**Putting a reverse proxy in front would not have fixed it.** That is the trap here: TLS terminating upstream still delivers a plain `http` request to the container, and OpenIddict still rejects it.

### The fix

`OpenIddict:TlsTerminatedUpstream` — a config flag that, when true, chains `DisableTransportSecurityRequirement()`. Both compose files set it; it lives in the existing `OpenIddict:` config section alongside `RsaSigningKey`.

**It defaults to `false`.** A host running this image without those compose files stays strict and refuses to issue tokens over cleartext rather than doing it silently — the same fail-closed posture as the JWT signing-key guard in #86.

### Verified by controlled comparison

Same image, same request, only the flag differing:

| `OpenIddict__TlsTerminatedUpstream` | `POST /oauth/token` over plain HTTP |
|---|---|
| `false` (code default) | `400 invalid_request` — "This server only accepts HTTPS requests." (ID2083) |
| `true` (both stacks) | `401 invalid_client` (ID2052) |

The `true` row is the interesting one: it advances **past** the transport gate and is then blocked by the separate `OpenIddictApplications` defect (I0-E, still open, documented in #88). That error shift is the proof the flag does what it claims — and it means the transport question is genuinely settled without needing to seed OpenIddict's tables first.

Full stack re-verified alongside it: migrate one-shot exits 0, API reports `healthy`.

### Why not `UseForwardedHeaders`

It was the other candidate and it *sounds* more rigorous. But container bridge addresses are dynamic, so it needs `KnownNetworks`/`KnownProxies` cleared — which means trusting `X-Forwarded-Proto` from anything that can reach the container. That is the **same practical exposure** as the flag, with more moving parts. It becomes the stronger option once a terminator exists at a known address, and the runbook says so.

### ⚠️ What turning the flag on actually asserts

With it on, this container issues access tokens to anything that can reach it over plain HTTP. That is safe only while it is unreachable except through a terminator — which is why `compose.prod.yaml` binds to `127.0.0.1`. Publish 8080 on a public interface and the flag must go back to `false` first. The runbook states this explicitly rather than burying it.

### Notes

- `.env.example` deliberately does **not** assign this flag. Both compose files set it in `environment:`, which overrides `env_file`, so a value there could never take effect — the template says that instead of carrying a misleading assignment.
- No unit test: the code is a config read plus a conditional, so a unit test would exercise Microsoft's binder rather than our logic. The controlled comparison above is the evidence that means something.
- Suite unchanged at **648** (647 pass, 1 skip), all six suites re-run.

Top of the stack, on #88.
