### PR TITLE
fix: clear the three remaining high-severity advisories in dev/test dependencies

### DIFF
--- a/src/IndyPOS.AppHost/IndyPOS.AppHost.csproj
+++ b/src/IndyPOS.AppHost/IndyPOS.AppHost.csproj
@@ -17,6 +17,11 @@
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions" Version="9.3.0" />
     <!-- Override KubernetesClient to fix vulnerability GHSA-w7r3-mgwf-4mqq -->
     <PackageReference Include="KubernetesClient" Version="17.0.14" />
+    <!-- Override MessagePack to fix vulnerabilities GHSA-hv8m-jj95-wg3x and GHSA-vh6j-jc39-fggf.
+         Reached via Aspire.Hosting -> StreamJsonRpc, which pins 2.5.192; patched in 2.5.301.
+         Pinned rather than bumping Aspire, whose current release is 13.x: that is a migration,
+         not a dependency fix. This host is dev-only tooling and never ships. -->
+    <PackageReference Include="MessagePack" Version="2.5.302" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/IndyPOS.Application.Tests/IndyPOS.Application.Tests.csproj
+++ b/tests/IndyPOS.Application.Tests/IndyPOS.Application.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="WireMock.Net" Version="1.7.0" />
+    <PackageReference Include="WireMock.Net" Version="2.15.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/IndyPOS.MigrationTool.Tests/IndyPOS.MigrationTool.Tests.csproj
+++ b/tests/IndyPOS.MigrationTool.Tests/IndyPOS.MigrationTool.Tests.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.3.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
     <PackageReference Include="Dapper" Version="2.1.72" />
     <PackageReference Include="Bogus" Version="35.6.1" />

--- a/tests/IndyPOS.StoreHub.IntegrationTests/IndyPOS.StoreHub.IntegrationTests.csproj
+++ b/tests/IndyPOS.StoreHub.IntegrationTests/IndyPOS.StoreHub.IntegrationTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Respawn" Version="6.2.1" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.3.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Clears the three flagged packages that surfaced while verifying #90. All are dev/test-only — none ships to a store or the Droplet — but they were burying future findings under 48 build warnings.

Branched off `development`, independent of both #90 and the I0 stack (no file overlap with either).

### What was wrong, and why each remedy differs

| Package | Advisories | Arrived via | Patched at | Remedy |
|---|---|---|---|---|
| `MessagePack` 2.5.192 | 2 (high) | `Aspire.Hosting` → `StreamJsonRpc` | 2.5.301 | **Pin 2.5.302** in AppHost |
| `SSH.NET` 2024.2.0 | 1 (high) | `Testcontainers` 4.3.0 / 4.4.0 | 2026.0.0 | **Bump `Testcontainers.PostgreSql` → 4.14.0** |
| `Scriban.Signed` 5.5.0 | 8 (high) | `WireMock.Net` 1.7.0 | 7.2.0 | **Bump `WireMock.Net` → 2.15.0** |

**MessagePack is pinned, not bumped, because the parent fix is a migration.** The vulnerable version comes through `Aspire.Hosting` 9.3.0, and Aspire's current release is **13.x** — a 9→13 move is a project in its own right, not a dependency fix. The pin is a patch bump inside 2.5.x, and it follows the `KubernetesClient` override already sitting in that same csproj for exactly the same reason.

**Testcontainers 4.14.0 is the minimum that actually works** — worth flagging, because the obvious smaller bump doesn't. 4.11.0 still carries SSH.NET **2025.1.0**, and the advisory covers `<= 2025.1.0`. Only 4.14.0 reaches 2026.0.0. Bumping the parent (rather than pinning SSH.NET directly) keeps Testcontainers running against the SSH.NET it was built for, instead of one two years newer than its own declared dependency. This also removes a pre-existing skew: the two suites were on 4.3.0 and 4.4.0.

**WireMock.Net 2.x drops `Scriban.Signed` entirely**, so the package leaves the graph rather than being force-upgraded across two majors inside a library we don't control. That's why the major bump is the *safer* option here, not the riskier one. Usage surface is a single file — `Integration/StoreHub/StoreHubE2ETests.cs`, on the stable core API.

### Verification

`dotnet list package --vulnerable --include-transitive` across the solution:

- `IndyPOS.AppHost` — **no vulnerable packages**
- `IndyPOS.Application.Tests` — **no vulnerable packages**
- `IndyPOS.MigrationTool.Tests` — **no vulnerable packages**
- `IndyPOS.StoreHub.IntegrationTests` — only `Microsoft.OpenApi`, which **#90** fixes

NU1903 warnings: **48 → 12**, and all 12 remaining are the `Microsoft.OpenApi` advisory that #90 clears. **With #90 merged, the solution reports zero vulnerable packages.**

Full suite green: **637 total / 636 pass / 1 skip** (`development`'s baseline). That matters more than usual here — Testcontainers and WireMock *are* the test infrastructure, so both bumps are exercised by the run itself: 104 StoreHub integration tests and 134 MigrationTool tests on the new Testcontainers, and the WireMock E2E test among Application.Tests' 299.
