### PR TITLE
fix: own the Microsoft.OpenApi reference to clear GHSA-v5pm-xwqc-g5wc

### DIFF
--- a/src/IndyPOS.CloudApi/IndyPOS.CloudApi.csproj
+++ b/src/IndyPOS.CloudApi/IndyPOS.CloudApi.csproj
@@ -11,6 +11,15 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <!--
+      Referenced directly, on purpose. Microsoft.AspNetCore.OpenApi pulls Microsoft.OpenApi in
+      transitively but pins an old floor (2.0.0), which carries GHSA-v5pm-xwqc-g5wc (NU1903, high
+      severity: circular schema references can terminate OpenAPI parsing; patched in 2.7.5).
+      ASP.NET Core does not track this package's releases closely (see dotnet/aspnetcore#67505), so
+      owning the reference is what keeps us on current fixes instead of waiting for a framework bump.
+      Stay on 2.x: 3.x is a breaking change that does not compile against this integration.
+    -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />
     <PackageReference Include="OpenIddict.AspNetCore" Version="6.*" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="6.*" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.*" />

--- a/src/IndyPOS.StoreHub/IndyPOS.StoreHub.csproj
+++ b/src/IndyPOS.StoreHub/IndyPOS.StoreHub.csproj
@@ -11,6 +11,15 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <!--
+      Referenced directly, on purpose. Microsoft.AspNetCore.OpenApi pulls Microsoft.OpenApi in
+      transitively but pins an old floor (2.0.0), which carries GHSA-v5pm-xwqc-g5wc (NU1903, high
+      severity: circular schema references can terminate OpenAPI parsing; patched in 2.7.5).
+      ASP.NET Core does not track this package's releases closely (see dotnet/aspnetcore#67505), so
+      owning the reference is what keeps us on current fixes instead of waiting for a framework bump.
+      Stay on 2.x: 3.x is a breaking change that does not compile against this integration.
+    -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">


### PR DESCRIPTION
Clears `NU1903` / [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) from both API hosts. **Item 2 of the three decisions #88 left open.** Branched off `development`, not the I0 stack, so it can merge on its own timeline.

### The advisory

`Microsoft.AspNetCore.OpenApi` 10.0.3 pins `Microsoft.OpenApi` **2.0.0**, which is affected. Patched in **2.7.5**. Both CloudApi and StoreHub referenced it only transitively, so both inherited it.

| `Microsoft.AspNetCore.OpenApi` | depends on |
|---|---|
| 10.0.3 (ours), 10.0.4, 10.0.8 | `Microsoft.OpenApi 2.0.0` — affected |
| 10.0.11 | `Microsoft.OpenApi [2.7.5, 3.0.0)` — patched |

### Why a direct reference rather than bumping the framework package

Bumping to 10.0.11 would also have worked. This follows maintainer guidance on [dotnet/aspnetcore#67505](https://github.com/dotnet/aspnetcore/issues/67505) instead:

> Personally I would recommend adding your own reference anyway (regardless of the CVEs) so that you always get the latest features and bug fixes (because ASP.NET Core won't always update to the latest version).

Bumping the framework package fixes *today's* advisory and leaves the next one waiting on Microsoft. Owning the reference doesn't.

Pinned to **2.12.0**, the latest 2.x. Deliberately **not** 3.x — that's a breaking change which doesn't compile against this integration, which is the actual subject of the linked issue. A comment in both csproj files records all of this, so the reference doesn't look redundant to a future reader and get "cleaned up".

### Honest exposure assessment

The vulnerability is a denial-of-service while **parsing** an OpenAPI document. Both hosts only ever *generate* them, and `MapOpenApi()` is gated behind `IsDevelopment()` in both (`StoreHub/Program.cs:242`, `CloudApi/Program.cs:137`). The vulnerable path was not reachable in production. This is about not shipping a flagged package — not about closing an exploitable hole.

### Verification

- `Microsoft.OpenApi` now resolves to **2.12.0** in both hosts (`dotnet list package --include-transitive`)
- `Microsoft.OpenApi` no longer appears in any `NU1903` warning solution-wide
- Full suite **637 total / 636 pass / 1 skip** — `development`'s baseline, unchanged
- No `docker build` here: the Dockerfile lives on the I0 stack, not on `development`. The image will pick this up when both land.

### 🔎 Three more flagged packages found while verifying — NOT fixed here

Clearing `Microsoft.OpenApi` revealed that the solution build still emits 48 `NU1903` warnings, from three packages nobody had flagged:

| Package | Advisories | Reached via | Ships? |
|---|---|---|---|
| `MessagePack` 2.5.192 | 2 | `IndyPOS.AppHost` (Aspire dev orchestrator) | **No** — dev-only |
| `SSH.NET` 2024.2.0 | 1 | `StoreHub.IntegrationTests`, `MigrationTool.Tests` (Testcontainers) | **No** — test-only |
| `Scriban.Signed` 5.5.0 | 8 | `Application.Tests` (WireMock.Net templating) | **No** — test-only |

All three are dev/test-only, which is materially different from `Microsoft.OpenApi` — that one was in both *shipping* hosts, which is why it was worth fixing before deploying. These are left for a separate PR so this one stays reviewable, but they are real and worth a follow-up.
